### PR TITLE
Add broad unit tests

### DIFF
--- a/tests/data/test_loader_extra.py
+++ b/tests/data/test_loader_extra.py
@@ -1,0 +1,78 @@
+import unittest
+from unittest.mock import patch
+import pandas as pd
+import os
+import yaml
+import shutil
+import tempfile
+import sys
+import time
+
+# Add src to Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'src')))
+
+from data.loader import DataLoader
+
+class TestCheckMissingDates(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.config_path = os.path.join(self.tmpdir, 'config.yaml')
+        config = {
+            'data': {
+                'symbols': ['TEST'],
+                'start_date': '2020-01-01',
+                'end_date': '2020-01-10',
+                'cache_path': self.tmpdir,
+                'use_cache': False
+            }
+        }
+        with open(self.config_path, 'w') as f:
+            yaml.dump(config, f)
+        self.loader = DataLoader(self.config_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_check_missing_dates_detects_gap(self):
+        dates = pd.date_range('2020-01-01', '2020-01-07', freq='B')
+        df = pd.DataFrame({'Open':1, 'High':1, 'Low':1, 'Close':1, 'Volume':1}, index=dates)
+        df = df.drop(pd.Timestamp('2020-01-03'))
+        missing = self.loader._check_missing_dates(df)
+        self.assertIn(pd.Timestamp('2020-01-03'), missing)
+        self.assertEqual(len(missing), 1)
+
+class TestIsCacheValid(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.cache_file = os.path.join(self.tmpdir, 'TEST_data.parquet')
+        df = pd.DataFrame({'a':[1]}, index=pd.date_range('2020-01-01', periods=1))
+        df.to_parquet(self.cache_file)
+        self.config_path = os.path.join(self.tmpdir, 'config.yaml')
+        config = {
+            'data': {
+                'symbols': ['TEST'],
+                'start_date': '2020-01-01',
+                'end_date': '2020-01-02',
+                'cache_path': self.tmpdir,
+                'cache_expiration_days': 1,
+                'use_cache': True
+            }
+        }
+        with open(self.config_path, 'w') as f:
+            yaml.dump(config, f)
+        self.loader = DataLoader(self.config_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_is_cache_valid_true(self):
+        os.utime(self.cache_file, None)
+        self.assertTrue(self.loader._is_cache_valid(self.cache_file))
+
+    def test_is_cache_valid_expired(self):
+        old = time.time() - 2 * 24 * 3600
+        os.utime(self.cache_file, (old, old))
+        self.assertFalse(self.loader._is_cache_valid(self.cache_file))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/data/test_processor_steps.py
+++ b/tests/data/test_processor_steps.py
@@ -1,0 +1,50 @@
+import unittest
+import pandas as pd
+import numpy as np
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src')))
+
+from data.processor import DataProcessor
+
+class TestProcessorSteps(unittest.TestCase):
+    def setUp(self):
+        self.processor = DataProcessor()
+
+    def test_generate_feature_combinations(self):
+        self.processor.cross_indicators = [['a','b']]
+        self.processor.ratio_indicators = [['a','b']]
+        df = pd.DataFrame({'a':[1,2,3],'b':[1,2,4]})
+        result = self.processor._generate_feature_combinations(df.copy())
+        self.assertIn('cross_a_b', result.columns)
+        self.assertIn('ratio_a_b', result.columns)
+
+    def test_scale_features_minmax(self):
+        self.processor.scaling_method = 'minmax'
+        self.processor.scaling_range = [0,1]
+        df = pd.DataFrame({'a':[1,2,3],'b':[4,5,6]})
+        scaled = self.processor._scale_features(df.copy())
+        self.assertAlmostEqual(scaled['a'].min(), 0.0)
+        self.assertAlmostEqual(scaled['a'].max(), 1.0)
+
+    def test_select_features(self):
+        self.processor.n_features = 2
+        df = pd.DataFrame(np.random.rand(3,4), columns=list('abcd'))
+        selected = self.processor._select_features(df)
+        self.assertEqual(list(selected.columns), ['a','b'])
+
+    def test_remove_outliers_clip(self):
+        self.processor.outlier_method = 'clip'
+        self.processor.outlier_limits = [0.0, 0.8]
+        df = pd.DataFrame({'a':[1,2,100],'b':[1,2,3]})
+        cleaned = self.processor._remove_outliers(df.copy())
+        self.assertLessEqual(cleaned['a'].max(), df['a'].quantile(0.8))
+
+    def test_generate_labels(self):
+        df = pd.DataFrame({'Close':[1,2,3,4,5]})
+        labeled = self.processor.generate_labels(df.copy(), forward_returns=1, threshold=0.5)
+        self.assertIn('label', labeled.columns)
+        self.assertEqual(len(labeled), 4)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import patch
+import pandas as pd
+import numpy as np
+import os, sys
+
+# add src to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src')))
+
+from features import technical as ft
+from features import custom as cf
+
+class TestTechnicalFunctions(unittest.TestCase):
+    @patch('pandas_ta.sma')
+    def test_sma_calls_pandas_ta(self, mock_sma):
+        series = pd.Series([1,2,3])
+        ft.sma(series, 5)
+        mock_sma.assert_called_once_with(series, length=5)
+
+    @patch('pandas_ta.macd')
+    def test_macd_returns_dataframe(self, mock_macd):
+        mock_df = pd.DataFrame({'MACD_12_26_9':[0], 'MACDs_12_26_9':[0], 'MACDh_12_26_9':[0]})
+        mock_macd.return_value = mock_df
+        res = ft.macd(pd.Series([1,2,3]))
+        self.assertIn('macd', res.columns)
+        self.assertIn('signal', res.columns)
+        self.assertIn('hist', res.columns)
+
+class TestCustomFunctions(unittest.TestCase):
+    def test_momentum_score_basic(self):
+        close = pd.Series([10,12,11])
+        sma = pd.Series([9,11,12])
+        rsi = pd.Series([60,40,55])
+        macd = pd.Series([0.5,-0.2,0.1])
+        signal = pd.Series([0.3,-0.1,0.0])
+        result = cf.momentum_score(close, sma, rsi, macd, signal)
+        raw = ((close>sma).astype(int)*0.3 + (rsi>50).astype(int)*0.3 + (macd>signal).astype(int)*0.4)
+        expected = (raw - raw.mean())/raw.std()
+        pd.testing.assert_series_equal(result, expected)
+
+    def test_volatility_breakout_flag(self):
+        high = pd.Series([10]*25)
+        low = pd.Series([5]*25)
+        close = pd.Series([10]*24 + [16])
+        res = cf.volatility_breakout(high, low, close, lookback=20, threshold=1)
+        self.assertEqual(res.iloc[-1], 1)
+        self.assertEqual(res.iloc[:-1].sum(), 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/models/test_classifier.py
+++ b/tests/models/test_classifier.py
@@ -1,0 +1,35 @@
+import unittest
+import pandas as pd
+import numpy as np
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src')))
+
+from models.classifier import MomentumClassifier
+
+class TestMomentumClassifier(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(0)
+        n = 20
+        self.df = pd.DataFrame({
+            'Open': np.random.rand(n),
+            'High': np.random.rand(n),
+            'Low': np.random.rand(n),
+            'Close': np.random.rand(n),
+            'Volume': np.random.rand(n),
+            'feature1': np.random.rand(n),
+            'feature2': np.random.rand(n),
+            'forward_returns': np.random.rand(n),
+            'label': np.random.randint(0,2,n)
+        })
+        self.model = MomentumClassifier('config/model_config.yaml')
+        self.X, self.y = self.model.prepare_data(self.df)
+
+    def test_train_and_predict(self):
+        self.model.train(self.X, self.y)
+        preds = self.model.predict(self.X)
+        self.assertEqual(len(preds), len(self.y))
+        self.assertTrue(set(np.unique(preds)).issubset({0,1}))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend data loader tests to cover cache validity and missing dates
- add feature module tests
- test DataProcessor pipeline steps including outliers, scaling, labeling
- add basic MomentumClassifier train and predict test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f25e58e5c832a9c5e6541e13743c6