### PR TITLE
Add portfolio manager for multi-symbol backtests

### DIFF
--- a/quanttradeai/backtest/backtester.py
+++ b/quanttradeai/backtest/backtester.py
@@ -2,27 +2,82 @@ import pandas as pd
 
 from quanttradeai.utils.metrics import sharpe_ratio, max_drawdown
 from quanttradeai.trading.risk import apply_stop_loss_take_profit
+from quanttradeai.trading.portfolio import Portfolio
 
 
-def simulate_trades(
-    df: pd.DataFrame,
+def _simulate_portfolio(
+    data: dict[str, pd.DataFrame],
+    portfolio: Portfolio,
     stop_loss_pct: float | None = None,
     take_profit_pct: float | None = None,
     transaction_cost: float = 0.0,
     slippage: float = 0.0,
 ) -> pd.DataFrame:
+    trade_cost = transaction_cost + slippage
+    processed = {}
+    for sym, df in data.items():
+        d = df.copy()
+        if stop_loss_pct is not None or take_profit_pct is not None:
+            d = apply_stop_loss_take_profit(d, stop_loss_pct, take_profit_pct)
+        processed[sym] = d
+
+    length = min(len(df) for df in processed.values())
+    index = list(processed.values())[0].index[:length]
+    equity = []
+    returns = []
+    for i in range(length):
+        prices = {sym: df["Close"].iloc[i] for sym, df in processed.items()}
+        for sym, df in processed.items():
+            signal = df["label"].iloc[i]
+            prev = df["label"].iloc[i - 1] if i > 0 else 0
+            if signal != prev:
+                if prev != 0:
+                    portfolio.close(sym, prices[sym], trade_cost)
+                if signal != 0:
+                    direction = 1 if signal > 0 else -1
+                    portfolio.allocate(
+                        sym, prices[sym], stop_loss_pct or 0.01, direction, trade_cost
+                    )
+        portfolio.update_value(prices)
+        value = portfolio.total_value
+        if i == 0:
+            base = value
+            returns.append(0.0)
+        else:
+            ret = (value - equity[-1]) / equity[-1]
+            returns.append(ret)
+        equity.append(value)
+
+    equity_curve = [v / base for v in equity]
+    return pd.DataFrame(
+        {"strategy_return": returns, "equity_curve": equity_curve}, index=index
+    )
+
+
+def simulate_trades(
+    df: pd.DataFrame | dict[str, pd.DataFrame],
+    stop_loss_pct: float | None = None,
+    take_profit_pct: float | None = None,
+    transaction_cost: float = 0.0,
+    slippage: float = 0.0,
+    portfolio: Portfolio | None = None,
+) -> pd.DataFrame:
     """Simulate trades using label signals.
 
     Parameters
     ----------
-    df : pd.DataFrame
+    df : pd.DataFrame or dict
         DataFrame containing ``Close`` prices and a ``label`` column where
         1 indicates a long position, -1 a short position and 0 no position.
+        If a dictionary is provided, each value should be such a DataFrame and
+        ``portfolio`` must be supplied.
 
     transaction_cost : float, optional
         Fixed cost applied every time a position is opened or closed.
     slippage : float, optional
         Additional cost applied on each trade to model slippage.
+    portfolio : Portfolio, optional
+        Portfolio instance used when backtesting multiple symbols.
 
     Returns
     -------
@@ -30,6 +85,18 @@ def simulate_trades(
         Input DataFrame with additional ``strategy_return`` and
         ``equity_curve`` columns.
     """
+    if isinstance(df, dict):
+        if portfolio is None:
+            raise ValueError("portfolio instance required for multi-symbol data")
+        return _simulate_portfolio(
+            df,
+            portfolio,
+            stop_loss_pct,
+            take_profit_pct,
+            transaction_cost,
+            slippage,
+        )
+
     data = df.copy()
     if stop_loss_pct is not None or take_profit_pct is not None:
         data = apply_stop_loss_take_profit(data, stop_loss_pct, take_profit_pct)

--- a/quanttradeai/trading/portfolio.py
+++ b/quanttradeai/trading/portfolio.py
@@ -1,0 +1,57 @@
+# Portfolio management module
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+from .risk import position_size
+
+
+@dataclass
+class Portfolio:
+    """Simple portfolio manager for backtests."""
+
+    capital: float
+    risk_per_trade: float
+    cash: float | None = None
+    positions: Dict[str, int] = field(default_factory=dict)
+    _value: float | None = None
+
+    def __post_init__(self) -> None:
+        self.cash = self.capital if self.cash is None else self.cash
+        self._value = self.capital if self._value is None else self._value
+
+    @property
+    def total_value(self) -> float:
+        return self._value if self._value is not None else 0.0
+
+    def allocate(
+        self,
+        symbol: str,
+        price: float,
+        stop_loss_pct: float,
+        direction: int = 1,
+        trade_cost: float = 0.0,
+    ) -> int:
+        """Open a new position and return allocated quantity."""
+        qty = position_size(self.total_value, self.risk_per_trade, stop_loss_pct, price)
+        if direction > 0 and qty * price > self.cash:
+            qty = int(self.cash // price)
+        qty *= 1 if direction >= 0 else -1
+        self.cash -= qty * price
+        self.cash -= trade_cost
+        self.positions[symbol] = self.positions.get(symbol, 0) + qty
+        return qty
+
+    def close(self, symbol: str, price: float, trade_cost: float = 0.0) -> int:
+        """Close an existing position and return closed quantity."""
+        qty = self.positions.pop(symbol, 0)
+        self.cash += qty * price
+        self.cash -= trade_cost
+        return qty
+
+    def update_value(self, prices: Dict[str, float]) -> None:
+        holdings = sum(
+            qty * prices.get(sym, 0.0) for sym, qty in self.positions.items()
+        )
+        self._value = self.cash + holdings

--- a/tests/trading/test_portfolio.py
+++ b/tests/trading/test_portfolio.py
@@ -1,0 +1,25 @@
+import unittest
+import pandas as pd
+
+from quanttradeai.trading.portfolio import Portfolio
+from quanttradeai.backtest.backtester import simulate_trades
+
+
+class TestPortfolio(unittest.TestCase):
+    def test_position_size_allocation(self):
+        portfolio = Portfolio(capital=10000, risk_per_trade=0.02)
+        qty = portfolio.allocate("AAPL", price=100, stop_loss_pct=0.05)
+        self.assertEqual(qty, 40)
+        self.assertAlmostEqual(portfolio.cash, 6000)
+
+    def test_multi_symbol_backtest(self):
+        df_a = pd.DataFrame({"Close": [100, 102, 104], "label": [1, 1, 0]})
+        df_b = pd.DataFrame({"Close": [200, 198, 202], "label": [0, -1, 0]})
+        portfolio = Portfolio(capital=10000, risk_per_trade=0.02)
+        result = simulate_trades({"AAA": df_a, "BBB": df_b}, stop_loss_pct=0.05, portfolio=portfolio)
+        self.assertIn("equity_curve", result.columns)
+        self.assertAlmostEqual(result["equity_curve"].iloc[-1], 1.008, places=3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `Portfolio` module to manage allocations and cash
- extend `simulate_trades` to handle a dictionary of symbol data via a portfolio
- test position sizing and multi-symbol portfolio behavior

## Testing
- `pre-commit run --files quanttradeai/trading/portfolio.py quanttradeai/backtest/backtester.py tests/trading/test_portfolio.py tests/trading/test_risk.py`

------
https://chatgpt.com/codex/tasks/task_e_68856c00fa50832aa9017c200d9bb6cb