### PR TITLE
Format codebase and resolve flake8 warnings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,4 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     python_requires=">=3.9",
-) 
+)

--- a/src/data/processor.py
+++ b/src/data/processor.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-from typing import Dict, List, Union
+
 import logging
 import yaml  # Added for YAML loading
 from pydantic import ValidationError
@@ -227,10 +227,12 @@ class DataProcessor:
         logger.info(f"DataProcessor initialized with bb_period: {self.bb_period}")
         logger.info(f"DataProcessor initialized with bb_std: {self.bb_std}")
         logger.info(
-            f"DataProcessor initialized with volume_sma_periods: {self.volume_sma_periods}"
+            "DataProcessor initialized with volume_sma_periods: "
+            f"{self.volume_sma_periods}"
         )
         logger.info(
-            f"DataProcessor initialized with volume_ema_periods: {self.volume_ema_periods}"
+            "DataProcessor initialized with volume_ema_periods: "
+            f"{self.volume_ema_periods}"
         )
         logger.info(f"DataProcessor initialized with sma_periods: {self.sma_periods}")
 

--- a/src/features/__init__.py
+++ b/src/features/__init__.py
@@ -4,4 +4,3 @@ from . import technical
 from . import custom
 
 __all__ = ["technical", "custom"]
-

--- a/src/features/custom.py
+++ b/src/features/custom.py
@@ -1,9 +1,13 @@
 import pandas as pd
-import pandas_ta as ta
 
 
-def momentum_score(close: pd.Series, sma: pd.Series, rsi_series: pd.Series,
-                    macd: pd.Series, macd_signal: pd.Series) -> pd.Series:
+def momentum_score(
+    close: pd.Series,
+    sma: pd.Series,
+    rsi_series: pd.Series,
+    macd: pd.Series,
+    macd_signal: pd.Series,
+) -> pd.Series:
     """Compute a simple momentum score from multiple indicators."""
     score = (
         (close > sma).astype(int) * 0.3
@@ -13,8 +17,13 @@ def momentum_score(close: pd.Series, sma: pd.Series, rsi_series: pd.Series,
     return (score - score.mean()) / score.std()
 
 
-def volatility_breakout(high: pd.Series, low: pd.Series, close: pd.Series,
-                        lookback: int = 20, threshold: float = 2.0) -> pd.Series:
+def volatility_breakout(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    lookback: int = 20,
+    threshold: float = 2.0,
+) -> pd.Series:
     """Flag days when price breaks above the previous high plus a threshold."""
     rolling_high = high.shift(1).rolling(lookback).max()
     rolling_low = low.shift(1).rolling(lookback).min()

--- a/src/features/technical.py
+++ b/src/features/technical.py
@@ -17,20 +17,25 @@ def rsi(series: pd.Series, period: int = 14) -> pd.Series:
     return ta.rsi(series, length=period)
 
 
-def macd(series: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9) -> pd.DataFrame:
+def macd(
+    series: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9
+) -> pd.DataFrame:
     """MACD indicator returning macd, signal and histogram columns"""
     df = ta.macd(series, fast=fast, slow=slow, signal=signal)
-    return pd.DataFrame({
-        'macd': df[f'MACD_{fast}_{slow}_{signal}'],
-        'signal': df[f'MACDs_{fast}_{slow}_{signal}'],
-        'hist': df[f'MACDh_{fast}_{slow}_{signal}']
-    })
+    return pd.DataFrame(
+        {
+            "macd": df[f"MACD_{fast}_{slow}_{signal}"],
+            "signal": df[f"MACDs_{fast}_{slow}_{signal}"],
+            "hist": df[f"MACDh_{fast}_{slow}_{signal}"],
+        }
+    )
 
 
-def stochastic(high: pd.Series, low: pd.Series, close: pd.Series, k: int = 14, d: int = 3) -> pd.DataFrame:
+def stochastic(
+    high: pd.Series, low: pd.Series, close: pd.Series, k: int = 14, d: int = 3
+) -> pd.DataFrame:
     """Stochastic Oscillator"""
     df = ta.stoch(high, low, close, k=k, d=d)
-    return pd.DataFrame({
-        'stoch_k': df['STOCHk_14_3_3'],
-        'stoch_d': df['STOCHd_14_3_3']
-    })
+    return pd.DataFrame(
+        {"stoch_k": df["STOCHk_14_3_3"], "stoch_d": df["STOCHd_14_3_3"]}
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from data.loader import DataLoader
 from data.processor import DataProcessor
 from models.classifier import MomentumClassifier
-import pandas as pd
 from sklearn.model_selection import train_test_split
 import yaml
 import json
@@ -14,99 +13,102 @@ import os
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def setup_directories(cache_dir: str = 'data/raw'):
+
+def setup_directories(cache_dir: str = "data/raw"):
     """Create necessary directories if they don't exist."""
     dirs = [
         cache_dir,
-        'data/processed',
-        'models/trained',
-        'models/experiments',
-        'reports/figures'
+        "data/processed",
+        "models/trained",
+        "models/experiments",
+        "reports/figures",
     ]
     for dir_path in dirs:
         Path(dir_path).mkdir(parents=True, exist_ok=True)
 
+
 def run_pipeline(config_path: str = "config/model_config.yaml"):
     """Run the complete trading strategy pipeline."""
-    
+
     # Load configuration
-    with open(config_path, 'r') as file:
+    with open(config_path, "r") as file:
         config = yaml.safe_load(file)
 
-    cache_dir = config.get('data', {}).get('cache_dir', 'data/raw')
+    cache_dir = config.get("data", {}).get("cache_dir", "data/raw")
     setup_directories(cache_dir)
-    
+
     # Initialize components
     data_loader = DataLoader(config_path)
     data_processor = DataProcessor()
     model = MomentumClassifier(config_path)
-    
+
     # Create experiment directory
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     experiment_dir = f"models/experiments/{timestamp}"
     Path(experiment_dir).mkdir(parents=True, exist_ok=True)
-    
+
     try:
         # 1. Fetch Data
         logger.info("Fetching data...")
-        refresh = config.get('data', {}).get('refresh', False)
+        refresh = config.get("data", {}).get("refresh", False)
         data_dict = data_loader.fetch_data(refresh=refresh)
-        
+
         # Process each stock
         results = {}
         for symbol, df in data_dict.items():
             logger.info(f"\nProcessing {symbol}...")
-            
+
             # 2. Generate Features
             df_processed = data_processor.process_data(df)
-            
+
             # 3. Generate Labels
             df_labeled = data_processor.generate_labels(df_processed)
-            
+
             # 4. Split Data
             X, y = model.prepare_data(df_labeled)
             X_train, X_test, y_train, y_test = train_test_split(
                 X, y, test_size=0.2, random_state=42
             )
-            
+
             # 5. Optimize Hyperparameters
             logger.info(f"Optimizing hyperparameters for {symbol}...")
             best_params = model.optimize_hyperparameters(X_train, y_train, n_trials=50)
-            
+
             # 6. Train Model
             logger.info(f"Training model for {symbol}...")
             model.train(X_train, y_train, params=best_params)
-            
+
             # 7. Evaluate Performance
             train_metrics = model.evaluate(X_train, y_train)
             test_metrics = model.evaluate(X_test, y_test)
-            
+
             # Save results
             results[symbol] = {
-                'hyperparameters': best_params,
-                'train_metrics': train_metrics,
-                'test_metrics': test_metrics
+                "hyperparameters": best_params,
+                "train_metrics": train_metrics,
+                "test_metrics": test_metrics,
             }
-            
+
             # Save model
             model_path = f"{experiment_dir}/{symbol}"
             Path(model_path).mkdir(parents=True, exist_ok=True)
             model.save_model(model_path)
-            
+
             logger.info(f"\n{symbol} Results:")
             logger.info(f"Train Metrics: {train_metrics}")
             logger.info(f"Test Metrics: {test_metrics}")
-        
+
         # Save experiment results
-        with open(f"{experiment_dir}/results.json", 'w') as f:
+        with open(f"{experiment_dir}/results.json", "w") as f:
             json.dump(results, f, indent=4)
-        
+
         logger.info("\nPipeline completed successfully!")
         return results
-        
+
     except Exception as e:
         logger.error(f"Error in pipeline: {str(e)}")
         raise
+
 
 def fetch_data_only(config_path: str, refresh: bool = False) -> None:
     """Fetch data using DataLoader and store it in the cache directory."""
@@ -141,15 +143,25 @@ def main():
     subparsers = parser.add_subparsers(dest="command")
 
     fetch_parser = subparsers.add_parser("fetch-data", help="Fetch data and cache it")
-    fetch_parser.add_argument("-c", "--config", default="config/model_config.yaml", help="Path to config file")
-    fetch_parser.add_argument("--refresh", action="store_true", help="Force refresh of cached data")
+    fetch_parser.add_argument(
+        "-c", "--config", default="config/model_config.yaml", help="Path to config file"
+    )
+    fetch_parser.add_argument(
+        "--refresh", action="store_true", help="Force refresh of cached data"
+    )
 
     train_parser = subparsers.add_parser("train", help="Run full training pipeline")
-    train_parser.add_argument("-c", "--config", default="config/model_config.yaml", help="Path to config file")
+    train_parser.add_argument(
+        "-c", "--config", default="config/model_config.yaml", help="Path to config file"
+    )
 
     eval_parser = subparsers.add_parser("evaluate", help="Evaluate a saved model")
-    eval_parser.add_argument("-c", "--config", default="config/model_config.yaml", help="Path to config file")
-    eval_parser.add_argument("-m", "--model-path", required=True, help="Directory containing saved model")
+    eval_parser.add_argument(
+        "-c", "--config", default="config/model_config.yaml", help="Path to config file"
+    )
+    eval_parser.add_argument(
+        "-m", "--model-path", required=True, help="Directory containing saved model"
+    )
 
     args = parser.parse_args()
 

--- a/src/models/classifier.py
+++ b/src/models/classifier.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import numpy as np
-from typing import Dict, List, Tuple, Any
+from typing import Dict, Tuple, Any
 import logging
-from sklearn.model_selection import train_test_split, cross_val_score
+from sklearn.model_selection import cross_val_score
 from sklearn.preprocessing import StandardScaler
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestClassifier, VotingClassifier
@@ -14,106 +14,117 @@ import yaml
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 class MomentumClassifier:
     """Voting Classifier for momentum trading strategy."""
-    
+
     def __init__(self, config_path: str = "config/model_config.yaml"):
         """Initialize the model with configuration."""
-        with open(config_path, 'r') as file:
+        with open(config_path, "r") as file:
             self.config = yaml.safe_load(file)
-        
+
         self.scaler = StandardScaler()
         self.model = None
         self.feature_columns = None
-        
+
     def prepare_data(self, df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
         """
         Prepare data for training/prediction.
-        
+
         Args:
             df: DataFrame with features and labels
-            
+
         Returns:
             Tuple of features array and labels array
         """
         # Remove non-feature columns
-        exclude_cols = ['Open', 'High', 'Low', 'Close', 'Volume', 
-                       'forward_returns', 'label']
+        exclude_cols = [
+            "Open",
+            "High",
+            "Low",
+            "Close",
+            "Volume",
+            "forward_returns",
+            "label",
+        ]
         feature_cols = [col for col in df.columns if col not in exclude_cols]
         self.feature_columns = feature_cols
-        
+
         X = df[feature_cols].values
-        y = df['label'].values
-        
+        y = df["label"].values
+
         return X, y
-    
-    def optimize_hyperparameters(self, X: np.ndarray, y: np.ndarray, 
-                               n_trials: int = 100) -> Dict:
+
+    def optimize_hyperparameters(
+        self, X: np.ndarray, y: np.ndarray, n_trials: int = 100
+    ) -> Dict:
         """
         Optimize hyperparameters using Optuna.
-        
+
         Args:
             X: Feature matrix
             y: Labels array
             n_trials: Number of optimization trials
-            
+
         Returns:
             Dictionary of best parameters
         """
+
         def objective(trial):
             # Logistic Regression parameters
             lr_params = {
-                'C': trial.suggest_loguniform('lr_C', 1e-5, 100),
-                'max_iter': 1000,
-                'class_weight': 'balanced'
+                "C": trial.suggest_loguniform("lr_C", 1e-5, 100),
+                "max_iter": 1000,
+                "class_weight": "balanced",
             }
-            
+
             # Random Forest parameters
             rf_params = {
-                'n_estimators': trial.suggest_int('rf_n_estimators', 50, 300),
-                'max_depth': trial.suggest_int('rf_max_depth', 3, 15),
-                'min_samples_split': trial.suggest_int('rf_min_samples_split', 2, 10),
-                'class_weight': 'balanced'
+                "n_estimators": trial.suggest_int("rf_n_estimators", 50, 300),
+                "max_depth": trial.suggest_int("rf_max_depth", 3, 15),
+                "min_samples_split": trial.suggest_int("rf_min_samples_split", 2, 10),
+                "class_weight": "balanced",
             }
-            
+
             # XGBoost parameters
             xgb_params = {
-                'n_estimators': trial.suggest_int('xgb_n_estimators', 50, 300),
-                'max_depth': trial.suggest_int('xgb_max_depth', 3, 15),
-                'learning_rate': trial.suggest_loguniform('xgb_learning_rate', 1e-3, 0.1),
-                'subsample': trial.suggest_uniform('xgb_subsample', 0.6, 1.0),
-                'colsample_bytree': trial.suggest_uniform('xgb_colsample_bytree', 0.6, 1.0)
+                "n_estimators": trial.suggest_int("xgb_n_estimators", 50, 300),
+                "max_depth": trial.suggest_int("xgb_max_depth", 3, 15),
+                "learning_rate": trial.suggest_loguniform(
+                    "xgb_learning_rate", 1e-3, 0.1
+                ),
+                "subsample": trial.suggest_uniform("xgb_subsample", 0.6, 1.0),
+                "colsample_bytree": trial.suggest_uniform(
+                    "xgb_colsample_bytree", 0.6, 1.0
+                ),
             }
-            
+
             # Create models with trial parameters
             lr = LogisticRegression(**lr_params)
             rf = RandomForestClassifier(**rf_params)
             xgb_clf = xgb.XGBClassifier(**xgb_params)
-            
+
             # Create voting classifier
             voting_clf = VotingClassifier(
-                estimators=[
-                    ('lr', lr),
-                    ('rf', rf),
-                    ('xgb', xgb_clf)
-                ],
-                voting='soft'
+                estimators=[("lr", lr), ("rf", rf), ("xgb", xgb_clf)], voting="soft"
             )
-            
+
             # Perform cross-validation
-            scores = cross_val_score(voting_clf, X, y, cv=5, scoring='f1_weighted')
+            scores = cross_val_score(voting_clf, X, y, cv=5, scoring="f1_weighted")
             return scores.mean()
-        
+
         # Create study and optimize
-        study = optuna.create_study(direction='maximize')
+        study = optuna.create_study(direction="maximize")
         study.optimize(objective, n_trials=n_trials)
-        
+
         return study.best_params
-    
-    def train(self, X: np.ndarray, y: np.ndarray, params: Dict[str, Any] = None) -> None:
+
+    def train(
+        self, X: np.ndarray, y: np.ndarray, params: Dict[str, Any] = None
+    ) -> None:
         """
         Train the voting classifier.
-        
+
         Args:
             X: Feature matrix
             y: Labels array
@@ -121,98 +132,93 @@ class MomentumClassifier:
         """
         # Scale features
         X_scaled = self.scaler.fit_transform(X)
-        
+
         # Use default parameters if none provided
         if params is None:
             params = {
-                'lr_C': 1.0,
-                'rf_n_estimators': 100,
-                'rf_max_depth': 10,
-                'rf_min_samples_split': 2,
-                'xgb_n_estimators': 100,
-                'xgb_max_depth': 6,
-                'xgb_learning_rate': 0.1,
-                'xgb_subsample': 0.8,
-                'xgb_colsample_bytree': 0.8
+                "lr_C": 1.0,
+                "rf_n_estimators": 100,
+                "rf_max_depth": 10,
+                "rf_min_samples_split": 2,
+                "xgb_n_estimators": 100,
+                "xgb_max_depth": 6,
+                "xgb_learning_rate": 0.1,
+                "xgb_subsample": 0.8,
+                "xgb_colsample_bytree": 0.8,
             }
-        
+
         # Create base models with parameters
         lr = LogisticRegression(
-            C=params['lr_C'],
-            max_iter=1000,
-            class_weight='balanced'
+            C=params["lr_C"], max_iter=1000, class_weight="balanced"
         )
-        
+
         rf = RandomForestClassifier(
-            n_estimators=params['rf_n_estimators'],
-            max_depth=params['rf_max_depth'],
-            min_samples_split=params['rf_min_samples_split'],
-            class_weight='balanced'
+            n_estimators=params["rf_n_estimators"],
+            max_depth=params["rf_max_depth"],
+            min_samples_split=params["rf_min_samples_split"],
+            class_weight="balanced",
         )
-        
+
         xgb_clf = xgb.XGBClassifier(
-            n_estimators=params['xgb_n_estimators'],
-            max_depth=params['xgb_max_depth'],
-            learning_rate=params['xgb_learning_rate'],
-            subsample=params['xgb_subsample'],
-            colsample_bytree=params['xgb_colsample_bytree']
+            n_estimators=params["xgb_n_estimators"],
+            max_depth=params["xgb_max_depth"],
+            learning_rate=params["xgb_learning_rate"],
+            subsample=params["xgb_subsample"],
+            colsample_bytree=params["xgb_colsample_bytree"],
         )
-        
+
         # Create and train voting classifier
         self.model = VotingClassifier(
-            estimators=[
-                ('lr', lr),
-                ('rf', rf),
-                ('xgb', xgb_clf)
-            ],
-            voting='soft'
+            estimators=[("lr", lr), ("rf", rf), ("xgb", xgb_clf)], voting="soft"
         )
-        
+
         self.model.fit(X_scaled, y)
         logger.info("Model training completed")
-    
+
     def predict(self, X: np.ndarray) -> np.ndarray:
         """
         Make predictions using the trained model.
-        
+
         Args:
             X: Feature matrix
-            
+
         Returns:
             Array of predictions
         """
         if self.model is None:
             raise ValueError("Model not trained yet")
-        
+
         X_scaled = self.scaler.transform(X)
         return self.model.predict(X_scaled)
-    
+
     def evaluate(self, X: np.ndarray, y: np.ndarray) -> Dict[str, float]:
         """
         Evaluate model performance.
-        
+
         Args:
             X: Feature matrix
             y: True labels
-            
+
         Returns:
             Dictionary of performance metrics
         """
         predictions = self.predict(X)
         return classification_metrics(y, predictions)
-    
+
     def save_model(self, path: str) -> None:
         """Save the trained model and scaler."""
         import joblib
+
         joblib.dump(self.model, f"{path}/voting_classifier.joblib")
         joblib.dump(self.scaler, f"{path}/scaler.joblib")
         joblib.dump(self.feature_columns, f"{path}/feature_columns.joblib")
         logger.info(f"Model saved to {path}")
-    
+
     def load_model(self, path: str) -> None:
         """Load a trained model and scaler."""
         import joblib
+
         self.model = joblib.load(f"{path}/voting_classifier.joblib")
         self.scaler = joblib.load(f"{path}/scaler.joblib")
         self.feature_columns = joblib.load(f"{path}/feature_columns.joblib")
-        logger.info(f"Model loaded from {path}") 
+        logger.info(f"Model loaded from {path}")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -4,4 +4,3 @@ from . import metrics
 from . import visualization
 
 __all__ = ["metrics", "visualization"]
-

--- a/src/utils/config_schemas.py
+++ b/src/utils/config_schemas.py
@@ -1,5 +1,5 @@
 from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, validator
+from pydantic import BaseModel
 
 
 class DataSection(BaseModel):

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -6,10 +6,10 @@ from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_sc
 def classification_metrics(y_true: np.ndarray, y_pred: np.ndarray) -> dict:
     """Return basic classification metrics."""
     return {
-        'accuracy': accuracy_score(y_true, y_pred),
-        'precision': precision_score(y_true, y_pred, average='weighted'),
-        'recall': recall_score(y_true, y_pred, average='weighted'),
-        'f1': f1_score(y_true, y_pred, average='weighted')
+        "accuracy": accuracy_score(y_true, y_pred),
+        "precision": precision_score(y_true, y_pred, average="weighted"),
+        "recall": recall_score(y_true, y_pred, average="weighted"),
+        "f1": f1_score(y_true, y_pred, average="weighted"),
     }
 
 

--- a/src/utils/visualization.py
+++ b/src/utils/visualization.py
@@ -4,10 +4,10 @@ import pandas as pd
 
 def plot_price(data: pd.DataFrame, title: str = "Price Chart") -> None:
     """Plot OHLC closing price."""
-    data['Close'].plot(figsize=(10, 4))
+    data["Close"].plot(figsize=(10, 4))
     plt.title(title)
-    plt.xlabel('Date')
-    plt.ylabel('Close')
+    plt.xlabel("Date")
+    plt.ylabel("Close")
     plt.tight_layout()
     plt.show()
 
@@ -16,7 +16,7 @@ def plot_performance(equity_curve: pd.Series, title: str = "Equity Curve") -> No
     """Plot cumulative returns or equity curve."""
     equity_curve.plot(figsize=(10, 4))
     plt.title(title)
-    plt.xlabel('Date')
-    plt.ylabel('Equity')
+    plt.xlabel("Date")
+    plt.ylabel("Equity")
     plt.tight_layout()
     plt.show()

--- a/tests/data/test_config_validation.py
+++ b/tests/data/test_config_validation.py
@@ -8,8 +8,8 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..", "src"))
 )
 
-from data.loader import DataLoader
-from data.processor import DataProcessor
+from data.loader import DataLoader  # noqa: E402
+from data.processor import DataProcessor  # noqa: E402
 
 
 class TestModelConfigValidation(unittest.TestCase):

--- a/tests/data/test_loader.py
+++ b/tests/data/test_loader.py
@@ -9,9 +9,12 @@ import sys
 
 
 # Add src to Python path to allow direct import of DataLoader
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../src')))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src"))
+)
 
-from data.loader import DataLoader
+from data.loader import DataLoader  # noqa: E402
+
 
 class TestDataLoaderCaching(unittest.TestCase):
     def setUp(self):
@@ -22,72 +25,80 @@ class TestDataLoaderCaching(unittest.TestCase):
         self._write_config(expiration=10)
 
         # create cached dataframe
-        self.df = pd.DataFrame({
-            'Open': [1.0],
-            'High': [2.0],
-            'Low': [1.0],
-            'Close': [2.0],
-            'Volume': [100]
-        }, index=pd.date_range('2020-01-01', periods=1))
-        self.df.to_parquet(os.path.join(self.cache_dir, 'TEST_data.parquet'))
+        self.df = pd.DataFrame(
+            {
+                "Open": [1.0],
+                "High": [2.0],
+                "Low": [1.0],
+                "Close": [2.0],
+                "Volume": [100],
+            },
+            index=pd.date_range("2020-01-01", periods=1),
+        )
+        self.df.to_parquet(os.path.join(self.cache_dir, "TEST_data.parquet"))
 
     def _write_config(self, expiration):
         config = {
-            'data': {
-                'symbols': ['TEST'],
-                'start_date': '2020-01-01',
-                'end_date': '2020-01-10',
-                'cache_path': self.cache_dir,
-                'cache_expiration_days': expiration,
-                'use_cache': True,
-                'refresh': False
+            "data": {
+                "symbols": ["TEST"],
+                "start_date": "2020-01-01",
+                "end_date": "2020-01-10",
+                "cache_path": self.cache_dir,
+                "cache_expiration_days": expiration,
+                "use_cache": True,
+                "refresh": False,
             }
         }
-        with open(self.config_path, 'w') as f:
+        with open(self.config_path, "w") as f:
             yaml.dump(config, f)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
-    @patch('yfinance.Ticker')
+    @patch("yfinance.Ticker")
     def test_fetch_data_uses_cache(self, mock_ticker):
         loader = DataLoader(self.config_path)
         data_dict = loader.fetch_data()
         mock_ticker.assert_not_called()
-        self.assertIn('TEST', data_dict)
-        pd.testing.assert_frame_equal(data_dict['TEST'], self.df, check_freq=False)
+        self.assertIn("TEST", data_dict)
+        pd.testing.assert_frame_equal(data_dict["TEST"], self.df, check_freq=False)
 
-    @patch('yfinance.Ticker')
+    @patch("yfinance.Ticker")
     def test_fetch_data_refreshes_cache(self, mock_ticker):
         # remove cached file to force fetch
-        os.remove(os.path.join(self.cache_dir, 'TEST_data.parquet'))
+        os.remove(os.path.join(self.cache_dir, "TEST_data.parquet"))
 
-        mock_history = pd.DataFrame({
-            'Open': [1], 'High': [1], 'Low': [1], 'Close': [1], 'Volume': [1]
-        }, index=pd.date_range('2020-01-01', periods=1))
+        mock_history = pd.DataFrame(
+            {"Open": [1], "High": [1], "Low": [1], "Close": [1], "Volume": [1]},
+            index=pd.date_range("2020-01-01", periods=1),
+        )
         mock_ticker.return_value.history.return_value = mock_history
 
         loader = DataLoader(self.config_path)
         data_dict = loader.fetch_data(refresh=True)
 
         mock_ticker.assert_called_once()
-        self.assertTrue(os.path.exists(os.path.join(self.cache_dir, 'TEST_data.parquet')))
-        pd.testing.assert_frame_equal(data_dict['TEST'], mock_history)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.cache_dir, "TEST_data.parquet"))
+        )
+        pd.testing.assert_frame_equal(data_dict["TEST"], mock_history)
 
-    @patch('yfinance.Ticker')
+    @patch("yfinance.Ticker")
     def test_fetch_data_expired_cache(self, mock_ticker):
         self._write_config(expiration=0)
 
-        mock_history = pd.DataFrame({
-            'Open': [1], 'High': [1], 'Low': [1], 'Close': [1], 'Volume': [1]
-        }, index=pd.date_range('2020-01-01', periods=1))
+        mock_history = pd.DataFrame(
+            {"Open": [1], "High": [1], "Low": [1], "Close": [1], "Volume": [1]},
+            index=pd.date_range("2020-01-01", periods=1),
+        )
         mock_ticker.return_value.history.return_value = mock_history
 
         loader = DataLoader(self.config_path)
         data_dict = loader.fetch_data()
 
         mock_ticker.assert_called_once()
-        pd.testing.assert_frame_equal(data_dict['TEST'], mock_history)
+        pd.testing.assert_frame_equal(data_dict["TEST"], mock_history)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/data/test_loader_extra.py
+++ b/tests/data/test_loader_extra.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import patch
 import pandas as pd
 import os
 import yaml
@@ -9,24 +8,27 @@ import sys
 import time
 
 # Add src to Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..', 'src')))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..", "src"))
+)
 
-from data.loader import DataLoader
+from data.loader import DataLoader  # noqa: E402
+
 
 class TestCheckMissingDates(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
-        self.config_path = os.path.join(self.tmpdir, 'config.yaml')
+        self.config_path = os.path.join(self.tmpdir, "config.yaml")
         config = {
-            'data': {
-                'symbols': ['TEST'],
-                'start_date': '2020-01-01',
-                'end_date': '2020-01-10',
-                'cache_path': self.tmpdir,
-                'use_cache': False
+            "data": {
+                "symbols": ["TEST"],
+                "start_date": "2020-01-01",
+                "end_date": "2020-01-10",
+                "cache_path": self.tmpdir,
+                "use_cache": False,
             }
         }
-        with open(self.config_path, 'w') as f:
+        with open(self.config_path, "w") as f:
             yaml.dump(config, f)
         self.loader = DataLoader(self.config_path)
 
@@ -34,31 +36,34 @@ class TestCheckMissingDates(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     def test_check_missing_dates_detects_gap(self):
-        dates = pd.date_range('2020-01-01', '2020-01-07', freq='B')
-        df = pd.DataFrame({'Open':1, 'High':1, 'Low':1, 'Close':1, 'Volume':1}, index=dates)
-        df = df.drop(pd.Timestamp('2020-01-03'))
+        dates = pd.date_range("2020-01-01", "2020-01-07", freq="B")
+        df = pd.DataFrame(
+            {"Open": 1, "High": 1, "Low": 1, "Close": 1, "Volume": 1}, index=dates
+        )
+        df = df.drop(pd.Timestamp("2020-01-03"))
         missing = self.loader._check_missing_dates(df)
-        self.assertIn(pd.Timestamp('2020-01-03'), missing)
+        self.assertIn(pd.Timestamp("2020-01-03"), missing)
         self.assertEqual(len(missing), 1)
+
 
 class TestIsCacheValid(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
-        self.cache_file = os.path.join(self.tmpdir, 'TEST_data.parquet')
-        df = pd.DataFrame({'a':[1]}, index=pd.date_range('2020-01-01', periods=1))
+        self.cache_file = os.path.join(self.tmpdir, "TEST_data.parquet")
+        df = pd.DataFrame({"a": [1]}, index=pd.date_range("2020-01-01", periods=1))
         df.to_parquet(self.cache_file)
-        self.config_path = os.path.join(self.tmpdir, 'config.yaml')
+        self.config_path = os.path.join(self.tmpdir, "config.yaml")
         config = {
-            'data': {
-                'symbols': ['TEST'],
-                'start_date': '2020-01-01',
-                'end_date': '2020-01-02',
-                'cache_path': self.tmpdir,
-                'cache_expiration_days': 1,
-                'use_cache': True
+            "data": {
+                "symbols": ["TEST"],
+                "start_date": "2020-01-01",
+                "end_date": "2020-01-02",
+                "cache_path": self.tmpdir,
+                "cache_expiration_days": 1,
+                "use_cache": True,
             }
         }
-        with open(self.config_path, 'w') as f:
+        with open(self.config_path, "w") as f:
             yaml.dump(config, f)
         self.loader = DataLoader(self.config_path)
 
@@ -74,5 +79,6 @@ class TestIsCacheValid(unittest.TestCase):
         os.utime(self.cache_file, (old, old))
         self.assertFalse(self.loader._is_cache_valid(self.cache_file))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/data/test_processor.py
+++ b/tests/data/test_processor.py
@@ -14,8 +14,8 @@ from data.processor import (
     DataProcessor,
 )  # Assuming DataProcessor is in src/data/processor.py
 
-# Mock pandas_ta for tests if its full import causes issues or if specific functions need mocking
-# We will mock specific pandas_ta functions like bbands and sma within test methods.
+# Mock pandas_ta functions if a full import causes issues during testing.
+# Specific functions like bbands and sma are mocked within test methods.
 
 # Default parameters from DataProcessor for comparison
 DEFAULT_SMA_PERIODS = [5, 10, 20, 50, 200]
@@ -45,7 +45,8 @@ class TestConfigLoading(unittest.TestCase):
                 "volume_ema": {"periods": [8, 15, 30]},  # Added for completeness
             },
             "pipeline": {"steps": ["generate_technical_indicators"]},
-            # Not including price_features or momentum_features to test fallback to defaults
+            # Exclude price_features and momentum_features
+            # to test fallback to defaults
         }
         with open(DUMMY_CONFIG_PATH, "w") as f:
             yaml.dump(self.dummy_config_data, f)
@@ -136,7 +137,8 @@ class TestFeatureGenerationMethods(unittest.TestCase):
         # DataProcessor will initialize with its defaults if config/features_config.yaml
         # (the real one) doesn't exist or is unparseable during tests,
         # or if patched (like in TestConfigLoading.test_load_parameters_file_not_found).
-        # For feature generation tests, we typically want a clean slate or direct override.
+        # For feature generation tests, we typically want a clean slate or
+        # direct override.
         if os.path.exists(
             DUMMY_CONFIG_PATH
         ):  # DUMMY_CONFIG_PATH is 'config/features_config.yaml'
@@ -240,13 +242,13 @@ class TestPipelineExecution(unittest.TestCase):
 
         with patch.object(
             processor, "_generate_technical_indicators", side_effect=record("tech")
-        ) as m_tech, patch.object(
+        ) as _m_tech, patch.object(
             processor, "_handle_missing_values", side_effect=record("missing")
-        ) as m_missing, patch.object(
+        ) as _m_missing, patch.object(
             processor, "_scale_features", side_effect=record("scale")
-        ) as m_scale, patch.object(
+        ) as _m_scale, patch.object(
             processor, "_clean_data", side_effect=record("clean")
-        ) as m_clean:
+        ) as _m_clean:
             processor.process_data(self.df.copy())
 
         self.assertEqual(call_sequence, ["tech", "missing", "scale", "clean"])

--- a/tests/data/test_processor_steps.py
+++ b/tests/data/test_processor_steps.py
@@ -1,50 +1,57 @@
 import unittest
 import pandas as pd
 import numpy as np
-import os, sys
+import os
+import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src')))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+)
 
-from data.processor import DataProcessor
+from data.processor import DataProcessor  # noqa: E402
+
 
 class TestProcessorSteps(unittest.TestCase):
     def setUp(self):
         self.processor = DataProcessor()
 
     def test_generate_feature_combinations(self):
-        self.processor.cross_indicators = [['a','b']]
-        self.processor.ratio_indicators = [['a','b']]
-        df = pd.DataFrame({'a':[1,2,3],'b':[1,2,4]})
+        self.processor.cross_indicators = [["a", "b"]]
+        self.processor.ratio_indicators = [["a", "b"]]
+        df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 4]})
         result = self.processor._generate_feature_combinations(df.copy())
-        self.assertIn('cross_a_b', result.columns)
-        self.assertIn('ratio_a_b', result.columns)
+        self.assertIn("cross_a_b", result.columns)
+        self.assertIn("ratio_a_b", result.columns)
 
     def test_scale_features_minmax(self):
-        self.processor.scaling_method = 'minmax'
-        self.processor.scaling_range = [0,1]
-        df = pd.DataFrame({'a':[1,2,3],'b':[4,5,6]})
+        self.processor.scaling_method = "minmax"
+        self.processor.scaling_range = [0, 1]
+        df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         scaled = self.processor._scale_features(df.copy())
-        self.assertAlmostEqual(scaled['a'].min(), 0.0)
-        self.assertAlmostEqual(scaled['a'].max(), 1.0)
+        self.assertAlmostEqual(scaled["a"].min(), 0.0)
+        self.assertAlmostEqual(scaled["a"].max(), 1.0)
 
     def test_select_features(self):
         self.processor.n_features = 2
-        df = pd.DataFrame(np.random.rand(3,4), columns=list('abcd'))
+        df = pd.DataFrame(np.random.rand(3, 4), columns=list("abcd"))
         selected = self.processor._select_features(df)
-        self.assertEqual(list(selected.columns), ['a','b'])
+        self.assertEqual(list(selected.columns), ["a", "b"])
 
     def test_remove_outliers_clip(self):
-        self.processor.outlier_method = 'clip'
+        self.processor.outlier_method = "clip"
         self.processor.outlier_limits = [0.0, 0.8]
-        df = pd.DataFrame({'a':[1,2,100],'b':[1,2,3]})
+        df = pd.DataFrame({"a": [1, 2, 100], "b": [1, 2, 3]})
         cleaned = self.processor._remove_outliers(df.copy())
-        self.assertLessEqual(cleaned['a'].max(), df['a'].quantile(0.8))
+        self.assertLessEqual(cleaned["a"].max(), df["a"].quantile(0.8))
 
     def test_generate_labels(self):
-        df = pd.DataFrame({'Close':[1,2,3,4,5]})
-        labeled = self.processor.generate_labels(df.copy(), forward_returns=1, threshold=0.5)
-        self.assertIn('label', labeled.columns)
+        df = pd.DataFrame({"Close": [1, 2, 3, 4, 5]})
+        labeled = self.processor.generate_labels(
+            df.copy(), forward_returns=1, threshold=0.5
+        )
+        self.assertIn("label", labeled.columns)
         self.assertEqual(len(labeled), 4)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -1,50 +1,61 @@
 import unittest
 from unittest.mock import patch
 import pandas as pd
-import numpy as np
-import os, sys
+import os
+import sys
 
 # add src to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src')))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+)
 
-from features import technical as ft
-from features import custom as cf
+from features import technical as ft  # noqa: E402
+from features import custom as cf  # noqa: E402
+
 
 class TestTechnicalFunctions(unittest.TestCase):
-    @patch('pandas_ta.sma')
+    @patch("pandas_ta.sma")
     def test_sma_calls_pandas_ta(self, mock_sma):
-        series = pd.Series([1,2,3])
+        series = pd.Series([1, 2, 3])
         ft.sma(series, 5)
         mock_sma.assert_called_once_with(series, length=5)
 
-    @patch('pandas_ta.macd')
+    @patch("pandas_ta.macd")
     def test_macd_returns_dataframe(self, mock_macd):
-        mock_df = pd.DataFrame({'MACD_12_26_9':[0], 'MACDs_12_26_9':[0], 'MACDh_12_26_9':[0]})
+        mock_df = pd.DataFrame(
+            {"MACD_12_26_9": [0], "MACDs_12_26_9": [0], "MACDh_12_26_9": [0]}
+        )
         mock_macd.return_value = mock_df
-        res = ft.macd(pd.Series([1,2,3]))
-        self.assertIn('macd', res.columns)
-        self.assertIn('signal', res.columns)
-        self.assertIn('hist', res.columns)
+        res = ft.macd(pd.Series([1, 2, 3]))
+        self.assertIn("macd", res.columns)
+        self.assertIn("signal", res.columns)
+        self.assertIn("hist", res.columns)
+
 
 class TestCustomFunctions(unittest.TestCase):
     def test_momentum_score_basic(self):
-        close = pd.Series([10,12,11])
-        sma = pd.Series([9,11,12])
-        rsi = pd.Series([60,40,55])
-        macd = pd.Series([0.5,-0.2,0.1])
-        signal = pd.Series([0.3,-0.1,0.0])
+        close = pd.Series([10, 12, 11])
+        sma = pd.Series([9, 11, 12])
+        rsi = pd.Series([60, 40, 55])
+        macd = pd.Series([0.5, -0.2, 0.1])
+        signal = pd.Series([0.3, -0.1, 0.0])
         result = cf.momentum_score(close, sma, rsi, macd, signal)
-        raw = ((close>sma).astype(int)*0.3 + (rsi>50).astype(int)*0.3 + (macd>signal).astype(int)*0.4)
-        expected = (raw - raw.mean())/raw.std()
+        raw = (
+            (close > sma).astype(int) * 0.3
+            + (rsi > 50).astype(int) * 0.3
+            + (macd > signal).astype(int) * 0.4
+        )
+        expected = (raw - raw.mean()) / raw.std()
         pd.testing.assert_series_equal(result, expected)
 
     def test_volatility_breakout_flag(self):
-        high = pd.Series([10]*25)
-        low = pd.Series([5]*25)
-        close = pd.Series([10]*24 + [16])
+        high = pd.Series([10] * 25)
+        low = pd.Series([5] * 25)
+        close = pd.Series([10] * 24 + [16])
         res = cf.volatility_breakout(high, low, close, lookback=20, threshold=1)
         self.assertEqual(res.iloc[-1], 1)
         self.assertEqual(res.iloc[:-1].sum(), 0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/models/test_classifier.py
+++ b/tests/models/test_classifier.py
@@ -1,35 +1,42 @@
 import unittest
 import pandas as pd
 import numpy as np
-import os, sys
+import os
+import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src')))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+)
 
-from models.classifier import MomentumClassifier
+from models.classifier import MomentumClassifier  # noqa: E402
+
 
 class TestMomentumClassifier(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
         n = 20
-        self.df = pd.DataFrame({
-            'Open': np.random.rand(n),
-            'High': np.random.rand(n),
-            'Low': np.random.rand(n),
-            'Close': np.random.rand(n),
-            'Volume': np.random.rand(n),
-            'feature1': np.random.rand(n),
-            'feature2': np.random.rand(n),
-            'forward_returns': np.random.rand(n),
-            'label': np.random.randint(0,2,n)
-        })
-        self.model = MomentumClassifier('config/model_config.yaml')
+        self.df = pd.DataFrame(
+            {
+                "Open": np.random.rand(n),
+                "High": np.random.rand(n),
+                "Low": np.random.rand(n),
+                "Close": np.random.rand(n),
+                "Volume": np.random.rand(n),
+                "feature1": np.random.rand(n),
+                "feature2": np.random.rand(n),
+                "forward_returns": np.random.rand(n),
+                "label": np.random.randint(0, 2, n),
+            }
+        )
+        self.model = MomentumClassifier("config/model_config.yaml")
         self.X, self.y = self.model.prepare_data(self.df)
 
     def test_train_and_predict(self):
         self.model.train(self.X, self.y)
         preds = self.model.predict(self.X)
         self.assertEqual(len(preds), len(self.y))
-        self.assertTrue(set(np.unique(preds)).issubset({0,1}))
+        self.assertTrue(set(np.unique(preds)).issubset({0, 1}))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/verify_config_loading.py
+++ b/verify_config_loading.py
@@ -3,24 +3,24 @@ import os
 
 # Add src to Python path to allow direct import of DataProcessor
 # This assumes the script is run from the root of the repository
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), './src')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "./src")))
 
-from data.processor import DataProcessor
+from data.processor import DataProcessor  # noqa: E402
 import logging
 
-logging.basicConfig(level=logging.INFO) # Ensure logging is configured to see output
+logging.basicConfig(level=logging.INFO)  # Ensure logging is configured to see output
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     logger.info("Attempting to initialize DataProcessor...")
-    sys.stdout.flush() # Try to flush output
+    sys.stdout.flush()  # Try to flush output
     try:
         processor = DataProcessor()
         logger.info("DataProcessor initialized successfully.")
-        sys.stdout.flush() # Try to flush output
+        sys.stdout.flush()  # Try to flush output
     except Exception as e:
         logger.error(f"Error initializing DataProcessor: {e}", exc_info=True)
-        sys.stderr.flush() # Try to flush error
+        sys.stderr.flush()  # Try to flush error
     finally:
-        sys.stdout.flush() # Final flush
+        sys.stdout.flush()  # Final flush
         sys.stderr.flush()


### PR DESCRIPTION
## Summary
- run `black` on the repository
- add `.flake8` configuration to harmonize line length with Black
- clean unused imports and long lines across the source and tests
- adjust tests to silence flake8 E402 warnings

## Testing
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f64559fd0832abc545ee4f6345a75