### PR TITLE
Fix portfolio simulation and stop-loss handling

### DIFF
--- a/docs/api/backtesting.md
+++ b/docs/api/backtesting.md
@@ -4,17 +4,20 @@ API documentation for trade simulation and performance metrics.
 
 ## Trade Simulation
 
-### `simulate_trades(df: pd.DataFrame, stop_loss_pct: float | None = None, take_profit_pct: float | None = None) -> pd.DataFrame`
+### `simulate_trades(df: pd.DataFrame | dict[str, pd.DataFrame], stop_loss_pct: float | None = None, take_profit_pct: float | None = None, transaction_cost: float = 0.0, slippage: float = 0.0, portfolio: PortfolioManager | None = None) -> pd.DataFrame | dict[str, pd.DataFrame]`
 
 Simulates trades using label signals.
 
 **Parameters:**
-- `df` (pd.DataFrame): DataFrame containing Close prices and label column
+- `df` (pd.DataFrame or dict[str, pd.DataFrame]): Single DataFrame or mapping of symbol to DataFrame with Close prices and label column
 - `stop_loss_pct` (float, optional): Stop-loss percentage as decimal
 - `take_profit_pct` (float, optional): Take-profit percentage as decimal
+- `transaction_cost` (float, optional): Fixed transaction fee per trade
+- `slippage` (float, optional): Additional cost per trade to model slippage
+- `portfolio` (PortfolioManager, optional): Portfolio manager required when `df` is a dictionary
 
 **Returns:**
-- `pd.DataFrame`: DataFrame with additional strategy_return and equity_curve columns
+- `pd.DataFrame` or `dict[str, pd.DataFrame]`: Trade results with strategy_return and equity_curve columns. When multiple symbols are provided, a `"portfolio"` key contains the aggregated results.
 
 **Example:**
 ```python

--- a/docs/api/trading.md
+++ b/docs/api/trading.md
@@ -52,6 +52,27 @@ qty = position_size(capital=10000, risk_per_trade=0.02, stop_loss_pct=0.05, pric
 print(f"Position size: {qty} shares")
 ```
 
+### `PortfolioManager(capital: float, max_risk_per_trade: float = 0.02, max_portfolio_risk: float = 0.1)`
+
+Manages capital allocation and risk across multiple symbols.
+
+**Parameters:**
+- `capital` (float): Initial portfolio capital
+- `max_risk_per_trade` (float, optional): Risk per trade as a fraction of portfolio value
+- `max_portfolio_risk` (float, optional): Maximum overall portfolio risk exposure
+
+**Example:**
+```python
+from quanttradeai.trading.portfolio import PortfolioManager
+
+# Create portfolio manager with $10,000 starting capital
+pm = PortfolioManager(10000, max_risk_per_trade=0.02, max_portfolio_risk=0.10)
+
+# Open a position without a stop loss
+qty = pm.open_position("AAPL", price=150)
+print(f"AAPL position: {qty} shares")
+```
+
 ## Risk Management Workflows
 
 ### Basic Risk Management
@@ -88,28 +109,17 @@ for capital, risk, sl, price in scenarios:
 
 ### Portfolio Risk Management
 ```python
-from quanttradeai.trading.risk import apply_stop_loss_take_profit, position_size
+from quanttradeai.trading.portfolio import PortfolioManager
 
-# Manage risk across multiple positions
-portfolio = {
-    'AAPL': {'price': 150.0, 'signal': 1},
-    'TSLA': {'price': 250.0, 'signal': 1},
-    'META': {'price': 300.0, 'signal': -1}
-}
+# Manage risk across multiple positions using PortfolioManager
+pm = PortfolioManager(50000, max_risk_per_trade=0.02, max_portfolio_risk=0.10)
 
-total_capital = 50000
-max_risk_per_position = 0.02
+# Open positions
+pm.open_position('AAPL', price=150.0, stop_loss_pct=0.05)
+pm.open_position('TSLA', price=250.0, stop_loss_pct=0.05)
+pm.open_position('META', price=300.0, stop_loss_pct=0.05)
 
-for symbol, data in portfolio.items():
-    if data['signal'] != 0:
-        # Calculate position size
-        qty = position_size(
-            capital=total_capital * 0.1,  # 10% per position
-            risk_per_trade=max_risk_per_position,
-            stop_loss_pct=0.05,
-            price=data['price']
-        )
-        print(f"{symbol}: {qty} shares at ${data['price']}")
+print(f"Current exposure: {pm.risk_exposure:.2%}")
 ```
 
 ## Risk Analysis

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -96,6 +96,16 @@ df_with_risk = apply_stop_loss_take_profit(df, stop_loss_pct=0.02, take_profit_p
 qty = position_size(capital=10000, risk_per_trade=0.02, stop_loss_pct=0.05, price=150.0)
 ```
 
+```python
+from quanttradeai.trading.portfolio import PortfolioManager
+
+# Allocate capital across multiple symbols
+pm = PortfolioManager(10000)
+pm.open_position('AAPL', price=150, stop_loss_pct=0.05)
+pm.open_position('TSLA', price=250, stop_loss_pct=0.05)
+print(f"Portfolio exposure: {pm.risk_exposure:.2%}")
+```
+
 ## 📈 Performance Metrics
 
 ```python

--- a/quanttradeai/trading/portfolio.py
+++ b/quanttradeai/trading/portfolio.py
@@ -1,0 +1,82 @@
+"""Simple portfolio management utilities."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .risk import position_size
+
+
+class PortfolioManager:
+    """Manage capital allocation and risk across multiple symbols."""
+
+    def __init__(
+        self,
+        capital: float,
+        max_risk_per_trade: float = 0.02,
+        max_portfolio_risk: float = 0.1,
+    ) -> None:
+        self.initial_capital = capital
+        self.cash = capital
+        self.max_risk_per_trade = max_risk_per_trade
+        self.max_portfolio_risk = max_portfolio_risk
+        self.positions: Dict[str, dict] = {}
+
+    @property
+    def portfolio_value(self) -> float:
+        return self.cash + sum(p["qty"] * p["price"] for p in self.positions.values())
+
+    @property
+    def risk_exposure(self) -> float:
+        if self.portfolio_value == 0:
+            return 0.0
+        exposure = sum(
+            p["qty"] * p["price"] * p["stop_loss_pct"] for p in self.positions.values()
+        )
+        return exposure / self.portfolio_value
+
+    def _remaining_risk_capacity(self) -> float:
+        return self.max_portfolio_risk * self.portfolio_value - sum(
+            p["qty"] * p["price"] * p["stop_loss_pct"] for p in self.positions.values()
+        )
+
+    def open_position(
+        self, symbol: str, price: float, stop_loss_pct: float | None = None
+    ) -> int:
+        """Open a new position and return the quantity allocated."""
+        if symbol in self.positions:
+            raise ValueError(f"Position for {symbol} already exists")
+
+        if stop_loss_pct is None or stop_loss_pct <= 0:
+            qty = int(self.max_risk_per_trade * self.portfolio_value / price)
+            stop_loss = 0.0
+        else:
+            qty = position_size(
+                capital=self.portfolio_value,
+                risk_per_trade=self.max_risk_per_trade,
+                stop_loss_pct=stop_loss_pct,
+                price=price,
+            )
+            allowed_qty = int(self._remaining_risk_capacity() / (price * stop_loss_pct))
+            qty = min(qty, allowed_qty)
+            stop_loss = stop_loss_pct
+
+        qty = min(qty, int(self.cash // price))
+        if qty <= 0:
+            return 0
+
+        self.cash -= qty * price
+        self.positions[symbol] = {
+            "qty": qty,
+            "price": price,
+            "stop_loss_pct": stop_loss,
+        }
+        return qty
+
+    def close_position(self, symbol: str, price: float) -> int:
+        """Close an existing position and return quantity closed."""
+        pos = self.positions.pop(symbol, None)
+        if pos is None:
+            return 0
+        self.cash += pos["qty"] * price
+        return pos["qty"]

--- a/tests/trading/test_portfolio.py
+++ b/tests/trading/test_portfolio.py
@@ -1,0 +1,41 @@
+import unittest
+import pandas as pd
+
+from quanttradeai.trading.portfolio import PortfolioManager
+from quanttradeai.trading.risk import position_size
+from quanttradeai.backtest.backtester import simulate_trades
+
+
+class TestPortfolioManager(unittest.TestCase):
+    def test_position_size_used(self):
+        pm = PortfolioManager(10000, max_risk_per_trade=0.02, max_portfolio_risk=0.1)
+        qty = pm.open_position("AAPL", price=100, stop_loss_pct=0.05)
+        self.assertEqual(qty, position_size(10000, 0.02, 0.05, 100))
+        self.assertAlmostEqual(pm.risk_exposure, qty * 100 * 0.05 / pm.portfolio_value)
+
+    def test_portfolio_risk_cap(self):
+        pm = PortfolioManager(10000, max_risk_per_trade=0.04, max_portfolio_risk=0.05)
+        pm.open_position("AAPL", 100, 0.05)
+        qty = pm.open_position("TSLA", 200, 0.05)
+        self.assertLessEqual(pm.risk_exposure, 0.05 + 1e-6)
+        self.assertGreaterEqual(qty, 0)
+
+    def test_open_position_without_stop_loss(self):
+        pm = PortfolioManager(10000, max_risk_per_trade=0.02)
+        qty = pm.open_position("AAPL", price=50, stop_loss_pct=None)
+        expected_qty = int(pm.max_risk_per_trade * pm.initial_capital / 50)
+        self.assertEqual(qty, expected_qty)
+        self.assertEqual(pm.positions["AAPL"]["stop_loss_pct"], 0.0)
+        self.assertEqual(pm.risk_exposure, 0.0)
+
+    def test_multi_symbol_simulation(self):
+        df1 = pd.DataFrame({"Close": [100, 101, 102], "label": [1, 0, 0]})
+        df2 = pd.DataFrame({"Close": [50, 49, 48], "label": [-1, 0, 0]})
+        pm = PortfolioManager(10000)
+        res = simulate_trades({"s1": df1, "s2": df2}, portfolio=pm, stop_loss_pct=0.05)
+        self.assertIn("portfolio", res)
+        self.assertIn("equity_curve", res["portfolio"].columns)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove forced 1% stop loss in portfolio manager
- support opening positions without stop loss
- update multi-symbol simulation weight calculation
- expand tests for portfolio open_position behavior
- document PortfolioManager and new simulate_trades parameters

## Testing
- `pre-commit run --files quanttradeai/backtest/backtester.py docs/api/backtesting.md docs/api/trading.md docs/quick-reference.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856c00fa50832aa9017c200d9bb6cb