### PR TITLE
fix(trading): skip risk multiplier for position exits

### DIFF
--- a/quanttradeai/trading/position_manager.py
+++ b/quanttradeai/trading/position_manager.py
@@ -231,10 +231,6 @@ class PositionManager:
                 logger.warning("Trade halted by risk guard for %s", symbol)
                 return 0
             qty = -pos.qty
-            if self.risk_manager is not None:
-                qty = int(qty * self.risk_manager.get_position_size_multiplier())
-                if qty == 0:
-                    return 0
             pos.update(qty, price)
             pos.market_price = price
             notional = -qty * price


### PR DESCRIPTION
## Summary
- ensure `PositionManager.close_position` fully liquidates without risk multiplier
- add regression test for closing under risk guard multiplier

## Testing
- `pre-commit run --all-files`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba29e74e90832ab2373fb337df99be