### PR TITLE
Add caching configuration and refresh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ pip install -r requirements.txt
 python setup.py develop
 ```
 
+## Data Caching
+
+The `DataLoader` caches downloaded OHLCV data in parquet format to reduce
+network usage. Configure caching in `config/model_config.yaml`:
+
+```yaml
+data:
+  cache_dir: 'data/raw'   # Storage location for cached files
+  use_cache: true         # Toggle cache usage
+  refresh: false          # Force fresh download when true
+```
+
 ## Competition Evaluation Metrics
 
 ### Trade-Level Analytics

--- a/config/model_config.yaml
+++ b/config/model_config.yaml
@@ -5,6 +5,9 @@ data:
   symbols: ['AAPL', 'META', 'TSLA', 'JPM', 'AMZN']
   start_date: '2015-01-01'
   end_date: '2024-12-31'
+  cache_dir: 'data/raw'
+  use_cache: true
+  refresh: false
   test_start: '2025-01-01'
   test_end: '2025-01-31'
 

--- a/src/main.py
+++ b/src/main.py
@@ -12,10 +12,10 @@ from datetime import datetime
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def setup_directories():
+def setup_directories(cache_dir: str = 'data/raw'):
     """Create necessary directories if they don't exist."""
     dirs = [
-        'data/raw',
+        cache_dir,
         'data/processed',
         'models/trained',
         'models/experiments',
@@ -30,6 +30,9 @@ def run_pipeline(config_path: str = "config/model_config.yaml"):
     # Load configuration
     with open(config_path, 'r') as file:
         config = yaml.safe_load(file)
+
+    cache_dir = config.get('data', {}).get('cache_dir', 'data/raw')
+    setup_directories(cache_dir)
     
     # Initialize components
     data_loader = DataLoader(config_path)
@@ -44,7 +47,8 @@ def run_pipeline(config_path: str = "config/model_config.yaml"):
     try:
         # 1. Fetch Data
         logger.info("Fetching data...")
-        data_dict = data_loader.fetch_data()
+        refresh = config.get('data', {}).get('refresh', False)
+        data_dict = data_loader.fetch_data(refresh=refresh)
         
         # Process each stock
         results = {}
@@ -103,5 +107,4 @@ def run_pipeline(config_path: str = "config/model_config.yaml"):
         raise
 
 if __name__ == "__main__":
-    setup_directories()
-    run_pipeline() 
+    run_pipeline()

--- a/tests/data/test_loader.py
+++ b/tests/data/test_loader.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest.mock import patch
+import pandas as pd
+import os
+import yaml
+import shutil
+import tempfile
+import sys
+
+# Add src to Python path to allow direct import of DataLoader
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../src')))
+
+from data.loader import DataLoader
+
+class TestDataLoaderCaching(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.cache_dir = os.path.join(self.tmpdir, "cache")
+        os.makedirs(self.cache_dir, exist_ok=True)
+        self.config_path = os.path.join(self.tmpdir, "config.yaml")
+        config = {
+            'data': {
+                'symbols': ['TEST'],
+                'start_date': '2020-01-01',
+                'end_date': '2020-01-10',
+                'cache_dir': self.cache_dir,
+                'use_cache': True,
+                'refresh': False
+            }
+        }
+        with open(self.config_path, 'w') as f:
+            yaml.dump(config, f)
+
+        # create cached dataframe
+        self.df = pd.DataFrame({
+            'Open': [1.0],
+            'High': [2.0],
+            'Low': [1.0],
+            'Close': [2.0],
+            'Volume': [100]
+        }, index=pd.date_range('2020-01-01', periods=1))
+        self.df.to_parquet(os.path.join(self.cache_dir, 'TEST_data.parquet'))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    @patch('yfinance.Ticker')
+    def test_fetch_data_uses_cache(self, mock_ticker):
+        loader = DataLoader(self.config_path)
+        data_dict = loader.fetch_data()
+        mock_ticker.assert_not_called()
+        self.assertIn('TEST', data_dict)
+        pd.testing.assert_frame_equal(data_dict['TEST'], self.df, check_freq=False)
+
+    @patch('yfinance.Ticker')
+    def test_fetch_data_refreshes_cache(self, mock_ticker):
+        # remove cached file to force fetch
+        os.remove(os.path.join(self.cache_dir, 'TEST_data.parquet'))
+
+        mock_history = pd.DataFrame({
+            'Open': [1], 'High': [1], 'Low': [1], 'Close': [1], 'Volume': [1]
+        }, index=pd.date_range('2020-01-01', periods=1))
+        mock_ticker.return_value.history.return_value = mock_history
+
+        loader = DataLoader(self.config_path)
+        data_dict = loader.fetch_data(refresh=True)
+
+        mock_ticker.assert_called_once()
+        self.assertTrue(os.path.exists(os.path.join(self.cache_dir, 'TEST_data.parquet')))
+        pd.testing.assert_frame_equal(data_dict['TEST'], mock_history)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- integrate cache options in `model_config.yaml`
- expose default refresh flag in `DataLoader`
- pass config parameters to `run_pipeline`
- update unit tests for cache settings
- document caching in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a19a47bf4832a9373ed13454faf80