### PR TITLE
Improve QuantTradeAI documentation and public API

### DIFF
--- a/quanttradeai/__init__.py
+++ b/quanttradeai/__init__.py
@@ -1,0 +1,53 @@
+"""QuantTradeAI
+=================
+
+High-level interface for the QuantTradeAI toolkit.  The package bundles
+data acquisition, feature engineering, model training and backtesting
+utilities for quantitative trading research.
+
+Public API:
+    - ``DataSource`` and concrete implementations
+    - ``DataLoader`` and ``DataProcessor``
+    - ``MomentumClassifier`` model
+    - ``PortfolioManager`` and risk helpers
+    - ``simulate_trades`` and ``compute_metrics`` for backtesting
+
+Quick Start:
+    ```python
+    from quanttradeai import DataLoader, DataProcessor, MomentumClassifier
+
+    loader = DataLoader()
+    data = loader.fetch_data()
+    processor = DataProcessor()
+    processed = {s: processor.process_data(df) for s, df in data.items()}
+    model = MomentumClassifier()
+    ```
+"""
+
+from .data.datasource import (
+    DataSource,
+    YFinanceDataSource,
+    AlphaVantageDataSource,
+    WebSocketDataSource,
+)
+from .data.loader import DataLoader
+from .data.processor import DataProcessor
+from .models.classifier import MomentumClassifier
+from .trading.portfolio import PortfolioManager
+from .trading.risk import apply_stop_loss_take_profit, position_size
+from .backtest.backtester import simulate_trades, compute_metrics
+
+__all__ = [
+    "DataSource",
+    "YFinanceDataSource",
+    "AlphaVantageDataSource",
+    "WebSocketDataSource",
+    "DataLoader",
+    "DataProcessor",
+    "MomentumClassifier",
+    "PortfolioManager",
+    "apply_stop_loss_take_profit",
+    "position_size",
+    "simulate_trades",
+    "compute_metrics",
+]

--- a/quanttradeai/backtest/__init__.py
+++ b/quanttradeai/backtest/__init__.py
@@ -1,0 +1,19 @@
+"""Backtesting utilities.
+
+This package contains helpers for simulating trades and evaluating
+strategy performance.
+
+Public API:
+    - :func:`simulate_trades`
+    - :func:`compute_metrics`
+
+Quick Start:
+    ```python
+    from quanttradeai.backtest import simulate_trades
+    results = simulate_trades(dataframe)
+    ```
+"""
+
+from .backtester import simulate_trades, compute_metrics
+
+__all__ = ["simulate_trades", "compute_metrics"]

--- a/quanttradeai/backtest/backtester.py
+++ b/quanttradeai/backtest/backtester.py
@@ -1,3 +1,22 @@
+"""Backtester: vectorised trade simulation utilities.
+
+This module implements simple helpers for running trading strategy
+simulations based on pre-generated labels and for calculating basic
+performance statistics.
+
+Key Components:
+    - :func:`simulate_trades`: run a labelled backtest for one or more symbols
+    - :func:`compute_metrics`: derive Sharpe ratio and drawdown statistics
+
+Typical Usage:
+    ```python
+    from quanttradeai.backtest import simulate_trades, compute_metrics
+
+    results = simulate_trades(df)
+    metrics = compute_metrics(results)
+    ```
+"""
+
 import pandas as pd
 
 from quanttradeai.utils.metrics import sharpe_ratio, max_drawdown

--- a/quanttradeai/data/__init__.py
+++ b/quanttradeai/data/__init__.py
@@ -1,0 +1,35 @@
+"""Data acquisition and preparation.
+
+Provides utilities to download market data and transform it into model
+ready datasets.
+
+Public API:
+    - :class:`DataLoader`
+    - :class:`DataProcessor`
+    - :class:`DataSource` implementations
+
+Quick Start:
+    ```python
+    from quanttradeai.data import DataLoader
+    loader = DataLoader()
+    data = loader.fetch_data()
+    ```
+"""
+
+from .loader import DataLoader
+from .processor import DataProcessor
+from .datasource import (
+    DataSource,
+    YFinanceDataSource,
+    AlphaVantageDataSource,
+    WebSocketDataSource,
+)
+
+__all__ = [
+    "DataLoader",
+    "DataProcessor",
+    "DataSource",
+    "YFinanceDataSource",
+    "AlphaVantageDataSource",
+    "WebSocketDataSource",
+]

--- a/quanttradeai/data/datasource.py
+++ b/quanttradeai/data/datasource.py
@@ -1,3 +1,24 @@
+"""Market data sources.
+
+This module defines the :class:`DataSource` interface along with concrete
+implementations for Yahoo! Finance, Alpha Vantage and generic WebSocket
+feeds.
+
+Key Components:
+    - :class:`DataSource`: abstract base for all data providers
+    - :class:`YFinanceDataSource`: wrapper around ``yfinance``
+    - :class:`AlphaVantageDataSource`: uses the Alpha Vantage REST API
+    - :class:`WebSocketDataSource`: asynchronous streaming interface
+
+Typical Usage:
+    ```python
+    from quanttradeai.data import YFinanceDataSource
+
+    source = YFinanceDataSource()
+    df = source.fetch("AAPL", "2024-01-01", "2024-06-01")
+    ```
+"""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/quanttradeai/data/loader.py
+++ b/quanttradeai/data/loader.py
@@ -1,3 +1,19 @@
+"""Historical market data loader.
+
+The :class:`DataLoader` class retrieves, validates and caches OHLCV data
+from a configurable :class:`~quanttradeai.data.datasource.DataSource`.
+
+Key Components:
+    - :class:`DataLoader`: orchestrates data downloading and caching
+
+Typical Usage:
+    ```python
+    from quanttradeai.data import DataLoader
+    loader = DataLoader("config/model_config.yaml")
+    frames = loader.fetch_data()
+    ```
+"""
+
 import pandas as pd
 from typing import List, Dict, Optional
 import logging

--- a/quanttradeai/data/processor.py
+++ b/quanttradeai/data/processor.py
@@ -1,3 +1,20 @@
+"""Data processing and feature engineering.
+
+The :class:`DataProcessor` transforms raw OHLCV data into a rich feature
+set used by models.  It supports a configurable pipeline described in a
+YAML file.
+
+Key Components:
+    - :class:`DataProcessor`: main entry point for feature generation
+
+Typical Usage:
+    ```python
+    from quanttradeai.data import DataProcessor
+    processor = DataProcessor()
+    features = processor.process_data(df)
+    ```
+"""
+
 import pandas as pd
 import numpy as np
 

--- a/quanttradeai/features/__init__.py
+++ b/quanttradeai/features/__init__.py
@@ -1,6 +1,19 @@
-"""Feature engineering modules."""
+"""Feature engineering.
 
-from . import technical
-from . import custom
+Collection of technical and custom indicator helpers used to generate
+model features.
+
+Public API:
+    - :mod:`technical`
+    - :mod:`custom`
+
+Quick Start:
+    ```python
+    from quanttradeai.features import technical as ta
+    ta.sma(close, 20)
+    ```
+"""
+
+from . import technical, custom
 
 __all__ = ["technical", "custom"]

--- a/quanttradeai/features/custom.py
+++ b/quanttradeai/features/custom.py
@@ -1,3 +1,19 @@
+"""Custom feature engineering helpers.
+
+Provides bespoke indicator calculations that supplement the technical
+analysis functions available in :mod:`quanttradeai.features.technical`.
+
+Key Components:
+    - :func:`momentum_score`: combine multiple indicators into a score
+    - :func:`volatility_breakout`: flag volatility based breakout days
+
+Typical Usage:
+    ```python
+    from quanttradeai.features import custom
+    score = custom.momentum_score(close, sma, rsi, macd, signal)
+    ```
+"""
+
 import pandas as pd
 
 

--- a/quanttradeai/features/technical.py
+++ b/quanttradeai/features/technical.py
@@ -1,3 +1,22 @@
+"""Technical indicator wrappers.
+
+Thin wrappers around ``pandas-ta`` functions used by the project.  These
+helpers provide a consistent namespace for commonly used indicators.
+
+Key Components:
+    - :func:`sma`
+    - :func:`ema`
+    - :func:`rsi`
+    - :func:`macd`
+    - :func:`stochastic`
+
+Typical Usage:
+    ```python
+    from quanttradeai.features import technical as ta
+    sma_fast = ta.sma(close, 20)
+    ```
+"""
+
 import pandas as pd
 import pandas_ta as ta
 

--- a/quanttradeai/main.py
+++ b/quanttradeai/main.py
@@ -3,6 +3,12 @@ import warnings
 # Suppress pandas_ta pkg_resources deprecation warning
 warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
 
+"""Command line interface entry points.
+
+Provides convenience functions and CLI commands to run the end-to-end
+pipeline, fetch data or evaluate models.
+"""
+
 import logging
 from pathlib import Path
 from quanttradeai.data.loader import DataLoader

--- a/quanttradeai/models/__init__.py
+++ b/quanttradeai/models/__init__.py
@@ -1,0 +1,18 @@
+"""Model implementations.
+
+This package currently provides the :class:`MomentumClassifier` ensemble
+for generating trading labels.
+
+Public API:
+    - :class:`MomentumClassifier`
+
+Quick Start:
+    ```python
+    from quanttradeai.models import MomentumClassifier
+    model = MomentumClassifier()
+    ```
+"""
+
+from .classifier import MomentumClassifier
+
+__all__ = ["MomentumClassifier"]

--- a/quanttradeai/models/classifier.py
+++ b/quanttradeai/models/classifier.py
@@ -1,3 +1,21 @@
+"""Machine learning models for trading signals.
+
+Currently the package offers a single :class:`MomentumClassifier` which
+combines several algorithms into a voting ensemble.
+
+Key Components:
+    - :class:`MomentumClassifier`: orchestrates training and evaluation
+
+Typical Usage:
+    ```python
+    from quanttradeai.models import MomentumClassifier
+    model = MomentumClassifier()
+    X, y = model.prepare_data(df)
+    model.train(X, y)
+    predictions = model.predict(X)
+    ```
+"""
+
 import pandas as pd
 import numpy as np
 from typing import Dict, Tuple, Any

--- a/quanttradeai/trading/__init__.py
+++ b/quanttradeai/trading/__init__.py
@@ -1,0 +1,20 @@
+"""Trading utilities.
+
+Expose portfolio management and risk helper functions.
+
+Public API:
+    - :class:`PortfolioManager`
+    - :func:`apply_stop_loss_take_profit`
+    - :func:`position_size`
+
+Quick Start:
+    ```python
+    from quanttradeai.trading import PortfolioManager
+    pm = PortfolioManager(100000)
+    ```
+"""
+
+from .portfolio import PortfolioManager
+from .risk import apply_stop_loss_take_profit, position_size
+
+__all__ = ["PortfolioManager", "apply_stop_loss_take_profit", "position_size"]

--- a/quanttradeai/trading/portfolio.py
+++ b/quanttradeai/trading/portfolio.py
@@ -1,4 +1,18 @@
-"""Simple portfolio management utilities."""
+"""Portfolio management helpers.
+
+Provides the :class:`PortfolioManager` class which tracks cash, positions
+and risk exposure for multiple symbols.
+
+Key Components:
+    - :class:`PortfolioManager`
+
+Typical Usage:
+    ```python
+    from quanttradeai.trading import PortfolioManager
+    pm = PortfolioManager(capital=100000)
+    qty = pm.open_position("AAPL", price=150, stop_loss_pct=0.02)
+    ```
+"""
 
 from __future__ import annotations
 

--- a/quanttradeai/trading/risk.py
+++ b/quanttradeai/trading/risk.py
@@ -1,3 +1,19 @@
+"""Risk management utilities.
+
+Contains helpers for applying stop-loss / take-profit rules and
+calculating position sizes.
+
+Key Components:
+    - :func:`apply_stop_loss_take_profit`
+    - :func:`position_size`
+
+Typical Usage:
+    ```python
+    from quanttradeai.trading import apply_stop_loss_take_profit
+    df = apply_stop_loss_take_profit(df, 0.02, 0.04)
+    ```
+"""
+
 import pandas as pd
 
 

--- a/quanttradeai/utils/__init__.py
+++ b/quanttradeai/utils/__init__.py
@@ -1,6 +1,12 @@
-"""Utility modules for metrics and visualization."""
+"""Miscellaneous utilities.
 
-from . import metrics
-from . import visualization
+Expose common metrics and visualization helpers used across the project.
+
+Public API:
+    - :mod:`metrics`
+    - :mod:`visualization`
+"""
+
+from . import metrics, visualization
 
 __all__ = ["metrics", "visualization"]

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -1,3 +1,14 @@
+"""Pydantic configuration schemas.
+
+Defines validation models for data and feature configuration files used
+throughout the project.
+
+Key Components:
+    - :class:`DataSection`
+    - :class:`ModelConfigSchema`
+    - :class:`FeaturesConfigSchema`
+"""
+
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel
 

--- a/quanttradeai/utils/metrics.py
+++ b/quanttradeai/utils/metrics.py
@@ -1,3 +1,14 @@
+"""Metric helper functions.
+
+Convenience wrappers around common evaluation metrics used by the
+framework.
+
+Key Components:
+    - :func:`classification_metrics`
+    - :func:`sharpe_ratio`
+    - :func:`max_drawdown`
+"""
+
 import numpy as np
 import pandas as pd
 from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score

--- a/quanttradeai/utils/visualization.py
+++ b/quanttradeai/utils/visualization.py
@@ -1,3 +1,13 @@
+"""Visualization helpers.
+
+Simple plotting utilities for exploratory analysis of price series and
+strategy performance.
+
+Key Components:
+    - :func:`plot_price`
+    - :func:`plot_performance`
+"""
+
 import matplotlib.pyplot as plt
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- add detailed module and package docstrings throughout the project
- expose core classes and functions via `__init__` files for clearer imports
- document backtesting, data loading, trading, and utility components

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pre-commit run --files quanttradeai/__init__.py quanttradeai/backtest/__init__.py quanttradeai/backtest/backtester.py quanttradeai/data/__init__.py quanttradeai/data/datasource.py quanttradeai/data/loader.py quanttradeai/data/processor.py quanttradeai/features/__init__.py quanttradeai/features/custom.py quanttradeai/features/technical.py quanttradeai/main.py quanttradeai/models/__init__.py quanttradeai/models/classifier.py quanttradeai/trading/__init__.py quanttradeai/trading/portfolio.py quanttradeai/trading/risk.py quanttradeai/utils/__init__.py quanttradeai/utils/config_schemas.py quanttradeai/utils/metrics.py quanttradeai/utils/visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_688e96abe078832ab86b37d11d43c2e8