### PR TITLE
feat(streaming): add connection health monitoring

### DIFF
--- a/quanttradeai/streaming/monitoring/health_monitor.py
+++ b/quanttradeai/streaming/monitoring/health_monitor.py
@@ -138,7 +138,9 @@ class StreamingHealthMonitor:
         success = await self.recovery_manager.reconnect(name)
         if success:
             health.status = "connected"
-            health.window_start = time.time()
+            now = time.time()
+            health.window_start = now
+            health.last_message_ts = now
             health.messages = 0
         else:
             health.status = "down"


### PR DESCRIPTION
## Summary
- reset last_message_ts after successful reconnect to avoid stale detections
- add regression test for last_message_ts reset

## Testing
- `SKIP=test poetry run pre-commit run --files config/streaming.yaml quanttradeai/streaming/__init__.py quanttradeai/streaming/gateway.py quanttradeai/streaming/monitoring/__init__.py quanttradeai/streaming/monitoring/health_monitor.py quanttradeai/streaming/monitoring/alerts.py quanttradeai/streaming/monitoring/metrics_collector.py quanttradeai/streaming/monitoring/recovery_manager.py tests/streaming/test_health_monitor.py`
- `poetry run pytest tests/streaming/test_health_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2359f1ff0832a8c6a01fb75686aeb