### PR TITLE
Add risk management module with stop loss

### DIFF
--- a/src/backtest/backtester.py
+++ b/src/backtest/backtester.py
@@ -1,9 +1,14 @@
 import pandas as pd
 
 from utils.metrics import sharpe_ratio, max_drawdown
+from trading.risk import apply_stop_loss_take_profit
 
 
-def simulate_trades(df: pd.DataFrame) -> pd.DataFrame:
+def simulate_trades(
+    df: pd.DataFrame,
+    stop_loss_pct: float | None = None,
+    take_profit_pct: float | None = None,
+) -> pd.DataFrame:
     """Simulate trades using label signals.
 
     Parameters
@@ -19,6 +24,8 @@ def simulate_trades(df: pd.DataFrame) -> pd.DataFrame:
         ``equity_curve`` columns.
     """
     data = df.copy()
+    if stop_loss_pct is not None or take_profit_pct is not None:
+        data = apply_stop_loss_take_profit(data, stop_loss_pct, take_profit_pct)
     data["price_return"] = data["Close"].pct_change()
     data["strategy_return"] = data["price_return"].shift(-1) * data["label"]
     data["strategy_return"] = data["strategy_return"].fillna(0.0)

--- a/src/trading/risk.py
+++ b/src/trading/risk.py
@@ -1,0 +1,95 @@
+import pandas as pd
+
+
+def apply_stop_loss_take_profit(
+    df: pd.DataFrame,
+    stop_loss_pct: float | None = None,
+    take_profit_pct: float | None = None,
+) -> pd.DataFrame:
+    """Apply stop-loss and take-profit rules to trading signals.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame with ``Close`` prices and ``label`` column.
+    stop_loss_pct : float, optional
+        Stop-loss percentage as a decimal (e.g. ``0.05`` for 5%). If ``None``
+        stop-loss is not applied.
+    take_profit_pct : float, optional
+        Take-profit percentage as a decimal. If ``None`` take-profit is not
+        applied.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with an adjusted ``label`` column after applying rules.
+    """
+    data = df.copy()
+    labels = data["label"].tolist()
+
+    position = 0
+    entry_price: float | None = None
+    force_flat = False
+
+    for i, price in enumerate(data["Close"]):
+        signal = labels[i]
+
+        if position == 0:
+            if force_flat:
+                if signal == 0:
+                    force_flat = False
+                labels[i] = 0
+                continue
+            if signal != 0:
+                position = signal
+                entry_price = price
+        else:
+            hit_sl = False
+            hit_tp = False
+            if position == 1:
+                ret = (price - entry_price) / entry_price
+                if stop_loss_pct is not None and ret <= -stop_loss_pct:
+                    hit_sl = True
+                if take_profit_pct is not None and ret >= take_profit_pct:
+                    hit_tp = True
+            else:  # short position
+                ret = (entry_price - price) / entry_price
+                if stop_loss_pct is not None and ret <= -stop_loss_pct:
+                    hit_sl = True
+                if take_profit_pct is not None and ret >= take_profit_pct:
+                    hit_tp = True
+
+            if hit_sl or hit_tp:
+                position = 0
+                entry_price = None
+                labels[i] = 0
+                signal = 0
+                force_flat = True
+            else:
+                labels[i] = position
+
+            # if a new non-zero signal appears, enter new position
+            if position == 0 and signal != 0:
+                position = signal
+                entry_price = price
+            elif position != 0 and signal != position and signal != 0:
+                position = signal
+                entry_price = price
+                labels[i] = signal
+
+    data["label"] = labels
+    return data
+
+
+def position_size(
+    capital: float, risk_per_trade: float, stop_loss_pct: float, price: float
+) -> int:
+    """Calculate position size based on account risk parameters."""
+    if price <= 0:
+        raise ValueError("price must be positive")
+    if stop_loss_pct <= 0:
+        raise ValueError("stop_loss_pct must be positive")
+
+    risk_amount = capital * risk_per_trade
+    qty = risk_amount / (price * stop_loss_pct)
+    return max(int(qty), 0)

--- a/tests/trading/test_risk.py
+++ b/tests/trading/test_risk.py
@@ -1,0 +1,28 @@
+import unittest
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+)
+
+from backtest.backtester import simulate_trades  # noqa: E402
+
+
+class TestRiskManagement(unittest.TestCase):
+    def test_stop_loss_closes_trade(self):
+        df = pd.DataFrame({"Close": [100, 95, 96], "label": [1, 1, 1]})
+        res = simulate_trades(df, stop_loss_pct=0.05)
+        self.assertEqual(res["label"].tolist(), [1, 0, 0])
+        self.assertAlmostEqual(res["equity_curve"].iloc[-1], 0.95)
+
+    def test_take_profit_closes_trade(self):
+        df = pd.DataFrame({"Close": [100, 105, 110, 111], "label": [1, 1, 1, 1]})
+        res = simulate_trades(df, take_profit_pct=0.1)
+        self.assertEqual(res["label"].tolist(), [1, 1, 0, 0])
+        self.assertAlmostEqual(res["equity_curve"].iloc[-1], 1.1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create trading risk management module to handle stop-loss and take-profit
- integrate risk checks into backtester
- add tests for risk rules

## Testing
- `pre-commit run --files src/trading/risk.py src/backtest/backtester.py tests/trading/test_risk.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672c458230832a8e5e7a461b6b1a30