### PR TITLE
Add timeframe support to data fetching

### DIFF
--- a/config/model_config.yaml
+++ b/config/model_config.yaml
@@ -5,6 +5,7 @@ data:
   symbols: ['AAPL', 'META', 'TSLA', 'JPM', 'AMZN']
   start_date: '2015-01-01'
   end_date: '2024-12-31'
+  timeframe: '1d'
   cache_dir: 'data/raw'
   cache_path: 'data/raw'  # Directory to load/store cached OHLCV files
   cache_expiration_days: 7  # Refresh cache after this many days

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -11,18 +11,19 @@ Handles data fetching, caching, and validation for multiple financial instrument
 **Parameters:**
 - `config_path` (str): Path to configuration file
 - `data_source` (DataSource, optional): Custom data source implementation
+- `timeframe` (str, optional): Interval defined in `config/model_config.yaml` (default `'1d'`)
 
 **Example:**
 ```python
 from quanttradeai.data.loader import DataLoader
 
-# Initialize with default configuration
+# Initialize with default configuration (daily timeframe)
 loader = DataLoader("config/model_config.yaml")
 
 # Fetch data for all symbols
 data_dict = loader.fetch_data()
 
-# Fetch data for specific symbols
+# Fetch hourly data for specific symbols
 data_dict = loader.fetch_data(symbols=['AAPL', 'META'], refresh=True)
 ```
 
@@ -102,8 +103,8 @@ from quanttradeai.data.datasource import YFinanceDataSource
 # Initialize YFinance data source
 data_source = YFinanceDataSource()
 
-# Fetch data for a symbol
-df = data_source.fetch("AAPL", "2023-01-01", "2023-12-31")
+# Fetch daily data for a symbol
+df = data_source.fetch("AAPL", "2023-01-01", "2023-12-31", interval="1d")
 ```
 
 ### `AlphaVantageDataSource(api_key: Optional[str] = None)`
@@ -120,8 +121,8 @@ from quanttradeai.data.datasource import AlphaVantageDataSource
 # Initialize with API key
 data_source = AlphaVantageDataSource("YOUR_API_KEY")
 
-# Fetch data
-df = data_source.fetch("AAPL", "2023-01-01", "2023-12-31")
+# Fetch hourly data
+df = data_source.fetch("AAPL", "2023-01-01", "2023-12-31", interval="1h")
 ```
 
 ## DataProcessor Class
@@ -193,6 +194,7 @@ data:
   symbols: ['AAPL', 'META', 'TSLA', 'JPM', 'AMZN']
   start_date: '2015-01-01'
   end_date: '2024-12-31'
+  timeframe: '1d'
   cache_dir: 'data/raw'
   cache_expiration_days: 7
   use_cache: true

--- a/quanttradeai/data/datasource.py
+++ b/quanttradeai/data/datasource.py
@@ -10,23 +10,48 @@ class DataSource(ABC):
     """Abstract interface for price data providers."""
 
     @abstractmethod
-    def fetch(self, symbol: str, start: str, end: str) -> pd.DataFrame:
-        """Retrieve OHLCV data for a single symbol."""
+    def fetch(
+        self, symbol: str, start: str, end: str, interval: str = "1d"
+    ) -> pd.DataFrame:
+        """Retrieve OHLCV data for a single symbol.
+
+        Parameters
+        ----------
+        symbol : str
+            Ticker symbol to fetch data for.
+        start : str
+            Start date for the data range.
+        end : str
+            End date for the data range.
+        interval : str, optional
+            Data interval (e.g. ``"1d"`` or ``"1h"``). Implementations
+            should document the supported values.
+        """
         raise NotImplementedError
 
 
 class YFinanceDataSource(DataSource):
-    """DataSource implementation using the yfinance package."""
+    """DataSource implementation using the yfinance package.
 
-    def fetch(self, symbol: str, start: str, end: str) -> pd.DataFrame:
+    Supported intervals include ``"1m"``, ``"2m"``, ``"5m"``, ``"15m"``, ``"30m"``,
+    ``"60m"``/``"1h"``, ``"1d"``, ``"5d"``, ``"1wk"``, ``"1mo"`` and ``"3mo"``.
+    """
+
+    def fetch(
+        self, symbol: str, start: str, end: str, interval: str = "1d"
+    ) -> pd.DataFrame:
         import yfinance as yf
 
         ticker = yf.Ticker(symbol)
-        return ticker.history(start=start, end=end)
+        return ticker.history(start=start, end=end, interval=interval)
 
 
 class AlphaVantageDataSource(DataSource):
-    """DataSource implementation for AlphaVantage API."""
+    """DataSource implementation for AlphaVantage API.
+
+    Supported intervals are ``"1min"``, ``"5min"``, ``"15min"``, ``"30min"``,
+    ``"60min"``/``"1h"`` for intraday data and ``"1d"`` for daily data.
+    """
 
     def __init__(self, api_key: Optional[str] = None) -> None:
         self.api_key = api_key or os.getenv("ALPHAVANTAGE_API_KEY")
@@ -36,8 +61,24 @@ class AlphaVantageDataSource(DataSource):
 
         self.ts = TimeSeries(key=self.api_key, output_format="pandas")
 
-    def fetch(self, symbol: str, start: str, end: str) -> pd.DataFrame:
-        data, _ = self.ts.get_daily_adjusted(symbol=symbol, outputsize="full")
+    def fetch(
+        self, symbol: str, start: str, end: str, interval: str = "1d"
+    ) -> pd.DataFrame:
+        if interval in {"1d", "daily"}:
+            data, _ = self.ts.get_daily_adjusted(symbol=symbol, outputsize="full")
+        else:
+            # map common aliases like "1h" -> "60min"
+            mapping = {"1h": "60min"}
+            av_interval = mapping.get(interval, interval)
+            supported = {"1min", "5min", "15min", "30min", "60min"}
+            if av_interval not in supported:
+                raise ValueError(
+                    f"Interval '{interval}' not supported by AlphaVantage"
+                )
+            data, _ = self.ts.get_intraday(
+                symbol=symbol, interval=av_interval, outputsize="full"
+            )
+
         data.index = pd.to_datetime(data.index)
         data = data.loc[start:end]
         data = data.rename(

--- a/quanttradeai/data/loader.py
+++ b/quanttradeai/data/loader.py
@@ -36,6 +36,7 @@ class DataLoader:
         self.symbols = data_cfg.symbols
         self.start_date = data_cfg.start_date
         self.end_date = data_cfg.end_date
+        self.timeframe = data_cfg.timeframe or "1d"
         # allow both legacy 'cache_dir' and new 'cache_path' keys
         self.cache_dir = data_cfg.cache_path or data_cfg.cache_dir or "data/raw"
         self.cache_expiration_days = data_cfg.cache_expiration_days
@@ -55,14 +56,18 @@ class DataLoader:
 
     def _fetch_single(self, symbol: str, refresh: bool) -> Optional[pd.DataFrame]:
         """Fetch data for a single symbol and handle caching."""
-        cache_file = os.path.join(self.cache_dir, f"{symbol}_data.parquet")
+        cache_file = os.path.join(
+            self.cache_dir, f"{symbol}_{self.timeframe}_data.parquet"
+        )
         try:
             if self.use_cache and not refresh and self._is_cache_valid(cache_file):
                 logger.info(f"Loading cached data for {symbol} from {cache_file}")
                 df = pd.read_parquet(cache_file)
             else:
                 logger.info(f"Fetching data for {symbol}")
-                df = self.data_source.fetch(symbol, self.start_date, self.end_date)
+                df = self.data_source.fetch(
+                    symbol, self.start_date, self.end_date, self.timeframe
+                )
 
                 if df is None or df.empty:
                     logger.error(f"No data found for {symbol}")

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -6,6 +6,7 @@ class DataSection(BaseModel):
     symbols: List[str]
     start_date: str
     end_date: str
+    timeframe: Optional[str] = "1d"
     cache_path: Optional[str] = None
     cache_dir: Optional[str] = None
     cache_expiration_days: Optional[int] = None

--- a/tests/data/test_datasource_alpha.py
+++ b/tests/data/test_datasource_alpha.py
@@ -21,6 +21,7 @@ class TestAlphaVantageAdapter(unittest.TestCase):
                 "end_date": "2020-01-10",
                 "cache_path": self.tmpdir,
                 "use_cache": False,
+                "timeframe": "1d",
             }
         }
         with open(self.config_path, "w") as f:
@@ -39,7 +40,7 @@ class TestAlphaVantageAdapter(unittest.TestCase):
         source = AlphaVantageDataSource(api_key="demo")
         loader = DataLoader(self.config_path, data_source=source)
         data = loader.fetch_data(refresh=True)
-        mock_fetch.assert_called_once_with("TEST", "2020-01-01", "2020-01-10")
+        mock_fetch.assert_called_once_with("TEST", "2020-01-01", "2020-01-10", "1d")
         pd.testing.assert_frame_equal(data["TEST"], df)
 
 

--- a/tests/data/test_loader.py
+++ b/tests/data/test_loader.py
@@ -28,7 +28,7 @@ class TestDataLoaderCaching(unittest.TestCase):
             },
             index=pd.date_range("2020-01-01", periods=1),
         )
-        self.df.to_parquet(os.path.join(self.cache_dir, "TEST_data.parquet"))
+        self.df.to_parquet(os.path.join(self.cache_dir, "TEST_1d_data.parquet"))
 
     def _write_config(self, expiration):
         config = {
@@ -37,6 +37,7 @@ class TestDataLoaderCaching(unittest.TestCase):
                 "start_date": "2020-01-01",
                 "end_date": "2020-01-10",
                 "cache_path": self.cache_dir,
+                "timeframe": "1d",
                 "cache_expiration_days": expiration,
                 "use_cache": True,
                 "refresh": False,
@@ -59,7 +60,7 @@ class TestDataLoaderCaching(unittest.TestCase):
     @patch("quanttradeai.data.datasource.YFinanceDataSource.fetch")
     def test_fetch_data_refreshes_cache(self, mock_fetch):
         # remove cached file to force fetch
-        os.remove(os.path.join(self.cache_dir, "TEST_data.parquet"))
+        os.remove(os.path.join(self.cache_dir, "TEST_1d_data.parquet"))
 
         mock_history = pd.DataFrame(
             {"Open": [1], "High": [1], "Low": [1], "Close": [1], "Volume": [1]},
@@ -72,7 +73,7 @@ class TestDataLoaderCaching(unittest.TestCase):
 
         mock_fetch.assert_called_once()
         self.assertTrue(
-            os.path.exists(os.path.join(self.cache_dir, "TEST_data.parquet"))
+            os.path.exists(os.path.join(self.cache_dir, "TEST_1d_data.parquet"))
         )
         pd.testing.assert_frame_equal(data_dict["TEST"], mock_history)
 

--- a/tests/data/test_loader_extra.py
+++ b/tests/data/test_loader_extra.py
@@ -44,7 +44,7 @@ class TestCheckMissingDates(unittest.TestCase):
 class TestIsCacheValid(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
-        self.cache_file = os.path.join(self.tmpdir, "TEST_data.parquet")
+        self.cache_file = os.path.join(self.tmpdir, "TEST_1d_data.parquet")
         df = pd.DataFrame({"a": [1]}, index=pd.date_range("2020-01-01", periods=1))
         df.to_parquet(self.cache_file)
         self.config_path = os.path.join(self.tmpdir, "config.yaml")
@@ -56,6 +56,7 @@ class TestIsCacheValid(unittest.TestCase):
                 "cache_path": self.tmpdir,
                 "cache_expiration_days": 1,
                 "use_cache": True,
+                "timeframe": "1d",
             }
         }
         with open(self.config_path, "w") as f:

--- a/tests/data/test_timeframe.py
+++ b/tests/data/test_timeframe.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest.mock import patch
+import pandas as pd
+import os
+import yaml
+import tempfile
+
+from quanttradeai.data.loader import DataLoader
+
+class TestDataLoaderTimeframe(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.config_path = os.path.join(self.tmpdir, "config.yaml")
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir)
+
+    @patch("quanttradeai.data.datasource.YFinanceDataSource.fetch")
+    def test_custom_timeframe_passed(self, mock_fetch):
+        config = {
+            "data": {
+                "symbols": ["AAA"],
+                "start_date": "2020-01-01",
+                "end_date": "2020-01-02",
+                "cache_path": self.tmpdir,
+                "use_cache": False,
+                "timeframe": "1h",
+            }
+        }
+        with open(self.config_path, "w") as f:
+            yaml.dump(config, f)
+
+        mock_fetch.return_value = pd.DataFrame(
+            {"Open": [1], "High": [1], "Low": [1], "Close": [1], "Volume": [1]},
+            index=pd.date_range("2020-01-01", periods=1, freq="H"),
+        )
+        loader = DataLoader(self.config_path)
+        loader.fetch_data()
+        mock_fetch.assert_called_once_with("AAA", "2020-01-01", "2020-01-02", "1h")
+
+    @patch("quanttradeai.data.datasource.YFinanceDataSource.fetch")
+    def test_default_timeframe(self, mock_fetch):
+        config = {
+            "data": {
+                "symbols": ["AAA"],
+                "start_date": "2020-01-01",
+                "end_date": "2020-01-02",
+                "cache_path": self.tmpdir,
+                "use_cache": False,
+            }
+        }
+        with open(self.config_path, "w") as f:
+            yaml.dump(config, f)
+
+        mock_fetch.return_value = pd.DataFrame(
+            {"Open": [1], "High": [1], "Low": [1], "Close": [1], "Volume": [1]},
+            index=pd.date_range("2020-01-01", periods=1),
+        )
+        loader = DataLoader(self.config_path)
+        loader.fetch_data()
+        mock_fetch.assert_called_once_with("AAA", "2020-01-01", "2020-01-02", "1d")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support custom data intervals in DataSource implementations
- parse `timeframe` from model configuration
- document and demonstrate new parameter
- add tests covering hourly and daily fetches

## Testing
- `pre-commit run --files config/model_config.yaml docs/api/data.md quanttradeai/data/datasource.py quanttradeai/data/loader.py quanttradeai/utils/config_schemas.py tests/data/test_datasource_alpha.py tests/data/test_loader.py tests/data/test_loader_extra.py tests/data/test_timeframe.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_688268e0112c832aac606fc6b9be326a