### PR TITLE
docs: sync imports with new API

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -72,8 +72,7 @@ make test     # pytest testing
 
 ### Data Loading
 ```python
-from quanttradeai.data.loader import DataLoader
-from quanttradeai.data.processor import DataProcessor
+from quanttradeai import DataLoader, DataProcessor
 
 # Initialize components
 loader = DataLoader("config/model_config.yaml")
@@ -87,7 +86,7 @@ df_labeled = processor.generate_labels(df_processed)
 
 ### Model Training
 ```python
-from quanttradeai.models.classifier import MomentumClassifier
+from quanttradeai import MomentumClassifier
 
 # Initialize and train
 classifier = MomentumClassifier("config/model_config.yaml")
@@ -97,7 +96,7 @@ classifier.train(X, y)
 
 ### Backtesting
 ```python
-from quanttradeai.backtest.backtester import simulate_trades, compute_metrics
+from quanttradeai import simulate_trades, compute_metrics
 
 # Simulate trades
 df_trades = simulate_trades(df_labeled)
@@ -203,17 +202,17 @@ def test_complete_pipeline():
 
 ### Feature Engineering
 ```python
-from quanttradeai.features.technical import sma, ema, rsi, macd
+from quanttradeai.features import technical as ta
 
 # Generate technical indicators
-df['sma_20'] = sma(df['Close'], 20)
-df['rsi'] = rsi(df['Close'], 14)
-macd_df = macd(df['Close'])
+df['sma_20'] = ta.sma(df['Close'], 20)
+df['rsi'] = ta.rsi(df['Close'], 14)
+macd_df = ta.macd(df['Close'])
 ```
 
 ### Risk Management
 ```python
-from quanttradeai.trading.risk import apply_stop_loss_take_profit
+from quanttradeai import apply_stop_loss_take_profit
 
 # Apply risk rules
 df_with_risk = apply_stop_loss_take_profit(df, stop_loss_pct=0.02)

--- a/README.md
+++ b/README.md
@@ -111,9 +111,7 @@ poetry run quanttradeai evaluate -m models/trained/AAPL
 ### Python API
 
 ```python
-from quanttradeai.data.loader import DataLoader
-from quanttradeai.data.processor import DataProcessor
-from quanttradeai.models.classifier import MomentumClassifier
+from quanttradeai import DataLoader, DataProcessor, MomentumClassifier
 
 # Initialize components
 loader = DataLoader("config/model_config.yaml")

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -32,9 +32,7 @@ Complete API documentation for QuantTradeAI.
 
 ### Basic Workflow
 ```python
-from quanttradeai.data.loader import DataLoader
-from quanttradeai.data.processor import DataProcessor
-from quanttradeai.models.classifier import MomentumClassifier
+from quanttradeai import DataLoader, DataProcessor, MomentumClassifier
 
 # Initialize components
 loader = DataLoader("config/model_config.yaml")
@@ -54,8 +52,7 @@ classifier.train(X, y)
 
 ### Advanced Usage
 ```python
-from quanttradeai.backtest.backtester import simulate_trades, compute_metrics
-from quanttradeai.trading.risk import apply_stop_loss_take_profit
+from quanttradeai import simulate_trades, compute_metrics, apply_stop_loss_take_profit
 
 # Backtest with risk management
 df_with_risk = apply_stop_loss_take_profit(df_labeled, stop_loss_pct=0.02)

--- a/docs/api/backtesting.md
+++ b/docs/api/backtesting.md
@@ -21,7 +21,7 @@ Simulates trades using label signals.
 
 **Example:**
 ```python
-from quanttradeai.backtest.backtester import simulate_trades
+from quanttradeai import simulate_trades
 
 # Simulate trades with stop-loss and take-profit
 df_with_trades = simulate_trades(df, stop_loss_pct=0.02, take_profit_pct=0.04)
@@ -43,7 +43,7 @@ Calculates basic performance metrics for a strategy.
 
 **Example:**
 ```python
-from quanttradeai.backtest.backtester import compute_metrics
+from quanttradeai import compute_metrics
 
 # Calculate performance metrics
 metrics = compute_metrics(df_with_trades, risk_free_rate=0.02)
@@ -56,7 +56,7 @@ print(f"Max Drawdown: {metrics['max_drawdown']:.4f}")
 
 ### Basic Backtesting
 ```python
-from quanttradeai.backtest.backtester import simulate_trades, compute_metrics
+from quanttradeai import simulate_trades, compute_metrics
 
 # Simulate trades
 df_trades = simulate_trades(df_labeled)
@@ -71,8 +71,7 @@ print(f"Max Drawdown: {metrics['max_drawdown']:.2%}")
 
 ### Backtesting with Risk Management
 ```python
-from quanttradeai.backtest.backtester import simulate_trades, compute_metrics
-from quanttradeai.trading.risk import apply_stop_loss_take_profit
+from quanttradeai import simulate_trades, compute_metrics, apply_stop_loss_take_profit
 
 # Apply risk management rules
 df_with_risk = apply_stop_loss_take_profit(
@@ -94,7 +93,7 @@ print(f"Max Drawdown: {metrics['max_drawdown']:.2%}")
 
 ### Multi-Asset Backtesting
 ```python
-from quanttradeai.backtest.backtester import simulate_trades, compute_metrics
+from quanttradeai import simulate_trades, compute_metrics
 
 # Backtest multiple assets
 results = {}
@@ -169,7 +168,7 @@ print(f"Average Loss: {losing_trades['strategy_return'].mean():.2%}")
 
 ### Stop-Loss and Take-Profit
 ```python
-from quanttradeai.trading.risk import apply_stop_loss_take_profit
+from quanttradeai import apply_stop_loss_take_profit
 
 # Apply different risk management scenarios
 scenarios = [

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -15,7 +15,7 @@ Handles data fetching, caching, and validation for multiple financial instrument
 
 **Example:**
 ```python
-from quanttradeai.data.loader import DataLoader
+from quanttradeai import DataLoader
 
 # Initialize with default configuration (daily timeframe)
 loader = DataLoader("config/model_config.yaml")
@@ -97,9 +97,7 @@ Streams real-time data from a `WebSocketDataSource` and processes each update.
 
 **Example:**
 ```python
-from quanttradeai.data.loader import DataLoader
-from quanttradeai.data.processor import DataProcessor
-from quanttradeai.data.datasource import WebSocketDataSource
+from quanttradeai import DataLoader, DataProcessor, WebSocketDataSource
 
 loader = DataLoader(data_source=WebSocketDataSource("wss://example"))
 processor = DataProcessor()
@@ -123,7 +121,7 @@ DataSource implementation using the yfinance package.
 
 **Example:**
 ```python
-from quanttradeai.data.datasource import YFinanceDataSource
+from quanttradeai import YFinanceDataSource
 
 # Initialize YFinance data source
 data_source = YFinanceDataSource()
@@ -141,7 +139,7 @@ DataSource implementation for AlphaVantage API.
 
 **Example:**
 ```python
-from quanttradeai.data.datasource import AlphaVantageDataSource
+from quanttradeai import AlphaVantageDataSource
 
 # Initialize with API key
 data_source = AlphaVantageDataSource("YOUR_API_KEY")
@@ -159,7 +157,7 @@ Asynchronous data source for streaming market data over WebSocket.
 
 **Example:**
 ```python
-from quanttradeai.data.datasource import WebSocketDataSource
+from quanttradeai import WebSocketDataSource
 
 ws_source = WebSocketDataSource("wss://example")
 await ws_source.connect()
@@ -179,7 +177,7 @@ Processes raw OHLCV data and generates required features for the trading strateg
 
 **Example:**
 ```python
-from quanttradeai.data.processor import DataProcessor
+from quanttradeai import DataProcessor
 
 # Initialize processor
 processor = DataProcessor("config/features_config.yaml")

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -13,7 +13,7 @@ Voting Classifier for momentum trading strategy using Logistic Regression, Rando
 
 **Example:**
 ```python
-from quanttradeai.models.classifier import MomentumClassifier
+from quanttradeai import MomentumClassifier
 
 # Initialize classifier
 classifier = MomentumClassifier("config/model_config.yaml")
@@ -178,7 +178,7 @@ xgb_params = {
 
 ### Complete Training Example
 ```python
-from quanttradeai.models.classifier import MomentumClassifier
+from quanttradeai import MomentumClassifier
 from sklearn.model_selection import train_test_split
 
 # Initialize classifier

--- a/docs/api/trading.md
+++ b/docs/api/trading.md
@@ -18,7 +18,7 @@ Applies stop-loss and take-profit rules to trading signals.
 
 **Example:**
 ```python
-from quanttradeai.trading.risk import apply_stop_loss_take_profit
+from quanttradeai import apply_stop_loss_take_profit
 
 # Apply 2% stop-loss and 4% take-profit
 df_with_risk = apply_stop_loss_take_profit(df, stop_loss_pct=0.02, take_profit_pct=0.04)
@@ -45,7 +45,7 @@ Calculates position size based on account risk parameters.
 
 **Example:**
 ```python
-from quanttradeai.trading.risk import position_size
+from quanttradeai import position_size
 
 # Calculate position size
 qty = position_size(capital=10000, risk_per_trade=0.02, stop_loss_pct=0.05, price=150.0)
@@ -63,7 +63,7 @@ Manages capital allocation and risk across multiple symbols.
 
 **Example:**
 ```python
-from quanttradeai.trading.portfolio import PortfolioManager
+from quanttradeai import PortfolioManager
 
 # Create portfolio manager with $10,000 starting capital
 pm = PortfolioManager(10000, max_risk_per_trade=0.02, max_portfolio_risk=0.10)
@@ -77,7 +77,7 @@ print(f"AAPL position: {qty} shares")
 
 ### Basic Risk Management
 ```python
-from quanttradeai.trading.risk import apply_stop_loss_take_profit
+from quanttradeai import apply_stop_loss_take_profit
 
 # Apply risk management to trading signals
 df_with_risk = apply_stop_loss_take_profit(
@@ -93,7 +93,7 @@ print(f"Risk-adjusted signals: {risk_adjusted_signals}")
 
 ### Dynamic Position Sizing
 ```python
-from quanttradeai.trading.risk import position_size
+from quanttradeai import position_size
 
 # Calculate position sizes for different scenarios
 scenarios = [
@@ -109,7 +109,7 @@ for capital, risk, sl, price in scenarios:
 
 ### Portfolio Risk Management
 ```python
-from quanttradeai.trading.portfolio import PortfolioManager
+from quanttradeai import PortfolioManager
 
 # Manage risk across multiple positions using PortfolioManager
 pm = PortfolioManager(50000, max_risk_per_trade=0.02, max_portfolio_risk=0.10)

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -23,7 +23,7 @@ poetry run quanttradeai evaluate -m models/trained/AAPL
 
 ### Data Loading
 ```python
-from quanttradeai.data.loader import DataLoader
+from quanttradeai import DataLoader
 
 # Initialize and fetch data
 loader = DataLoader("config/model_config.yaml")
@@ -35,7 +35,7 @@ is_valid = loader.validate_data(data)
 
 ### Feature Engineering
 ```python
-from quanttradeai.data.processor import DataProcessor
+from quanttradeai import DataProcessor
 
 # Process raw data
 processor = DataProcessor("config/features_config.yaml")
@@ -47,7 +47,7 @@ df_labeled = processor.generate_labels(df_processed, forward_returns=5, threshol
 
 ### Model Training
 ```python
-from quanttradeai.models.classifier import MomentumClassifier
+from quanttradeai import MomentumClassifier
 
 # Initialize and train
 classifier = MomentumClassifier("config/model_config.yaml")
@@ -60,7 +60,7 @@ classifier.save_model("models/trained/AAPL")
 
 ### Backtesting
 ```python
-from quanttradeai.backtest.backtester import simulate_trades, compute_metrics
+from quanttradeai import simulate_trades, compute_metrics
 
 # Simulate trades
 df_trades = simulate_trades(df_labeled, stop_loss_pct=0.02, take_profit_pct=0.04)
@@ -72,22 +72,22 @@ metrics = compute_metrics(df_trades, risk_free_rate=0.02)
 ## 🔧 Technical Indicators
 
 ```python
-from quanttradeai.features.technical import sma, ema, rsi, macd, stochastic
+from quanttradeai.features import technical as ta
 
 # Moving averages
-sma_20 = sma(df['Close'], 20)
-ema_20 = ema(df['Close'], 20)
+sma_20 = ta.sma(df['Close'], 20)
+ema_20 = ta.ema(df['Close'], 20)
 
 # Momentum indicators
-rsi_14 = rsi(df['Close'], 14)
-macd_df = macd(df['Close'])
-stoch_df = stochastic(df['High'], df['Low'], df['Close'])
+rsi_14 = ta.rsi(df['Close'], 14)
+macd_df = ta.macd(df['Close'])
+stoch_df = ta.stochastic(df['High'], df['Low'], df['Close'])
 ```
 
 ## 🛡️ Risk Management
 
 ```python
-from quanttradeai.trading.risk import apply_stop_loss_take_profit, position_size
+from quanttradeai import apply_stop_loss_take_profit, position_size
 
 # Apply risk rules
 df_with_risk = apply_stop_loss_take_profit(df, stop_loss_pct=0.02, take_profit_pct=0.04)
@@ -97,7 +97,7 @@ qty = position_size(capital=10000, risk_per_trade=0.02, stop_loss_pct=0.05, pric
 ```
 
 ```python
-from quanttradeai.trading.portfolio import PortfolioManager
+from quanttradeai import PortfolioManager
 
 # Allocate capital across multiple symbols
 pm = PortfolioManager(10000)

--- a/verify_config_loading.py
+++ b/verify_config_loading.py
@@ -4,7 +4,7 @@ import os
 # Add project root to import path for direct execution
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
-from quanttradeai.data.processor import DataProcessor
+from quanttradeai import DataProcessor
 import logging
 
 logging.basicConfig(level=logging.INFO)  # Ensure logging is configured to see output


### PR DESCRIPTION
## Summary
- refresh README, LLM guide, and API docs to use top-level `quanttradeai` imports
- update quick reference and helper script for streamlined usage of backtesting and risk tools

## Testing
- `pre-commit run --files LLM.md README.md docs/api/README.md docs/api/backtesting.md docs/api/data.md docs/api/models.md docs/api/trading.md docs/quick-reference.md verify_config_loading.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eb496902c832a9a285d728a952e17