### PR TITLE
feat: add market impact modeling

### DIFF
--- a/config/backtest_config.yaml
+++ b/config/backtest_config.yaml
@@ -13,5 +13,13 @@ execution:
     enabled: false
     max_participation: 0.1
     volume_source: bar_volume
+  impact:
+    enabled: false
+    model: linear
+    alpha: 0.0
+    beta: 0.0
+    decay: 0.0
+    spread: 0.0
+    average_daily_volume: 0
 # sample data path for CLI backtest
 data_path: data/backtest_sample.csv

--- a/config/impact_config.yaml
+++ b/config/impact_config.yaml
@@ -1,0 +1,10 @@
+# Market impact parameters by asset class
+asset_classes:
+  equities:
+    alpha: 0.1
+    beta: 0.05
+    model: linear
+  futures:
+    alpha: 0.2
+    beta: 0.1
+    model: square_root

--- a/quanttradeai/__init__.py
+++ b/quanttradeai/__init__.py
@@ -35,7 +35,15 @@ from .data.processor import DataProcessor
 from .models.classifier import MomentumClassifier
 from .trading.portfolio import PortfolioManager
 from .trading.risk import apply_stop_loss_take_profit, position_size
-from .backtest.backtester import simulate_trades, compute_metrics
+from .backtest import (
+    simulate_trades,
+    compute_metrics,
+    MarketImpactModel,
+    LinearImpactModel,
+    SquareRootImpactModel,
+    AlmgrenChrissModel,
+    ImpactCalculator,
+)
 
 __all__ = [
     "DataSource",
@@ -50,4 +58,9 @@ __all__ = [
     "position_size",
     "simulate_trades",
     "compute_metrics",
+    "MarketImpactModel",
+    "LinearImpactModel",
+    "SquareRootImpactModel",
+    "AlmgrenChrissModel",
+    "ImpactCalculator",
 ]

--- a/quanttradeai/backtest/__init__.py
+++ b/quanttradeai/backtest/__init__.py
@@ -15,5 +15,20 @@ Quick Start:
 """
 
 from .backtester import simulate_trades, compute_metrics
+from .impact import (
+    MarketImpactModel,
+    LinearImpactModel,
+    SquareRootImpactModel,
+    AlmgrenChrissModel,
+    ImpactCalculator,
+)
 
-__all__ = ["simulate_trades", "compute_metrics"]
+__all__ = [
+    "simulate_trades",
+    "compute_metrics",
+    "MarketImpactModel",
+    "LinearImpactModel",
+    "SquareRootImpactModel",
+    "AlmgrenChrissModel",
+    "ImpactCalculator",
+]

--- a/quanttradeai/backtest/backtester.py
+++ b/quanttradeai/backtest/backtester.py
@@ -38,6 +38,24 @@ def _simulate_single(
     tc = exec_cfg.get("transaction_costs", {})
     sl = exec_cfg.get("slippage", {})
     liq = exec_cfg.get("liquidity", {})
+    impact_cfg = exec_cfg.get("impact", {})
+
+    impact_calc = None
+    if impact_cfg.get("enabled", False):
+        from .impact import MODEL_MAP, ImpactCalculator
+
+        model_cls = MODEL_MAP.get(
+            impact_cfg.get("model", "linear"), MODEL_MAP["linear"]
+        )
+        model_params = {
+            k: v for k, v in impact_cfg.items() if k in {"alpha", "beta", "gamma"}
+        }
+        model = model_cls(**model_params)
+        impact_calc = ImpactCalculator(
+            model=model,
+            decay=impact_cfg.get("decay", 0.0),
+            spread=impact_cfg.get("spread", 0.0),
+        )
 
     ref_col = "Close"
     if sl.get("reference_price", "close") == "mid" and "Mid" in data.columns:
@@ -84,6 +102,19 @@ def _simulate_single(
                         slip_bps = slip_amt / price * 10000
                 fill_price = price + slip_amt if side > 0 else price - slip_amt
 
+                impact_cost = 0.0
+                impact_temp = 0.0
+                impact_perm = 0.0
+                if impact_calc is not None:
+                    adv = impact_cfg.get("average_daily_volume", float(volume))
+                    imp = impact_calc.impact_cost(exec_qty, adv)
+                    impact_cost = imp["total"]
+                    impact_temp = imp["temp"] * exec_qty
+                    impact_perm = imp["perm"] * exec_qty
+                    fill_price += (imp["temp"] + imp["spread"]) * (
+                        1 if side > 0 else -1
+                    )
+
                 t_cost = 0.0
                 if tc.get("enabled", False) and tc.get("value", 0) > 0:
                     if tc.get("mode", "bps") == "bps":
@@ -95,7 +126,7 @@ def _simulate_single(
                             t_cost = tc["value"]
 
                 sl_cost = abs(slip_amt) * exec_qty
-                total_cost = t_cost + sl_cost
+                total_cost = t_cost + sl_cost + impact_cost
 
                 gross_pnl = 0.0
                 if position != 0 and side != (1 if position > 0 else -1):
@@ -127,6 +158,9 @@ def _simulate_single(
                         "gross_pnl_contrib": gross_pnl,
                         "transaction_cost": t_cost,
                         "slippage_cost": sl_cost,
+                        "impact_temp_cost": impact_temp,
+                        "impact_perm_cost": impact_perm,
+                        "impact_cost": impact_cost,
                         "costs": total_cost,
                         "slippage_bps_applied": slip_bps,
                         "net_pnl_contrib": gross_pnl - total_cost,

--- a/quanttradeai/backtest/impact.py
+++ b/quanttradeai/backtest/impact.py
@@ -1,0 +1,126 @@
+"""Market impact modeling utilities.
+
+Provides a base :class:`MarketImpactModel` and a set of concrete
+implementations used to estimate execution price effects. These models are
+kept deliberately lightweight to allow fast vectorised backtests.
+
+The module also exposes :class:`ImpactCalculator` which orchestrates model
+selection and applies spread and decay logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+import math
+
+
+class MarketImpactModel(Protocol):
+    """Interface for market impact models."""
+
+    alpha: float
+    beta: float
+
+    def temporary(self, trade_volume: float, adv: float) -> float:
+        """Return temporary impact per share."""
+
+    def permanent(self, trade_volume: float, adv: float) -> float:
+        """Return permanent impact per share."""
+
+
+@dataclass
+class LinearImpactModel:
+    """Simple square-root impact model."""
+
+    alpha: float = 0.0
+    beta: float = 0.0
+
+    def _ratio(self, trade_volume: float, adv: float) -> float:
+        if adv <= 0:
+            return 0.0
+        return trade_volume / adv
+
+    def temporary(
+        self, trade_volume: float, adv: float
+    ) -> float:  # pragma: no cover - simple
+        r = self._ratio(trade_volume, adv)
+        return self.alpha * math.sqrt(r)
+
+    def permanent(self, trade_volume: float, adv: float) -> float:
+        r = self._ratio(trade_volume, adv)
+        return self.beta * r
+
+
+@dataclass
+class SquareRootImpactModel(LinearImpactModel):
+    """Square-root model with explicit temporary/permanent components."""
+
+    def temporary(self, trade_volume: float, adv: float) -> float:
+        r = self._ratio(trade_volume, adv)
+        return self.alpha * math.sqrt(r)
+
+    def permanent(self, trade_volume: float, adv: float) -> float:
+        r = self._ratio(trade_volume, adv)
+        return self.beta * math.sqrt(r)
+
+
+@dataclass
+class AlmgrenChrissModel(LinearImpactModel):
+    """Basic Almgren-Chriss style model."""
+
+    gamma: float = 0.0
+
+    def temporary(self, trade_volume: float, adv: float) -> float:
+        r = self._ratio(trade_volume, adv)
+        return self.alpha * r + self.beta * math.sqrt(r)
+
+    def permanent(self, trade_volume: float, adv: float) -> float:
+        r = self._ratio(trade_volume, adv)
+        return self.gamma * r
+
+
+MODEL_MAP = {
+    "linear": LinearImpactModel,
+    "square_root": SquareRootImpactModel,
+    "almgren_chriss": AlmgrenChrissModel,
+}
+
+
+@dataclass
+class ImpactCalculator:
+    """Service class for applying market impact models."""
+
+    model: MarketImpactModel
+    decay: float = 0.0
+    spread: float = 0.0
+    _cache: dict[tuple[float, float], tuple[float, float]] = field(
+        default_factory=dict, init=False
+    )
+
+    def _impact(self, trade_volume: float, adv: float) -> tuple[float, float]:
+        key = (trade_volume, adv)
+        if key in self._cache:
+            return self._cache[key]
+        tmp = self.model.temporary(trade_volume, adv)
+        perm = self.model.permanent(trade_volume, adv)
+        if self.decay > 0:
+            tmp *= math.exp(-self.decay)
+        self._cache[key] = (tmp, perm)
+        return tmp, perm
+
+    def impact_per_share(
+        self, trade_volume: float, adv: float
+    ) -> tuple[float, float, float]:
+        tmp, perm = self._impact(trade_volume, adv)
+        spread_cost = self.spread / 2.0
+        return tmp, perm, spread_cost
+
+    def impact_cost(self, trade_volume: float, adv: float) -> dict[str, float]:
+        tmp, perm, spread_cost = self.impact_per_share(trade_volume, adv)
+        per_share = tmp + spread_cost + perm
+        return {
+            "temp": tmp,
+            "perm": perm,
+            "spread": spread_cost,
+            "total": per_share * trade_volume,
+        }

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -78,10 +78,22 @@ class LiquidityConfig(BaseModel):
     volume_source: str = "bar_volume"
 
 
+class MarketImpactConfig(BaseModel):
+    enabled: bool = False
+    model: Literal["linear", "square_root", "almgren_chriss"] = "linear"
+    alpha: float = 0.0
+    beta: float = 0.0
+    gamma: float | None = None
+    decay: float = 0.0
+    spread: float = 0.0
+    average_daily_volume: float | None = None
+
+
 class ExecutionConfig(BaseModel):
     transaction_costs: TransactionCostConfig = TransactionCostConfig()
     slippage: SlippageConfig = SlippageConfig()
     liquidity: LiquidityConfig = LiquidityConfig()
+    impact: MarketImpactConfig = MarketImpactConfig()
 
 
 class BacktestConfigSchema(BaseModel):

--- a/quanttradeai/utils/metrics.py
+++ b/quanttradeai/utils/metrics.py
@@ -86,14 +86,21 @@ def compute_performance(data: pd.DataFrame, risk_free_rate: float = 0.0) -> dict
         total_slippage = float(
             (ledger["slippage_cost"] / ledger["reference_price"]).sum()
         )
+        total_impact = float(
+            (ledger.get("impact_cost", 0) / ledger["reference_price"]).sum()
+            if "impact_cost" in ledger
+            else 0.0
+        )
     else:
         total_costs = 0.0
         total_slippage = 0.0
+        total_impact = 0.0
 
     summary = {
         "gross_pnl": float(float(equity.iloc[-1]) - 1.0),
         "total_costs": float(total_costs),
         "total_slippage_cost": float(total_slippage),
+        "total_impact_cost": float(total_impact),
         "net_pnl": float(float(net_equity.iloc[-1]) - 1.0),
         "gross_sharpe": float(sharpe_ratio(returns, risk_free_rate)),
         "net_sharpe": float(sharpe_ratio(net_returns, risk_free_rate)),

--- a/tests/backtest/test_market_impact.py
+++ b/tests/backtest/test_market_impact.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from quanttradeai.backtest.backtester import simulate_trades, compute_metrics
+
+
+def make_df(prices, labels, volumes=None):
+    idx = pd.date_range("2021-01-01", periods=len(prices), freq="D")
+    data = {"Close": prices, "label": labels}
+    if volumes is not None:
+        data["Volume"] = volumes
+    return pd.DataFrame(data, index=idx)
+
+
+def test_linear_impact_applied_to_trades():
+    df = make_df([100, 101], [1, 0], volumes=[1000, 1000])
+    res = simulate_trades(
+        df,
+        execution={
+            "impact": {
+                "enabled": True,
+                "model": "linear",
+                "alpha": 0.5,
+                "beta": 0.0,
+                "average_daily_volume": 1000,
+                "spread": 0.02,
+            }
+        },
+    )
+    ledger = res.attrs["ledger"]
+    assert "impact_cost" in ledger.columns
+    assert ledger["impact_cost"].iloc[0] > 0
+    metrics = compute_metrics(res)
+    assert metrics["total_impact_cost"] > 0


### PR DESCRIPTION
## Summary
- add flexible MarketImpactModel implementations and ImpactCalculator service
- integrate impact costs into backtester execution and reporting
- expose impact configuration schema and sample YAML settings

## Testing
- `pre-commit run --all-files`
- `poetry run python verify_config_loading.py`

------
https://chatgpt.com/codex/tasks/task_e_68b383609518832a98308f3759bb7301