### PR TITLE
Add transaction cost and slippage support

### DIFF
--- a/tests/backtest/test_backtester.py
+++ b/tests/backtest/test_backtester.py
@@ -23,6 +23,11 @@ class TestBacktester(unittest.TestCase):
         )
         self.assertIn("equity_curve", result.columns)
 
+    def test_simulate_trades_with_costs(self):
+        result = simulate_trades(self.df, transaction_cost=0.01, slippage=0.01)
+        self.assertAlmostEqual(result["strategy_return"].iloc[0], 0.08, places=6)
+        self.assertAlmostEqual(result["equity_curve"].iloc[-1], 0.694785, places=6)
+
     def test_compute_metrics(self):
         result = simulate_trades(self.df)
         metrics = compute_metrics(result)


### PR DESCRIPTION
## Summary
- support transaction cost and slippage in `simulate_trades`
- adjust equity curve calculation for trade costs
- cover new parameters in unit and integration tests

## Testing
- `pre-commit run -a`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841637b8c8832a9cb296ab52d9e5bf