### PR TITLE
Add WebSocket streaming support

### DIFF
--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -86,6 +86,31 @@ loader.save_data(data_dict)
 loader.save_data(data_dict, "data/custom_cache")
 ```
 
+### `stream_data(processor, symbols: Optional[List[str]] = None, callback=None)`
+
+Streams real-time data from a `WebSocketDataSource` and processes each update.
+
+**Parameters:**
+- `processor` (DataProcessor): Processor instance used to transform incoming data
+- `symbols` (List[str], optional): Symbols to subscribe to. Defaults to configured symbols
+- `callback` (Callable, optional): Optional function or coroutine invoked with each processed batch
+
+**Example:**
+```python
+from quanttradeai.data.loader import DataLoader
+from quanttradeai.data.processor import DataProcessor
+from quanttradeai.data.datasource import WebSocketDataSource
+
+loader = DataLoader(data_source=WebSocketDataSource("wss://example"))
+processor = DataProcessor()
+
+# Print each processed update
+async def handle_update(df):
+    print(df)
+
+await loader.stream_data(processor, callback=handle_update)
+```
+
 ## DataSource Classes
 
 ### `DataSource` (Abstract Base Class)
@@ -123,6 +148,24 @@ data_source = AlphaVantageDataSource("YOUR_API_KEY")
 
 # Fetch hourly data
 df = data_source.fetch("AAPL", "2023-01-01", "2023-12-31", interval="1h")
+```
+
+### `WebSocketDataSource(url: str)`
+
+Asynchronous data source for streaming market data over WebSocket.
+
+**Parameters:**
+- `url` (str): WebSocket endpoint provided by the data vendor
+
+**Example:**
+```python
+from quanttradeai.data.datasource import WebSocketDataSource
+
+ws_source = WebSocketDataSource("wss://example")
+await ws_source.connect()
+await ws_source.subscribe(["AAPL"])
+async for msg in ws_source.stream():
+    print(msg)
 ```
 
 ## DataProcessor Class

--- a/tests/integration/test_websocket_stream.py
+++ b/tests/integration/test_websocket_stream.py
@@ -1,0 +1,60 @@
+import asyncio
+import json
+import tempfile
+import yaml
+import pandas as pd
+from unittest.mock import patch
+import pytest
+
+from quanttradeai.data.loader import DataLoader
+from quanttradeai.data.datasource import WebSocketDataSource
+from quanttradeai.data.processor import DataProcessor
+
+
+class FakeConnection:
+    def __init__(self, messages):
+        self._messages = list(messages)
+        self.sent = []
+
+    async def send(self, msg):
+        self.sent.append(msg)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._messages:
+            raise StopAsyncIteration
+        return self._messages.pop(0)
+
+    async def close(self):
+        pass
+
+
+async def fake_connect(_):
+    return FakeConnection([])
+
+
+@patch("websockets.connect", new=lambda url: fake_connect(url))
+def test_streaming_dispatch():
+    msg = json.dumps({"symbol": "TEST", "Open": 1, "High": 1, "Low": 1, "Close": 1, "Volume": 1})
+
+    async def connect(_):
+        return FakeConnection([msg])
+
+    async def run_test():
+        with patch("websockets.connect", new=connect):
+            cfg = {"data": {"symbols": ["TEST"], "start_date": "2020-01-01", "end_date": "2020-01-01"}}
+            with tempfile.NamedTemporaryFile("w+") as f:
+                yaml.dump(cfg, f)
+                f.flush()
+                processor = DataProcessor()
+                processor.process_data = lambda df: df  # type: ignore
+                loader = DataLoader(f.name, data_source=WebSocketDataSource("ws://test"))
+                out = []
+                await loader.stream_data(processor, callback=lambda df: out.append(df))
+                assert len(out) == 1
+                pd.testing.assert_frame_equal(out[0], pd.DataFrame([json.loads(msg)]))
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- implement `WebSocketDataSource` for streaming APIs
- extend `DataLoader` with async `stream_data`
- add live trading CLI command
- provide integration test using mocked WebSocket data
- document WebSocket streaming components

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68897ed877c4832a944ce2ada623116b