### PR TITLE
Add command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,22 @@ network usage. Configure caching in `config/model_config.yaml`:
 data:
   cache_dir: 'data/raw'   # Storage location for cached files
   use_cache: true         # Toggle cache usage
-  refresh: false          # Force fresh download when true
+ refresh: false          # Force fresh download when true
 ```
+
+## Command Line Interface
+
+Use the CLI in `src/main.py` to run common tasks:
+
+```bash
+python -m src.main fetch-data -c config/model_config.yaml       # download data
+python -m src.main train -c config/model_config.yaml             # run pipeline
+python -m src.main evaluate -m models/trained/MY_MODEL           # evaluate
+```
+
+`fetch-data` saves raw data to the configured cache directory. `train` executes
+the full training pipeline. `evaluate` loads an existing model directory and
+generates evaluation metrics.
 
 ## Competition Evaluation Metrics
 

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,8 @@ from sklearn.model_selection import train_test_split
 import yaml
 import json
 from datetime import datetime
+import argparse
+import os
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -106,5 +108,60 @@ def run_pipeline(config_path: str = "config/model_config.yaml"):
         logger.error(f"Error in pipeline: {str(e)}")
         raise
 
+def fetch_data_only(config_path: str, refresh: bool = False) -> None:
+    """Fetch data using DataLoader and store it in the cache directory."""
+    data_loader = DataLoader(config_path)
+    data = data_loader.fetch_data(refresh=refresh)
+    data_loader.save_data(data)
+
+
+def evaluate_model(config_path: str, model_path: str) -> None:
+    """Load a saved model and evaluate it on the configured dataset."""
+    data_loader = DataLoader(config_path)
+    data_processor = DataProcessor()
+    model = MomentumClassifier(config_path)
+    model.load_model(model_path)
+
+    data_dict = data_loader.fetch_data()
+    results = {}
+    for symbol, df in data_dict.items():
+        df_processed = data_processor.process_data(df)
+        df_labeled = data_processor.generate_labels(df_processed)
+        X, y = model.prepare_data(df_labeled)
+        metrics = model.evaluate(X, y)
+        results[symbol] = metrics
+        logger.info(f"{symbol} Evaluation: {metrics}")
+
+    with open(os.path.join(model_path, "evaluation.json"), "w") as f:
+        json.dump(results, f, indent=4)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="QuantTradeAI command line interface")
+    subparsers = parser.add_subparsers(dest="command")
+
+    fetch_parser = subparsers.add_parser("fetch-data", help="Fetch data and cache it")
+    fetch_parser.add_argument("-c", "--config", default="config/model_config.yaml", help="Path to config file")
+    fetch_parser.add_argument("--refresh", action="store_true", help="Force refresh of cached data")
+
+    train_parser = subparsers.add_parser("train", help="Run full training pipeline")
+    train_parser.add_argument("-c", "--config", default="config/model_config.yaml", help="Path to config file")
+
+    eval_parser = subparsers.add_parser("evaluate", help="Evaluate a saved model")
+    eval_parser.add_argument("-c", "--config", default="config/model_config.yaml", help="Path to config file")
+    eval_parser.add_argument("-m", "--model-path", required=True, help="Directory containing saved model")
+
+    args = parser.parse_args()
+
+    if args.command == "fetch-data":
+        fetch_data_only(args.config, args.refresh)
+    elif args.command == "train":
+        run_pipeline(args.config)
+    elif args.command == "evaluate":
+        evaluate_model(args.config, args.model_path)
+    else:
+        parser.print_help()
+
+
 if __name__ == "__main__":
-    run_pipeline()
+    main()


### PR DESCRIPTION
## Summary
- expose CLI with argparse supporting `fetch-data`, `train`, and `evaluate`
- document CLI usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f24539ce0832a9f4b3c24a1e6d9eb