### PR TITLE
fix(trading): enforce risk guard before trades

### DIFF
--- a/tests/trading/test_position_manager.py
+++ b/tests/trading/test_position_manager.py
@@ -53,3 +53,58 @@ def test_risk_manager_integration() -> None:
     pm.handle_market_data({"symbol": "AAPL", "price": 80, "timestamp": ts + timedelta(minutes=1)})
     assert pm.risk_manager.should_halt_trading()
 
+
+def test_open_position_respects_risk_guard() -> None:
+    cfg = PositionManagerConfig(
+        risk_management=RiskManagementConfig(
+            drawdown_protection=DrawdownProtectionConfig(enabled=True, max_drawdown_pct=0.1)
+        )
+    )
+    pm = PositionManager.from_config(cfg)
+    pm.cash = 1000
+    ts = datetime.utcnow()
+    assert pm.risk_manager is not None
+    pm.risk_manager.update(1000, ts)
+    pm.risk_manager.update(900, ts + timedelta(minutes=1))
+    assert pm.risk_manager.should_halt_trading()
+    pm.open_position("AAPL", qty=10, price=10, timestamp=ts + timedelta(minutes=2))
+    assert pm.cash == 1000
+    assert "AAPL" not in pm._positions
+
+
+def test_position_size_multiplier_applied() -> None:
+    cfg = PositionManagerConfig(
+        risk_management=RiskManagementConfig(
+            drawdown_protection=DrawdownProtectionConfig(enabled=True, max_drawdown_pct=0.1)
+        )
+    )
+    pm = PositionManager.from_config(cfg)
+    pm.cash = 1000
+    ts = datetime.utcnow()
+    assert pm.risk_manager is not None
+    pm.risk_manager.update(1000, ts)
+    pm.risk_manager.update(905, ts + timedelta(minutes=1))
+    assert pm.risk_manager.get_position_size_multiplier() == 0.5
+    pm.open_position("AAPL", qty=10, price=10, timestamp=ts + timedelta(minutes=2))
+    assert pm._positions["AAPL"].qty == 5
+    assert pm.cash == pytest.approx(950)
+
+
+def test_close_position_blocked_when_halted() -> None:
+    cfg = PositionManagerConfig(
+        risk_management=RiskManagementConfig(
+            drawdown_protection=DrawdownProtectionConfig(enabled=True, max_drawdown_pct=0.1)
+        )
+    )
+    pm = PositionManager.from_config(cfg)
+    pm.cash = 1000
+    pm.open_position("AAPL", qty=10, price=10)
+    ts = datetime.utcnow()
+    pm.risk_manager.update(1000, ts)
+    pm.risk_manager.update(800, ts + timedelta(minutes=1))
+    assert pm.risk_manager is not None
+    assert pm.risk_manager.should_halt_trading()
+    closed = pm.close_position("AAPL", price=10, timestamp=ts + timedelta(minutes=2))
+    assert closed == 0
+    assert pm._positions["AAPL"].qty == 10
+


### PR DESCRIPTION
## Summary
- check `RiskManager` guards before mutating positions and cash
- scale trade quantities with `get_position_size_multiplier`
- add tests for risk guard halting and size multiplier

## Testing
- `pre-commit run --all-files`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1ed93c90832a81e75e860bfe4d73