### PR TITLE
feat(backtest): add intrabar fills and borrow fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - 📊 Data: YFinance/AlphaVantage loaders, caching, validation
 - 🧪 Features: technical indicators, custom signals, optional LLM sentiment
 - 🤖 Models: ensemble VotingClassifier (LR, RF, XGBoost) with Optuna tuning
-- 📈 Backtesting: execution costs, slippage, liquidity limits, market impact modeling, portfolio helpers
+- 📈 Backtesting: execution costs, slippage, liquidity limits, adaptive impact, intrabar fills, borrow fees
 - 🛡️ Risk management: drawdown and turnover guards
 - 📟 Live trading: real-time position manager with intraday risk controls
 - 🛠️ CLI: end‑to‑end pipeline, evaluation, and model backtest in one place

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,10 +132,11 @@ QuantTradeAI/
 - **Model persistence** and loading
 
 ### Backtesting
-- **Trade simulation** with realistic constraints
+- **Trade simulation** with limit/stop orders and intrabar tick fills
+- **Adaptive market impact modeling** with dynamic spreads and asymmetric coefficients
+- **Borrow fee accounting** for short positions
 - **Risk management** (stop-loss, take-profit)
 - **Performance metrics** (Sharpe ratio, max drawdown)
-- **Market impact modeling** for execution cost realism
 - **Position sizing** based on risk parameters
 
 ### Risk Management

--- a/docs/api/backtesting.md
+++ b/docs/api/backtesting.md
@@ -16,7 +16,9 @@ API documentation for trade simulation and performance metrics.
 
 Simulates trades using label signals.  The ``transaction_cost`` and ``slippage``
 arguments are shorthand for populating the ``execution`` configuration, which
-can also specify liquidity and market impact parameters.
+can also specify liquidity, market impact, borrow fees, and intrabar simulation
+parameters. The engine supports market, limit, and stop orders with partial
+fills.
 
 **Parameters:**
 - `df` (pd.DataFrame or dict[str, pd.DataFrame]): Single DataFrame or mapping of symbol to DataFrame with Close prices and label column
@@ -24,7 +26,8 @@ can also specify liquidity and market impact parameters.
 - `take_profit_pct` (float, optional): Take-profit percentage as decimal
 - `transaction_cost` (float, optional): Transaction cost in decimal bps
 - `slippage` (float, optional): Slippage cost in decimal bps
-- `execution` (dict, optional): Detailed execution settings including `transaction_costs`, `slippage`, `liquidity`, and `impact`
+- `execution` (dict, optional): Detailed execution settings including `transaction_costs`, `slippage`, `liquidity`, `impact`,
+  `borrow_fee`, and `intrabar`
 - `portfolio` (PortfolioManager, optional): Portfolio manager required when `df` is a dictionary
 
 **Returns:**
@@ -34,7 +37,7 @@ can also specify liquidity and market impact parameters.
 ```python
 from quanttradeai import simulate_trades
 
-# Simulate trades with market impact
+# Simulate trades with intrabar fills and borrow fees
 df_with_trades = simulate_trades(
     df,
     execution={
@@ -45,7 +48,9 @@ df_with_trades = simulate_trades(
             "beta": 0.0,
             "average_daily_volume": 1_000_000,
             "spread": 0.02,
-        }
+        },
+        "intrabar": {"enabled": True, "synthetic_ticks": 20, "volatility": 0.01},
+        "borrow_fee": {"enabled": True, "rate_bps": 100},
     },
 )
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,15 +114,32 @@ execution:
     model: linear        # linear, square_root, almgren_chriss
     alpha: 0.0
     beta: 0.0
+    alpha_buy: 0.0       # optional asymmetric coefficients
+    alpha_sell: 0.0
     decay: 0.0           # temporary impact decay rate
+    decay_volume_coeff: 0.0
     spread: 0.0          # bid-ask spread per share
+    spread_model: {type: dynamic}
     average_daily_volume: 0
+  borrow_fee:
+    enabled: false
+    rate_bps: 0
+  intrabar:
+    enabled: false
+    drift: 0.0
+    volatility: 0.0
+    synthetic_ticks: 0
 ```
 
-The `impact` block activates market impact modeling.  Parameters `alpha`,
-`beta`, and optional `gamma` control the chosen model, while `decay` and
-`spread` apply temporary impact decay and bid-ask spread costs.  Default
-parameter sets per asset class can be defined in `config/impact_config.yaml`.
+The `impact` block activates market impact modeling. Parameters `alpha`/`beta`
+and their buy/sell counterparts control the chosen model, while `decay`,
+`decay_volume_coeff`, and `spread_model` enable dynamic spread and volume-based
+decay. Default parameter sets per asset class can be defined in
+`config/impact_config.yaml`.
+
+The `borrow_fee` block applies financing costs to short positions, and the
+`intrabar` block enables tick-level fill simulation with optional synthetic
+Brownian motion ticks.
 
 ### Position Manager
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -71,7 +71,7 @@ classifier.save_model("models/trained/AAPL")
 ```python
 from quanttradeai import simulate_trades, compute_metrics
 
-# Simulate trades with market impact
+# Simulate trades with intrabar fills and market impact
 df_trades = simulate_trades(
     df_labeled,
     execution={
@@ -81,7 +81,9 @@ df_trades = simulate_trades(
             "alpha": 0.5,
             "beta": 0.0,
             "average_daily_volume": 1_000_000,
-        }
+        },
+        "intrabar": {"enabled": True, "synthetic_ticks": 20, "volatility": 0.01},
+        "borrow_fee": {"enabled": True, "rate_bps": 100},
     },
 )
 

--- a/quanttradeai/__init__.py
+++ b/quanttradeai/__init__.py
@@ -1,44 +1,8 @@
-"""QuantTradeAI
-=================
+"""Lightweight package initializer for QuantTradeAI.
 
-High-level interface for the QuantTradeAI toolkit.  The package bundles
-data acquisition, feature engineering, model training and backtesting
-utilities for quantitative trading research.
+Only core trading and backtesting utilities are imported to keep the
+module usable without optional heavy dependencies."""
 
-Public API:
-    - ``DataSource`` and concrete implementations
-    - ``DataLoader`` and ``DataProcessor``
-    - ``MomentumClassifier`` model
-    - ``PortfolioManager`` and risk helpers
-    - ``simulate_trades`` and ``compute_metrics`` for backtesting
-
-Quick Start:
-    ```python
-    from quanttradeai import DataLoader, DataProcessor, MomentumClassifier
-
-    loader = DataLoader()
-    data = loader.fetch_data()
-    processor = DataProcessor()
-    processed = {s: processor.process_data(df) for s, df in data.items()}
-    model = MomentumClassifier()
-    ```
-"""
-
-from .data.datasource import (
-    DataSource,
-    YFinanceDataSource,
-    AlphaVantageDataSource,
-    WebSocketDataSource,
-)
-
-# Lazily import optional dependencies to keep lightweight usage possible
-from .data.loader import DataLoader
-from .data.processor import DataProcessor
-
-try:  # pragma: no cover - optional heavy dependency
-    from .models.classifier import MomentumClassifier
-except Exception:  # pragma: no cover - tolerate missing ML libs
-    MomentumClassifier = None  # type: ignore[assignment]
 from .trading.portfolio import PortfolioManager
 from .trading.risk import apply_stop_loss_take_profit, position_size
 from .backtest import (
@@ -49,16 +13,10 @@ from .backtest import (
     SquareRootImpactModel,
     AlmgrenChrissModel,
     ImpactCalculator,
+    BacktestEngine,
 )
 
 __all__ = [
-    "DataSource",
-    "YFinanceDataSource",
-    "AlphaVantageDataSource",
-    "WebSocketDataSource",
-    "DataLoader",
-    "DataProcessor",
-    "MomentumClassifier",
     "PortfolioManager",
     "apply_stop_loss_take_profit",
     "position_size",
@@ -69,4 +27,5 @@ __all__ = [
     "SquareRootImpactModel",
     "AlmgrenChrissModel",
     "ImpactCalculator",
+    "BacktestEngine",
 ]

--- a/quanttradeai/__init__.py
+++ b/quanttradeai/__init__.py
@@ -1,8 +1,44 @@
-"""Lightweight package initializer for QuantTradeAI.
+"""QuantTradeAI
+=================
 
-Only core trading and backtesting utilities are imported to keep the
-module usable without optional heavy dependencies."""
+High-level interface for the QuantTradeAI toolkit.  The package bundles
+data acquisition, feature engineering, model training and backtesting
+utilities for quantitative trading research.
 
+Public API:
+    - ``DataSource`` and concrete implementations
+    - ``DataLoader`` and ``DataProcessor``
+    - ``MomentumClassifier`` model
+    - ``PortfolioManager`` and risk helpers
+    - ``simulate_trades`` and ``compute_metrics`` for backtesting
+
+Quick Start:
+    ```python
+    from quanttradeai import DataLoader, DataProcessor, MomentumClassifier
+
+    loader = DataLoader()
+    data = loader.fetch_data()
+    processor = DataProcessor()
+    processed = {s: processor.process_data(df) for s, df in data.items()}
+    model = MomentumClassifier()
+    ```
+"""
+
+from .data.datasource import (
+    DataSource,
+    YFinanceDataSource,
+    AlphaVantageDataSource,
+    WebSocketDataSource,
+)
+
+# Lazily import optional dependencies to keep lightweight usage possible
+from .data.loader import DataLoader
+from .data.processor import DataProcessor
+
+try:  # pragma: no cover - optional heavy dependency
+    from .models.classifier import MomentumClassifier
+except Exception:  # pragma: no cover - tolerate missing ML libs
+    MomentumClassifier = None  # type: ignore[assignment]
 from .trading.portfolio import PortfolioManager
 from .trading.risk import apply_stop_loss_take_profit, position_size
 from .backtest import (
@@ -18,6 +54,13 @@ from .backtest import (
 )
 
 __all__ = [
+    "DataSource",
+    "YFinanceDataSource",
+    "AlphaVantageDataSource",
+    "WebSocketDataSource",
+    "DataLoader",
+    "DataProcessor",
+    "MomentumClassifier",
     "PortfolioManager",
     "apply_stop_loss_take_profit",
     "position_size",

--- a/quanttradeai/__init__.py
+++ b/quanttradeai/__init__.py
@@ -13,6 +13,7 @@ from .backtest import (
     SquareRootImpactModel,
     AlmgrenChrissModel,
     ImpactCalculator,
+    DynamicSpreadModel,
     BacktestEngine,
 )
 
@@ -27,5 +28,6 @@ __all__ = [
     "SquareRootImpactModel",
     "AlmgrenChrissModel",
     "ImpactCalculator",
+    "DynamicSpreadModel",
     "BacktestEngine",
 ]

--- a/quanttradeai/backtest/__init__.py
+++ b/quanttradeai/backtest/__init__.py
@@ -22,6 +22,7 @@ from .impact import (
     SquareRootImpactModel,
     AlmgrenChrissModel,
     ImpactCalculator,
+    DynamicSpreadModel,
 )
 
 __all__ = [
@@ -32,5 +33,6 @@ __all__ = [
     "SquareRootImpactModel",
     "AlmgrenChrissModel",
     "ImpactCalculator",
+    "DynamicSpreadModel",
     "BacktestEngine",
 ]

--- a/quanttradeai/backtest/__init__.py
+++ b/quanttradeai/backtest/__init__.py
@@ -15,6 +15,7 @@ Quick Start:
 """
 
 from .backtester import simulate_trades, compute_metrics
+from .engine import BacktestEngine
 from .impact import (
     MarketImpactModel,
     LinearImpactModel,
@@ -31,4 +32,5 @@ __all__ = [
     "SquareRootImpactModel",
     "AlmgrenChrissModel",
     "ImpactCalculator",
+    "BacktestEngine",
 ]

--- a/quanttradeai/backtest/engine.py
+++ b/quanttradeai/backtest/engine.py
@@ -1,0 +1,54 @@
+"""Backtest engine coordinating portfolio and risk management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import pandas as pd
+
+from quanttradeai.trading.portfolio import PortfolioManager
+from quanttradeai.trading.risk_manager import RiskManager
+
+from .backtester import simulate_trades
+
+
+@dataclass
+class BacktestEngine:
+    """Simple wrapper around :func:`simulate_trades`.
+
+    Parameters
+    ----------
+    portfolio: PortfolioManager | None
+        Portfolio manager used for capital allocation when backtesting multiple
+        symbols.
+    risk_manager: RiskManager | None
+        Risk manager coordinating guards during backtests.
+    """
+
+    portfolio: Optional[PortfolioManager] = None
+    risk_manager: Optional[RiskManager] = None
+
+    def run(
+        self,
+        data: pd.DataFrame | Dict[str, pd.DataFrame],
+        execution: dict | None = None,
+        **kwargs,
+    ) -> pd.DataFrame | Dict[str, pd.DataFrame]:
+        """Execute a backtest using the underlying :func:`simulate_trades`.
+
+        Any additional keyword arguments are forwarded to
+        :func:`simulate_trades`.
+        """
+        if self.portfolio is not None and self.risk_manager is not None:
+            # ensure portfolio uses provided risk manager
+            self.portfolio.risk_manager = self.risk_manager
+        return simulate_trades(
+            data,
+            execution=execution,
+            portfolio=self.portfolio,
+            drawdown_guard=(
+                self.risk_manager.drawdown_guard if self.risk_manager else None
+            ),
+            **kwargs,
+        )

--- a/quanttradeai/backtest/intrabar.py
+++ b/quanttradeai/backtest/intrabar.py
@@ -1,0 +1,55 @@
+"""Intrabar price path simulation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+import math
+import numpy as np
+
+
+@dataclass
+class BrownianParams:
+    """Parameters for geometric Brownian motion tick generation."""
+
+    drift: float = 0.0
+    volatility: float = 0.0
+    ticks: int = 0
+
+
+def generate_gbm_ticks(
+    start_price: float,
+    volume: float,
+    params: BrownianParams,
+    seed: int | None = None,
+) -> Sequence[dict[str, float]]:
+    """Generate synthetic ticks using geometric Brownian motion.
+
+    Parameters
+    ----------
+    start_price : float
+        Starting price for the path.
+    volume : float
+        Total volume available in the bar.
+    params : BrownianParams
+        Brownian motion parameters controlling drift, volatility and number of
+        ticks to generate.
+    seed : int, optional
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    Sequence[dict[str, float]]
+        List of tick dictionaries with ``price`` and ``volume`` keys.
+    """
+    n = max(1, params.ticks)
+    dt = 1.0 / n
+    rng = np.random.default_rng(seed)
+    prices = [start_price]
+    for _ in range(n - 1):
+        shock = (
+            params.drift - 0.5 * params.volatility**2
+        ) * dt + params.volatility * math.sqrt(dt) * rng.standard_normal()
+        prices.append(prices[-1] * math.exp(shock))
+    vol_per_tick = volume / n if n else 0.0
+    return [{"price": p, "volume": vol_per_tick} for p in prices]

--- a/quanttradeai/trading/__init__.py
+++ b/quanttradeai/trading/__init__.py
@@ -15,12 +15,14 @@ Quick Start:
 """
 
 from .portfolio import PortfolioManager
+from .position_manager import PositionManager
 from .risk import apply_stop_loss_take_profit, position_size
 from .drawdown_guard import DrawdownGuard
 from .risk_manager import RiskManager
 
 __all__ = [
     "PortfolioManager",
+    "PositionManager",
     "apply_stop_loss_take_profit",
     "position_size",
     "DrawdownGuard",

--- a/quanttradeai/trading/__init__.py
+++ b/quanttradeai/trading/__init__.py
@@ -18,7 +18,6 @@ from .portfolio import PortfolioManager
 from .risk import apply_stop_loss_take_profit, position_size
 from .drawdown_guard import DrawdownGuard
 from .risk_manager import RiskManager
-from .position_manager import PositionManager
 
 __all__ = [
     "PortfolioManager",
@@ -26,5 +25,4 @@ __all__ = [
     "position_size",
     "DrawdownGuard",
     "RiskManager",
-    "PositionManager",
 ]

--- a/quanttradeai/trading/position_manager.py
+++ b/quanttradeai/trading/position_manager.py
@@ -16,8 +16,14 @@ from typing import Any, Dict, List
 
 import yaml
 
-from quanttradeai.streaming.gateway import StreamingGateway
-from quanttradeai.streaming.logging import logger
+try:
+    from quanttradeai.streaming.gateway import StreamingGateway
+    from quanttradeai.streaming.logging import logger
+except Exception:  # pragma: no cover - optional streaming deps
+    StreamingGateway = Any  # type: ignore
+    import logging
+
+    logger = logging.getLogger(__name__)
 from quanttradeai.trading.drawdown_guard import DrawdownGuard
 from quanttradeai.trading.risk_manager import RiskManager
 from quanttradeai.backtest.impact import ImpactCalculator, MODEL_MAP

--- a/quanttradeai/utils/__init__.py
+++ b/quanttradeai/utils/__init__.py
@@ -7,6 +7,6 @@ Public API:
     - :mod:`visualization`
 """
 
-from . import metrics, visualization
+from . import metrics
 
-__all__ = ["metrics", "visualization"]
+__all__ = ["metrics"]

--- a/quanttradeai/utils/__init__.py
+++ b/quanttradeai/utils/__init__.py
@@ -1,12 +1,17 @@
 """Miscellaneous utilities.
 
-Expose common metrics and visualization helpers used across the project.
+Expose common metrics lazily to avoid heavy optional dependencies.
 
 Public API:
     - :mod:`metrics`
-    - :mod:`visualization`
 """
 
-from . import metrics
-
 __all__ = ["metrics"]
+
+
+def __getattr__(name: str):
+    if name == "metrics":
+        from . import metrics as _metrics
+
+        return _metrics
+    raise AttributeError(name)

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -76,6 +76,7 @@ class LiquidityConfig(BaseModel):
     enabled: bool = False
     max_participation: float = 0.1
     volume_source: str = "bar_volume"
+    order_book_depth: float | None = None
 
 
 class MarketImpactConfig(BaseModel):
@@ -85,7 +86,16 @@ class MarketImpactConfig(BaseModel):
     beta: float = 0.0
     gamma: float | None = None
     decay: float = 0.0
+    decay_volume_coeff: float = 0.0
     spread: float = 0.0
+    spread_model: Optional[Dict[str, Any]] = None
+    alpha_buy: float | None = None
+    alpha_sell: float | None = None
+    beta_buy: float | None = None
+    beta_sell: float | None = None
+    cross_alpha: float = 0.0
+    cross_beta: float = 0.0
+    horizon_decay: float = 0.0
     average_daily_volume: float | None = None
     liquidity_scale: float = Field(1.0, ge=0.0)
 
@@ -98,6 +108,9 @@ class BorrowFeeConfig(BaseModel):
 class IntrabarConfig(BaseModel):
     enabled: bool = False
     tick_column: str = "ticks"
+    drift: float = 0.0
+    volatility: float = 0.0
+    synthetic_ticks: int = 0
 
 
 class ExecutionConfig(BaseModel):

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -10,7 +10,7 @@ Key Components:
 """
 
 from typing import List, Optional, Dict, Any, Literal
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class DataSection(BaseModel):
@@ -87,6 +87,17 @@ class MarketImpactConfig(BaseModel):
     decay: float = 0.0
     spread: float = 0.0
     average_daily_volume: float | None = None
+    liquidity_scale: float = Field(1.0, ge=0.0)
+
+
+class BorrowFeeConfig(BaseModel):
+    enabled: bool = False
+    rate_bps: float = Field(0.0, ge=0.0)
+
+
+class IntrabarConfig(BaseModel):
+    enabled: bool = False
+    tick_column: str = "ticks"
 
 
 class ExecutionConfig(BaseModel):
@@ -94,6 +105,8 @@ class ExecutionConfig(BaseModel):
     slippage: SlippageConfig = SlippageConfig()
     liquidity: LiquidityConfig = LiquidityConfig()
     impact: MarketImpactConfig = MarketImpactConfig()
+    borrow_fee: BorrowFeeConfig = BorrowFeeConfig()
+    intrabar: IntrabarConfig = IntrabarConfig()
 
 
 class DrawdownProtectionConfig(BaseModel):

--- a/tests/backtest/test_advanced_execution.py
+++ b/tests/backtest/test_advanced_execution.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import pytest
+
+from quanttradeai.backtest.backtester import simulate_trades
+from quanttradeai.backtest.engine import BacktestEngine
+from quanttradeai.trading.portfolio import PortfolioManager
+from quanttradeai.trading.risk_manager import RiskManager
+from quanttradeai.utils.config_schemas import BorrowFeeConfig, MarketImpactConfig
+
+
+def test_borrow_fee_applied():
+    df = pd.DataFrame({"Close": [10, 9, 8], "label": [-1, -1, 0]})
+    execution = {"borrow_fee": {"enabled": True, "rate_bps": 100}}
+    res = simulate_trades(df, execution=execution)
+    ledger = res.attrs["ledger"]
+    borrow_entries = ledger[ledger["side"] == "borrow_fee"]
+    assert borrow_entries["borrow_fee"].sum() > 0
+    # first bar net return should reflect borrow cost 0.01
+    assert pytest.approx(res["strategy_return"].iloc[0], rel=1e-6) == 0.09
+
+
+def test_intrabar_fill_vwap():
+    ticks = [[{"price": 10.0, "volume": 5}, {"price": 10.2, "volume": 5}], []]
+    df = pd.DataFrame(
+        {
+            "Close": [10, 10],
+            "label": [10, 0],
+            "ticks": ticks,
+            "Volume": [10, 10],
+        }
+    )
+    execution = {"intrabar": {"enabled": True}}
+    res = simulate_trades(df, execution=execution)
+    ledger = res.attrs["ledger"]
+    trade = ledger.iloc[0]
+    assert pytest.approx(trade["fill_price"], rel=1e-6) == 10.1
+    assert trade["tick_fills"] == 2
+    assert pytest.approx(trade["liquidity_participation"], rel=1e-6) == 1.0
+
+
+def test_config_validation():
+    with pytest.raises(ValueError):
+        BorrowFeeConfig(enabled=True, rate_bps=-1)
+    with pytest.raises(ValueError):
+        MarketImpactConfig(liquidity_scale=-1)
+
+
+def test_backtest_engine_wrapper():
+    df = pd.DataFrame({"Close": [10, 11], "label": [1, 0]})
+    pm = PortfolioManager(capital=1000)
+    rm = RiskManager()
+    engine = BacktestEngine(portfolio=pm, risk_manager=rm)
+    res = engine.run(df)
+    assert "equity_curve" in res.columns

--- a/tests/backtest/test_advanced_execution.py
+++ b/tests/backtest/test_advanced_execution.py
@@ -52,3 +52,78 @@ def test_backtest_engine_wrapper():
     engine = BacktestEngine(portfolio=pm, risk_manager=rm)
     res = engine.run(df)
     assert "equity_curve" in res.columns
+
+
+def test_synthetic_intrabar_generation():
+    df = pd.DataFrame(
+        {
+            "Close": [10, 10],
+            "label": [5, 0],
+            "Volume": [10, 10],
+        }
+    )
+    execution = {
+        "intrabar": {"enabled": True, "synthetic_ticks": 5, "volatility": 0.1}
+    }
+    res = simulate_trades(df, execution=execution)
+    trade = res.attrs["ledger"].iloc[0]
+    assert trade["tick_fills"] == 3
+
+
+def test_limit_and_stop_orders():
+    df = pd.DataFrame(
+        {
+            "Close": [10, 9, 8],
+            "label": [5, 5, -5],
+            "Volume": [10, 10, 10],
+            "order_type": ["limit", "limit", "stop"],
+            "limit_price": [9.5, 9.5, None],
+            "stop_price": [None, None, 8.5],
+        }
+    )
+    execution = {
+        "liquidity": {
+            "enabled": True,
+            "order_book_depth": 20,
+            "max_participation": 1.0,
+        }
+    }
+    res = simulate_trades(df, execution=execution)
+    ledger = res.attrs["ledger"]
+    # limit order partially fills on second bar
+    assert ledger.iloc[0]["order_type"] == "limit"
+    assert pytest.approx(ledger.iloc[0]["qty"], rel=1e-6) == 5.0
+    # stop order triggers on third bar with partial fill
+    assert ledger.iloc[1]["order_type"] == "stop"
+    assert pytest.approx(ledger.iloc[1]["qty"], rel=1e-6) == 2.5
+    assert ledger.iloc[1]["timestamp"] == df.index[2]
+
+
+def test_dynamic_spread_asymmetric_impact():
+    df = pd.DataFrame(
+        {
+            "Close": [10, 10, 10, 10],
+            "label": [1, 1, -1, 0],
+            "Volume": [100, 100, 100, 100],
+            "Volatility": [0.1, 0.1, 0.1, 0.1],
+        }
+    )
+    execution = {
+        "impact": {
+            "enabled": True,
+            "model": "linear",
+            "alpha_buy": 0.1,
+            "alpha_sell": 0.2,
+            "spread_model": {"base": 0.01, "vol_coeff": 0.5},
+            "average_daily_volume": 100,
+        }
+    }
+    res = simulate_trades(df, execution=execution)
+    ledger = res.attrs["ledger"]
+    buy = ledger.iloc[0]
+    sell = ledger.iloc[1]
+    buy_per = buy["impact_temp_cost"] / buy["qty"]
+    sell_per = sell["impact_temp_cost"] / sell["qty"]
+    assert sell_per > buy_per
+    expected_spread = 0.01 + 0.5 * 0.1
+    assert buy["impact_cost"] >= expected_spread / 2


### PR DESCRIPTION
## Summary
- support borrow fee and intrabar tick-level fills in backtester with ledger metrics
- add BacktestEngine wrapper and execution config knobs for borrow fee & intrabar fills
- cover new execution paths with unit tests

## Testing
- `PYTHONPATH=. pytest tests/backtest/test_backtester.py tests/backtest/test_advanced_execution.py -q`
- `SKIP=test pre-commit run --files quanttradeai/__init__.py quanttradeai/backtest/__init__.py quanttradeai/backtest/backtester.py quanttradeai/trading/__init__.py quanttradeai/utils/__init__.py quanttradeai/utils/config_schemas.py quanttradeai/backtest/engine.py tests/backtest/test_advanced_execution.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb88e249c0832abbc15e00dd6377c5