### PR TITLE
Add cache expiration to DataLoader

### DIFF
--- a/config/model_config.yaml
+++ b/config/model_config.yaml
@@ -6,6 +6,8 @@ data:
   start_date: '2015-01-01'
   end_date: '2024-12-31'
   cache_dir: 'data/raw'
+  cache_path: 'data/raw'  # Directory to load/store cached OHLCV files
+  cache_expiration_days: 7  # Refresh cache after this many days
   use_cache: true
   refresh: false
   test_start: '2025-01-01'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 pandas
+pyarrow
 yfinance
 scikit-learn
 xgboost

--- a/tests/data/test_loader.py
+++ b/tests/data/test_loader.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 import sys
 
+
 # Add src to Python path to allow direct import of DataLoader
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../src')))
 
@@ -18,18 +19,7 @@ class TestDataLoaderCaching(unittest.TestCase):
         self.cache_dir = os.path.join(self.tmpdir, "cache")
         os.makedirs(self.cache_dir, exist_ok=True)
         self.config_path = os.path.join(self.tmpdir, "config.yaml")
-        config = {
-            'data': {
-                'symbols': ['TEST'],
-                'start_date': '2020-01-01',
-                'end_date': '2020-01-10',
-                'cache_dir': self.cache_dir,
-                'use_cache': True,
-                'refresh': False
-            }
-        }
-        with open(self.config_path, 'w') as f:
-            yaml.dump(config, f)
+        self._write_config(expiration=10)
 
         # create cached dataframe
         self.df = pd.DataFrame({
@@ -40,6 +30,21 @@ class TestDataLoaderCaching(unittest.TestCase):
             'Volume': [100]
         }, index=pd.date_range('2020-01-01', periods=1))
         self.df.to_parquet(os.path.join(self.cache_dir, 'TEST_data.parquet'))
+
+    def _write_config(self, expiration):
+        config = {
+            'data': {
+                'symbols': ['TEST'],
+                'start_date': '2020-01-01',
+                'end_date': '2020-01-10',
+                'cache_path': self.cache_dir,
+                'cache_expiration_days': expiration,
+                'use_cache': True,
+                'refresh': False
+            }
+        }
+        with open(self.config_path, 'w') as f:
+            yaml.dump(config, f)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
@@ -67,6 +72,21 @@ class TestDataLoaderCaching(unittest.TestCase):
 
         mock_ticker.assert_called_once()
         self.assertTrue(os.path.exists(os.path.join(self.cache_dir, 'TEST_data.parquet')))
+        pd.testing.assert_frame_equal(data_dict['TEST'], mock_history)
+
+    @patch('yfinance.Ticker')
+    def test_fetch_data_expired_cache(self, mock_ticker):
+        self._write_config(expiration=0)
+
+        mock_history = pd.DataFrame({
+            'Open': [1], 'High': [1], 'Low': [1], 'Close': [1], 'Volume': [1]
+        }, index=pd.date_range('2020-01-01', periods=1))
+        mock_ticker.return_value.history.return_value = mock_history
+
+        loader = DataLoader(self.config_path)
+        data_dict = loader.fetch_data()
+
+        mock_ticker.assert_called_once()
         pd.testing.assert_frame_equal(data_dict['TEST'], mock_history)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- support optional cache loading with expiration in `DataLoader`
- expose `cache_path` and `cache_expiration_days` in `model_config.yaml`
- add `pyarrow` dependency
- extend loader tests to cover cache expiration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a202cc4c8832a8597b5facd29b1ea