### PR TITLE
Add agent backtest promotion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 | I want to... | Best path today | What I get |
 | --- | --- | --- |
 | Research a strategy end to end | `init` -> `validate` -> `research run` | Time-aware evaluation, backtests, metrics, run records |
-| Run a deterministic rule agent | `init --template rule-agent` -> `agent run --mode backtest|paper` | A no-LLM baseline agent driven entirely by YAML thresholds |
-| Run a trained model as an agent | `init --template model-agent` -> `agent run --mode backtest|paper` | One YAML-defined agent that can be backtested and paper-run |
-| Run an LLM agent | `init --template llm-agent` -> `agent run --mode backtest|paper` | Prompt-driven agent logic using project config |
-| Run a hybrid agent | `init --template hybrid` -> `research run` -> `agent run --mode backtest|paper` | Model signals plus LLM reasoning in one project |
+| Run a deterministic rule agent | `init --template rule-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` | A no-LLM baseline agent driven entirely by YAML thresholds |
+| Run a trained model as an agent | `init --template model-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` | One YAML-defined agent that can be backtested, promoted, and paper-run |
+| Run an LLM agent | `init --template llm-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` | Prompt-driven agent logic using project config |
+| Run a hybrid agent | `init --template hybrid` -> `research run` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` | Model signals plus LLM reasoning in one project |
 | Keep using the older live loop | `live-trade` with runtime YAML files | Legacy compatibility for existing setups |
 
 ## How It Fits Together
@@ -66,7 +66,8 @@ QuantTradeAI is one framework with two connected tracks:
 | `agent run` for `model` agents in `paper` | Supported |
 | `agent run` for `llm` and `hybrid` agents in `backtest` | Supported |
 | `agent run` for `llm` and `hybrid` agents in `paper` | Supported |
-| Deployment and promotion UX | Roadmap |
+| Agent backtest-to-paper promotion | Supported |
+| Deployment and live promotion UX | Roadmap |
 
 > [!NOTE]
 > `live-trade` still exists for legacy runtime YAML workflows. It does not read `config/project.yaml`.
@@ -112,6 +113,7 @@ Use this if you want the smallest deterministic agent workflow with no LLM depen
 poetry run quanttradeai init --template rule-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode paper
 ```
 
@@ -140,6 +142,7 @@ poetry run quanttradeai validate -c config/project.yaml
 # Replace models/trained/aapl_daily_classifier/ with a real trained model artifact
 
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode paper
 ```
 
@@ -154,6 +157,7 @@ Use this if you want prompt-driven agent logic from YAML and want to move the sa
 poetry run quanttradeai init --template llm-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
 ```
 
@@ -164,6 +168,8 @@ Use this if you want to combine trained model signals and LLM reasoning in one p
 ```bash
 poetry run quanttradeai init --template hybrid -o config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode paper
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ QuantTradeAI has one **canonical project config** for research and agent backtes
 | What you want to do | Primary file(s) | Used by |
 | --- | --- | --- |
 | Run the canonical research workflow | `config/project.yaml` | `quanttradeai validate`, `quanttradeai research run` |
-| Run an LLM or hybrid agent backtest | `config/project.yaml` | `quanttradeai agent run` |
+| Run or promote a project-defined agent | `config/project.yaml` | `quanttradeai agent run`, `quanttradeai promote` |
 | Run live streaming inference | `config/model_config.yaml`, `config/features_config.yaml`, `config/streaming.yaml`, `config/risk_config.yaml`, `config/position_manager.yaml` | `quanttradeai live-trade` |
 | Backtest a saved model with execution costs | `config/model_config.yaml`, `config/backtest_config.yaml`, optional `config/risk_config.yaml`, optional `config/impact_config.yaml` | `quanttradeai backtest-model` |
 | Validate the runtime YAML bundle | Runtime YAML files under `config/` | `quanttradeai validate-config` |
@@ -39,6 +39,7 @@ poetry run quanttradeai runs list
 poetry run quanttradeai init --template llm-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 ```
 
 ### Live Trading
@@ -54,7 +55,7 @@ poetry run quanttradeai live-trade \
 
 ## Important Boundaries
 
-- `config/project.yaml` is the center of gravity for **research** and **agent backtests**
+- `config/project.yaml` is the center of gravity for **research**, **agent backtests**, and **agent backtest-to-paper promotion**
 - `quanttradeai live-trade` does **not** read `config/project.yaml` today
 - `config/streaming.yaml`, `config/risk_config.yaml`, and `config/position_manager.yaml` are still first-class runtime files
 - `quanttradeai validate-config` is the fastest way to catch malformed runtime YAMLs before running live or backtest commands

--- a/docs/configuration/live-runtime-files.md
+++ b/docs/configuration/live-runtime-files.md
@@ -4,7 +4,8 @@
 
 - research runs
 - project-defined agent backtests
-- project-defined `model` agent paper runs
+- project-defined agent paper runs
+- agent backtest-to-paper promotion
 
 The legacy runtime YAML files still matter for:
 
@@ -31,11 +32,11 @@ This page explains that boundary.
 
 ### Canonical Paper Agent Path
 
-`quanttradeai agent run --mode paper` for `model` agents:
+`quanttradeai agent run --mode paper` for project-defined agents:
 
 - reads `config/project.yaml`
 - compiles runtime model, features, backtest, and streaming YAMLs into the run directory
-- passes the compiled feature config into the live/paper engine
+- passes the compiled feature config into the paper runtime
 
 ### Legacy Live Path
 

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -8,6 +8,7 @@ It drives:
 - `quanttradeai validate`
 - `quanttradeai research run`
 - `quanttradeai agent run` for project-defined agents
+- `quanttradeai promote` for agent backtest-to-paper promotion
 
 `live-trade` still uses the legacy runtime YAML files documented in [Runtime and Live Trading Configs](live-runtime-files.md).
 
@@ -27,6 +28,7 @@ poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai init --template model-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode paper
 ```
 
@@ -38,6 +40,7 @@ The `model-agent` template also creates a placeholder model artifact at `models/
 poetry run quanttradeai init --template rule-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode paper
 ```
 
@@ -47,6 +50,7 @@ poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml -
 poetry run quanttradeai init --template llm-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
 ```
 
@@ -60,6 +64,14 @@ Current support:
 | `llm` | Yes | Yes | No |
 | `hybrid` | Yes | Yes | No |
 | `rule` | Yes | Yes | No |
+
+Successful agent backtest runs can be promoted to paper mode with:
+
+```bash
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
+```
+
+This updates the matching agent's `mode` and `deployment.mode` to `paper`. Promotion to `live` remains future work.
 
 ## Canonical Shape
 
@@ -354,7 +366,7 @@ Paper mode:
 
 ### `deployment`
 
-Required metadata. It is not yet a complete workflow driver.
+Required metadata. `quanttradeai promote --run <run_id>` updates `deployment.mode` to `paper` when promoting a successful agent backtest run. Deployment generation and live promotion remain future work.
 
 ## Runtime Artifacts
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,9 +47,10 @@ Replace the placeholder model directory with a real trained model artifact befor
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
 ```
 
-### Run The Same Agent In Paper Mode
+### Promote And Run The Same Agent In Paper Mode
 
 ```bash
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode paper
 ```
 
@@ -68,6 +69,7 @@ LLM and hybrid agents are supported in both backtest and paper mode from `projec
 poetry run quanttradeai init --template llm-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
 ```
 
@@ -76,6 +78,8 @@ Hybrid projects use the same pattern:
 ```bash
 poetry run quanttradeai init --template hybrid -o config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode paper
 ```
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -20,6 +20,8 @@ poetry run quanttradeai runs list
 poetry run quanttradeai init --template llm-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
+# Promote the successful backtest run before starting paper mode
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
 
 # Import an existing legacy config/ directory into the canonical workflow

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -802,7 +802,7 @@ def cmd_research_run(
         help="Skip data-quality validation before training",
     ),
 ):
-    """Run the Stage 1 canonical research workflow from project.yaml."""
+    """Run the canonical research workflow from project.yaml."""
 
     import yaml
 
@@ -1105,6 +1105,43 @@ def cmd_runs_list(
         return
 
     typer.echo(_render_runs_table(records))
+
+
+@app.command("promote")
+def cmd_promote(
+    run: str = typer.Option(
+        ..., "--run", help="Run id to promote, for example agent/backtest/<run>"
+    ),
+    config: str = typer.Option(
+        "config/project.yaml", "-c", "--config", help="Path to project config YAML"
+    ),
+    target: str = typer.Option(
+        "paper",
+        "--to",
+        help="Target mode. Only paper is supported in this release.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show the proposed promotion without writing project.yaml",
+    ),
+):
+    """Promote a successful agent backtest run to paper mode."""
+
+    from .utils.promotion import promote_agent_run
+
+    try:
+        result = promote_agent_run(
+            run_id=run,
+            config_path=config,
+            target_mode=target,
+            dry_run=dry_run,
+        )
+    except Exception as exc:
+        typer.echo(f"Promotion failed: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo(json.dumps(result, indent=2))
 
 
 @agent_app.command("run")

--- a/quanttradeai/utils/promotion.py
+++ b/quanttradeai/utils/promotion.py
@@ -1,0 +1,187 @@
+"""Run-backed promotion helpers for canonical project workflows."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from quanttradeai.utils.config_schemas import ProjectConfigSchema
+from quanttradeai.utils.run_records import RUNS_ROOT, discover_runs
+
+
+def _normalize_run_id(value: str | Path) -> str:
+    """Normalize a run id/path for matching records discovered under runs/."""
+
+    normalized = str(value).replace("\\", "/").strip().strip("/")
+    parts = [part for part in normalized.split("/") if part and part != "."]
+    if "runs" in parts:
+        parts = parts[parts.index("runs") + 1 :]
+    return "/".join(parts)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Run summary not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Run summary is not valid JSON: {path}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"Run summary must contain a JSON object: {path}")
+    return payload
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Project config not found: {path}")
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Project config must contain a mapping at root: {path}")
+    return payload
+
+
+def _find_run_record(run_id: str | Path, *, runs_root: Path | str) -> dict[str, Any]:
+    expected = _normalize_run_id(run_id)
+    for record in discover_runs(runs_root):
+        candidates = {
+            _normalize_run_id(str(record.get("run_id") or "")),
+            _normalize_run_id(str(record.get("run_dir") or "")),
+        }
+        if expected in candidates:
+            return record
+
+    raise ValueError(f"Run not found: {run_id}")
+
+
+def _summary_path_for_record(record: dict[str, Any], runs_root: Path | str) -> Path:
+    summary_path = Path(str(record.get("run_dir") or "")) / "summary.json"
+    if summary_path.is_file():
+        return summary_path
+
+    run_id = str(record.get("run_id") or "")
+    return (
+        Path(runs_root).joinpath(*_normalize_run_id(run_id).split("/")) / "summary.json"
+    )
+
+
+def _validate_promotable_run(record: dict[str, Any], summary: dict[str, Any]) -> str:
+    run_type = str(summary.get("run_type") or record.get("run_type") or "")
+    mode = str(summary.get("mode") or record.get("mode") or "")
+    status = str(summary.get("status") or record.get("status") or "")
+
+    if run_type != "agent" or mode != "backtest" or status != "success":
+        raise ValueError(
+            "Only successful agent backtest runs can be promoted to paper."
+        )
+
+    agent_name = str(
+        summary.get("agent_name") or summary.get("name") or record.get("name") or ""
+    ).strip()
+    if not agent_name:
+        raise ValueError("Promotable agent run is missing an agent name.")
+
+    return agent_name
+
+
+def _apply_paper_promotion(
+    project_config: dict[str, Any],
+    *,
+    agent_name: str,
+) -> tuple[dict[str, Any], bool]:
+    proposed = copy.deepcopy(project_config)
+    agents = proposed.get("agents")
+    if not isinstance(agents, list):
+        raise ValueError("Project config must include an agents list.")
+
+    target_agent: dict[str, Any] | None = None
+    for agent in agents:
+        if isinstance(agent, dict) and agent.get("name") == agent_name:
+            target_agent = agent
+            break
+
+    if target_agent is None:
+        raise ValueError(f"Agent '{agent_name}' not found in project config.")
+
+    changed = False
+    if target_agent.get("mode") != "paper":
+        target_agent["mode"] = "paper"
+        changed = True
+
+    deployment = proposed.get("deployment")
+    if not isinstance(deployment, dict):
+        raise ValueError("Project config must include a deployment mapping.")
+    if deployment.get("mode") != "paper":
+        deployment["mode"] = "paper"
+        changed = True
+
+    streaming = (proposed.get("data") or {}).get("streaming")
+    if not isinstance(streaming, dict) or streaming.get("enabled") is not True:
+        raise ValueError(
+            "data.streaming.enabled must be true before promoting an agent to paper."
+        )
+
+    try:
+        ProjectConfigSchema(**proposed)
+    except ValidationError as exc:
+        raise ValueError(f"Promoted project config is invalid: {exc}") from exc
+
+    return proposed, changed
+
+
+def promote_agent_run(
+    *,
+    run_id: str | Path,
+    config_path: str | Path = "config/project.yaml",
+    target_mode: str = "paper",
+    dry_run: bool = False,
+    runs_root: Path | str = RUNS_ROOT,
+) -> dict[str, Any]:
+    """Promote a successful agent backtest run to paper mode in project.yaml."""
+
+    target_mode = target_mode.strip().lower()
+    if target_mode != "paper":
+        raise ValueError(
+            "Only promotion to paper is supported. Live promotion remains future work."
+        )
+
+    record = _find_run_record(run_id, runs_root=runs_root)
+    summary_path = _summary_path_for_record(record, runs_root)
+    summary = _load_json(summary_path)
+    agent_name = _validate_promotable_run(record, summary)
+
+    project_config_path = Path(config_path)
+    project_config = _load_yaml_mapping(project_config_path)
+    promoted_config, changed = _apply_paper_promotion(
+        project_config,
+        agent_name=agent_name,
+    )
+
+    if changed and not dry_run:
+        project_config_path.write_text(
+            yaml.safe_dump(promoted_config, sort_keys=False),
+            encoding="utf-8",
+        )
+
+    config_path_display = project_config_path.as_posix()
+    next_command = (
+        f"quanttradeai agent run --agent {agent_name} "
+        f"-c {config_path_display} --mode paper"
+    )
+    return {
+        "status": "success",
+        "source_run_id": str(record.get("run_id") or _normalize_run_id(run_id)),
+        "agent_name": agent_name,
+        "from_mode": "backtest",
+        "to_mode": "paper",
+        "changed": changed,
+        "config_path": config_path_display,
+        "dry_run": dry_run,
+        "next_command": next_command,
+    }

--- a/roadmap.md
+++ b/roadmap.md
@@ -329,7 +329,8 @@ Status on 2026-03-29:
 - LLM and hybrid paper runs now persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, and sampled prompt payloads under `runs/agent/paper/...`.
 - Rule-agent paper runs now persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, `decisions.jsonl`, and `executions.jsonl` under `runs/agent/paper/...`.
 - `quanttradeai runs list` is implemented for local research and agent run discovery.
-- Remaining Stage 1 work includes live execution for `llm` and `hybrid` agents, and promotion UX.
+- `quanttradeai promote --run <run_id>` is implemented for successful agent backtest-to-paper promotion.
+- Remaining Stage 1 work includes project-agent live execution, live promotion safety gates, and deployment UX.
 
 ### Stage 2: Multi-Agent Lab
 

--- a/tests/integration/test_promote_cli.py
+++ b/tests/integration/test_promote_cli.py
@@ -1,0 +1,262 @@
+import json
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from quanttradeai.cli import PROJECT_TEMPLATES, app
+
+
+runner = CliRunner()
+
+
+def _write_project_config(
+    path: Path,
+    *,
+    agent_mode: str = "backtest",
+    deployment_mode: str = "backtest",
+    streaming_enabled: bool = True,
+) -> dict:
+    payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["llm-agent"], sort_keys=False)
+    )
+    payload["agents"][0]["mode"] = agent_mode
+    payload["deployment"]["mode"] = deployment_mode
+    payload["data"]["streaming"]["enabled"] = streaming_enabled
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return payload
+
+
+def _write_run_summary(
+    *,
+    run_id: str = "agent/backtest/20260101_010000_breakout_gpt",
+    run_type: str = "agent",
+    mode: str = "backtest",
+    status: str = "success",
+    agent_name: str | None = "breakout_gpt",
+) -> Path:
+    run_dir = Path("runs").joinpath(*run_id.split("/"))
+    summary = {
+        "run_type": run_type,
+        "mode": mode,
+        "name": agent_name or "research_lab",
+        "status": status,
+        "symbols": ["AAPL"],
+        "timestamps": {
+            "started_at": "2026-01-01T01:00:00+00:00",
+            "completed_at": "2026-01-01T01:05:00+00:00",
+        },
+        "artifacts": {},
+        "warnings": [],
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+    }
+    if agent_name is not None:
+        summary["agent_name"] = agent_name
+    if run_type == "research":
+        summary["project_name"] = "research_lab"
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def _load_project_config(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_promote_agent_backtest_updates_project_yaml_and_prints_next_command(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_project_config(config_path)
+    run_id = "agent/backtest/20260101_010000_breakout_gpt"
+    _write_run_summary(run_id=run_id)
+
+    run_arg = "runs\\" + run_id.replace("/", "\\")
+    result = runner.invoke(
+        app,
+        ["promote", "--run", run_arg, "--config", str(config_path)],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    updated = _load_project_config(config_path)
+
+    assert payload["status"] == "success"
+    assert payload["source_run_id"] == run_id
+    assert payload["agent_name"] == "breakout_gpt"
+    assert payload["from_mode"] == "backtest"
+    assert payload["to_mode"] == "paper"
+    assert payload["changed"] is True
+    assert payload["dry_run"] is False
+    assert (
+        payload["next_command"]
+        == "quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper"
+    )
+    assert updated["agents"][0]["mode"] == "paper"
+    assert updated["deployment"]["mode"] == "paper"
+
+
+def test_promote_dry_run_reports_change_without_writing(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_project_config(config_path)
+    original = config_path.read_text(encoding="utf-8")
+    _write_run_summary()
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "--run",
+            "agent/backtest/20260101_010000_breakout_gpt",
+            "--config",
+            str(config_path),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["changed"] is True
+    assert payload["dry_run"] is True
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_promote_already_paper_agent_is_success_with_no_change(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_project_config(
+        config_path,
+        agent_mode="paper",
+        deployment_mode="paper",
+    )
+    _write_run_summary()
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "--run",
+            "agent/backtest/20260101_010000_breakout_gpt",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "success"
+    assert payload["changed"] is False
+
+
+def test_promote_failure_cases_do_not_mutate_project_yaml(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_project_config(config_path)
+    original = config_path.read_text(encoding="utf-8")
+    _write_run_summary(
+        run_id="agent/backtest/20260101_020000_failed_agent",
+        status="failed",
+    )
+    _write_run_summary(
+        run_id="research/20260101_000000_research_lab",
+        run_type="research",
+        mode="research",
+        agent_name=None,
+    )
+
+    cases = [
+        (
+            [
+                "promote",
+                "--run",
+                "agent/backtest/missing",
+                "--config",
+                str(config_path),
+            ],
+            "Run not found",
+        ),
+        (
+            [
+                "promote",
+                "--run",
+                "agent/backtest/20260101_020000_failed_agent",
+                "--config",
+                str(config_path),
+            ],
+            "Only successful agent backtest runs",
+        ),
+        (
+            [
+                "promote",
+                "--run",
+                "research/20260101_000000_research_lab",
+                "--config",
+                str(config_path),
+            ],
+            "Only successful agent backtest runs",
+        ),
+        (
+            [
+                "promote",
+                "--run",
+                "agent/backtest/20260101_020000_failed_agent",
+                "--config",
+                str(config_path),
+                "--to",
+                "live",
+            ],
+            "Only promotion to paper is supported",
+        ),
+    ]
+
+    for command, expected in cases:
+        result = runner.invoke(app, command)
+        assert result.exit_code == 1
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        assert expected in combined_output
+        assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_promote_requires_streaming_before_writing_paper_config(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_project_config(config_path, streaming_enabled=False)
+    original = config_path.read_text(encoding="utf-8")
+    _write_run_summary()
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "--run",
+            "agent/backtest/20260101_010000_breakout_gpt",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert "data.streaming.enabled must be true" in combined_output
+    assert config_path.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary
- add a run-backed \quanttradeai promote --run <run_id>\ command for successful agent backtest-to-paper promotion
- update project.yaml docs, README, and roadmap to include the promotion workflow
- add integration tests for successful promotion, dry runs, unsupported targets, missing/failed runs, and streaming preconditions

## Tests
- make format
- make lint
- make test
- pre-commit hook: format, lint, test