### PR TITLE
fix(backtest): guard gamma impact param

### DIFF
--- a/quanttradeai/backtest/backtester.py
+++ b/quanttradeai/backtest/backtester.py
@@ -47,9 +47,14 @@ def _simulate_single(
         model_cls = MODEL_MAP.get(
             impact_cfg.get("model", "linear"), MODEL_MAP["linear"]
         )
-        model_params = {
-            k: v for k, v in impact_cfg.items() if k in {"alpha", "beta", "gamma"}
-        }
+        model_params = {k: v for k, v in impact_cfg.items() if k in {"alpha", "beta"}}
+        # ``gamma`` is only relevant for the Almgren-Chriss model; the
+        # configuration schema sets it to ``None`` by default, which would raise
+        # ``TypeError`` if passed to other models. Only include it when provided
+        # and when the chosen model expects it.
+        gamma = impact_cfg.get("gamma")
+        if gamma is not None and model_cls is MODEL_MAP["almgren_chriss"]:
+            model_params["gamma"] = gamma
         model = model_cls(**model_params)
         impact_calc = ImpactCalculator(
             model=model,

--- a/tests/backtest/test_market_impact.py
+++ b/tests/backtest/test_market_impact.py
@@ -30,3 +30,23 @@ def test_linear_impact_applied_to_trades():
     assert ledger["impact_cost"].iloc[0] > 0
     metrics = compute_metrics(res)
     assert metrics["total_impact_cost"] > 0
+
+
+def test_gamma_none_ignored_for_non_almgren_models():
+    df = make_df([100, 101], [1, 0], volumes=[1000, 1000])
+    for model in ["linear", "square_root"]:
+        res = simulate_trades(
+            df,
+            execution={
+                "impact": {
+                    "enabled": True,
+                    "model": model,
+                    "alpha": 0.5,
+                    "beta": 0.0,
+                    "gamma": None,
+                    "average_daily_volume": 1000,
+                }
+            },
+        )
+        ledger = res.attrs["ledger"]
+        assert "impact_cost" in ledger.columns


### PR DESCRIPTION
## Summary
- avoid passing `gamma=None` to market impact models that don't accept it
- test that gamma defaults do not break linear/square-root impact

## Testing
- `poetry run pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68b3998bb428832aa2dd8e950765272c