### PR TITLE
Add Bollinger Bands feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A comprehensive machine learning framework for quantitative trading strategies, 
 ## Key Features
 - Robust data pipeline for financial instruments
 - Advanced feature engineering toolkit:
-  - Momentum indicators (SMA, EMA, RSI, MACD, Stochastic)
+  - Momentum indicators (SMA, EMA, RSI, MACD, Stochastic, Bollinger Bands)
   - Return-based features
   - Custom feature engineering
 - Ensemble ML models:

--- a/config/features_config.yaml
+++ b/config/features_config.yaml
@@ -19,8 +19,8 @@ volume_features:
 volatility_features:
   - atr_periods: [14]
   - bollinger_bands:
-      periods: [20]
-      std_dev: [2]
+      period: 20
+      std_dev: 2
   - keltner_channels:
       periods: [20]
       atr_multiple: 2

--- a/src/data/processor.py
+++ b/src/data/processor.py
@@ -20,6 +20,10 @@ class DataProcessor:
         self.macd_params = {"fast": 12, "slow": 26, "signal": 9}
         self.stoch_params = {"k": 14, "d": 3}
 
+        # Bollinger Bands parameters
+        self.bb_period = 20
+        self.bb_std = 2
+
     def process_data(self, data: pd.DataFrame) -> pd.DataFrame:
         """
         Process raw OHLCV data and generate all required features.
@@ -35,13 +39,16 @@ class DataProcessor:
         # 1. Generate Momentum Indicators
         df = self._add_momentum_indicators(df)
 
-        # 2. Generate Return-based Features
+        # 2. Generate Bollinger Bands
+        df = self._add_bollinger_bands(df)
+
+        # 3. Generate Return-based Features
         df = self._add_return_features(df)
 
-        # 3. Generate Custom Features
+        # 4. Generate Custom Features
         df = self._add_custom_features(df)
 
-        # 4. Clean up and validate
+        # 5. Clean up and validate
         df = self._clean_data(df)
 
         return df
@@ -87,6 +94,19 @@ class DataProcessor:
 
         except Exception as e:
             logger.error(f"Error calculating momentum indicators: {str(e)}")
+            raise
+
+        return df
+
+    def _add_bollinger_bands(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Calculate Bollinger Bands using ``pandas_ta`` and append them."""
+        try:
+            bb = ta.bbands(df["Close"], length=self.bb_period, std=self.bb_std)
+            df["bb_lower"] = bb.iloc[:, 0]
+            df["bb_middle"] = bb.iloc[:, 1]
+            df["bb_upper"] = bb.iloc[:, 2]
+        except Exception as e:
+            logger.error(f"Error calculating Bollinger Bands: {str(e)}")
             raise
 
         return df


### PR DESCRIPTION
## Summary
- add Bollinger Bands params and method in `DataProcessor`
- include Bollinger Bands step in data pipeline
- document Bollinger Bands in README
- align Bollinger Band defaults in config
- simplify extraction of Bollinger Bands columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408bb72ce4832aaeb0302ea1ac63f4