### PR TITLE
Fix missing value check and VPT calculation

### DIFF
--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -87,7 +87,8 @@ class DataLoader:
                 return False
             
             # Check for excessive missing values
-            if df.isnull().sum().max() > len(df) * 0.01:  # Max 1% missing values
+            # Check missing value ratio per column
+            if df.isnull().mean().max() > 0.01:  # Max 1% missing values
                 logger.error(f"Too many missing values for {symbol}")
                 return False
         

--- a/src/data/processor.py
+++ b/src/data/processor.py
@@ -122,9 +122,9 @@ class DataProcessor:
             
             # 2. Volume-Price Trend
             # Measures buying/selling pressure
-            df['vpt'] = (df['Volume'] * 
-                        ((df['Close'] - df['Close'].shift(1)) / 
-                         df['Close'].shift(1))).cumsum()
+            df['vpt'] = (
+                df['Volume'] * df['Close'].pct_change()
+            ).fillna(0).cumsum()
             
             # Normalize features
             df['momentum_score'] = (df['momentum_score'] - df['momentum_score'].mean()) / df['momentum_score'].std()


### PR DESCRIPTION
## Summary
- fix Volume Price Trend to avoid NaNs at the beginning of the series
- validate data using columnwise missing value ratio

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 src/data/loader.py src/data/processor.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6840830c57fc832ab2f2f174ee6eb960