### PR TITLE
Add canonical live agent workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 	poetry run flake8 --ignore=E501 quanttradeai/
 
 test:
-	poetry run pytest
+	poetry run python -c "import os; os.environ.setdefault('PYTEST_DISABLE_PLUGIN_AUTOLOAD', '1'); import pytest; raise SystemExit(pytest.main(['-p', 'pytest_asyncio.plugin']))"
 
 pipeline:
 	poetry run quanttradeai train -c config/model_config.yaml

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 | I want to... | Best path today | What I get |
 | --- | --- | --- |
 | Research a strategy end to end | `init` -> `validate` -> `research run` | Time-aware evaluation, backtests, metrics, run records |
-| Run a deterministic rule agent | `init --template rule-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` | A no-LLM baseline agent driven entirely by YAML thresholds |
-| Run a trained model as an agent | `init --template model-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` | One YAML-defined agent that can be backtested, promoted, and paper-run |
-| Run an LLM agent | `init --template llm-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` | Prompt-driven agent logic using project config |
-| Run a hybrid agent | `init --template hybrid` -> `research run` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` | Model signals plus LLM reasoning in one project |
+| Run a deterministic rule agent | `init --template rule-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | A YAML-only agent that can move through backtest, paper, and live with explicit promotion gates |
+| Run a trained model as an agent | `init --template model-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | One YAML-defined model agent that can be backtested, promoted, paper-run, and live-run |
+| Run an LLM agent | `init --template llm-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Prompt-driven agent logic using project config across all three modes |
+| Run a hybrid agent | `init --template hybrid` -> `research run` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Model signals plus LLM reasoning in one project, with the same YAML agent definition promoted through environments |
 | Generate a Docker Compose deployment bundle | `deploy --agent <name> --target docker-compose` | A paper-agent bundle with compose, Dockerfile, env placeholders, and resolved config |
 | Keep using the older live loop | `live-trade` with runtime YAML files | Legacy compatibility for existing setups |
 
@@ -49,6 +49,7 @@ flowchart LR
     C --> F["runs/research/..."]
     D --> G["runs/agent/backtest/..."]
     D --> H["runs/agent/paper/..."]
+    D --> I["runs/agent/live/..."]
 ```
 
 QuantTradeAI is one framework with two connected tracks:
@@ -63,16 +64,20 @@ QuantTradeAI is one framework with two connected tracks:
 | `research run` from `project.yaml` | Supported |
 | `agent run` for `rule` agents in `backtest` | Supported |
 | `agent run` for `rule` agents in `paper` | Supported |
+| `agent run` for `rule` agents in `live` | Supported |
 | `agent run` for `model` agents in `backtest` | Supported |
 | `agent run` for `model` agents in `paper` | Supported |
+| `agent run` for `model` agents in `live` | Supported |
 | `agent run` for `llm` and `hybrid` agents in `backtest` | Supported |
 | `agent run` for `llm` and `hybrid` agents in `paper` | Supported |
+| `agent run` for `llm` and `hybrid` agents in `live` | Supported |
 | Agent backtest-to-paper promotion | Supported |
+| Agent paper-to-live promotion with acknowledgement | Supported |
 | `deploy --target docker-compose` for paper agents | Supported |
-| Live promotion UX | Roadmap |
+| `live-trade` legacy runtime YAML workflow | Supported for compatibility |
 
 > [!NOTE]
-> `live-trade` still exists for legacy runtime YAML workflows. It does not read `config/project.yaml`.
+> `agent run --mode live` is the canonical live path for project-defined agents. `live-trade` still exists for legacy runtime YAML workflows and does not read `config/project.yaml`.
 
 ## Install In 2 Minutes
 
@@ -117,6 +122,8 @@ poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live rsi_reversion
+poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode live
 ```
 
 The default template wires a simple RSI threshold rule through YAML only:
@@ -135,7 +142,7 @@ agents:
 
 ### Run A Model Agent
 
-Use this if you already have a trained model artifact and want one YAML-defined agent that can run in both backtest and paper mode.
+Use this if you already have a trained model artifact and want one YAML-defined agent that can run in backtest, paper, and live mode.
 
 ```bash
 poetry run quanttradeai init --template model-agent -o config/project.yaml
@@ -146,6 +153,8 @@ poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live paper_momentum
+poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode live
 ```
 
 > [!IMPORTANT]
@@ -153,7 +162,7 @@ poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml 
 
 ### Run An LLM Agent
 
-Use this if you want prompt-driven agent logic from YAML and want to move the same agent definition from backtest into paper mode.
+Use this if you want prompt-driven agent logic from YAML and want to move the same agent definition from backtest into paper and live mode.
 
 ```bash
 poetry run quanttradeai init --template llm-agent -o config/project.yaml
@@ -161,11 +170,13 @@ poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live breakout_gpt
+poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode live
 ```
 
 ### Run A Hybrid Agent
 
-Use this if you want to combine trained model signals and LLM reasoning in one project and then run the agent in paper mode.
+Use this if you want to combine trained model signals and LLM reasoning in one project and then promote the same agent through paper and live mode.
 
 ```bash
 poetry run quanttradeai init --template hybrid -o config/project.yaml
@@ -173,6 +184,8 @@ poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live hybrid_swing_agent
+poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode live
 ```
 
 ### Deploy A Paper Agent
@@ -232,6 +245,7 @@ For the full shape, field reference, and supported agent modes, see [Project YAM
 | Research | `runs/research/<timestamp>_<project>/` | `resolved_project_config.yaml`, runtime YAML snapshots, `summary.json`, `metrics.json`, backtest artifacts |
 | Agent backtest | `runs/agent/backtest/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, backtest files |
 | Agent paper | `runs/agent/paper/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime YAML snapshots |
+| Agent live | `runs/agent/live/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime streaming/risk/position-manager YAML snapshots |
 
 This makes it easier to compare runs, audit what actually executed, and reuse winning configurations.
 
@@ -274,7 +288,8 @@ poetry run quanttradeai validate-config
 Important boundary:
 
 - `agent run --mode paper` for project-defined `model` agents compiles runtime config from `config/project.yaml`
-- `live-trade` still uses the runtime YAML files directly
+- `agent run --mode live` for project-defined `rule`, `model`, `llm`, and `hybrid` agents compiles runtime config from `config/project.yaml`
+- `live-trade` still uses the legacy runtime YAML files directly
 
 ## Development
 

--- a/docs/configuration/live-runtime-files.md
+++ b/docs/configuration/live-runtime-files.md
@@ -5,7 +5,9 @@
 - research runs
 - project-defined agent backtests
 - project-defined agent paper runs
+- project-defined agent live runs
 - agent backtest-to-paper promotion
+- agent paper-to-live promotion
 - project-agent docker-compose deployment bundles
 
 The legacy runtime YAML files still matter for:
@@ -31,13 +33,19 @@ This page explains that boundary.
 
 ## Important Boundary
 
-### Canonical Paper Agent Path
+### Canonical Project-Agent Path
 
-`quanttradeai agent run --mode paper` for project-defined agents:
+`quanttradeai agent run --mode paper|live` for project-defined agents:
 
 - reads `config/project.yaml`
-- compiles runtime model, features, backtest, and streaming YAMLs into the run directory
+- compiles runtime model, features, and streaming YAMLs into the run directory
+- compiles top-level `risk` and `position_manager` into runtime YAML snapshots for live runs
 - passes the compiled feature config into the paper runtime
+
+`quanttradeai promote` now supports:
+
+- `agent/backtest/...` -> `paper`
+- `agent/paper/...` -> `live` with `--acknowledge-live <agent_name>`
 
 ### Legacy Live Path
 
@@ -131,6 +139,8 @@ Behavior difference:
 - `backtest-model` continues without the guard if the file is missing
 - `live-trade` fails fast if the configured risk file is missing
 
+For project-defined live agents, the canonical source is now the top-level `risk` block inside `config/project.yaml`. QuantTradeAI writes that block into `runtime_risk_config.yaml` under `runs/agent/live/...`.
+
 ## `config/streaming.yaml`
 
 Used by:
@@ -138,13 +148,18 @@ Used by:
 - `live-trade`
 - direct `StreamingGateway` usage
 
-The project-agent paper path generates an equivalent runtime YAML from `data.streaming` inside `project.yaml`, but that compiled file is written into the run directory and is not intended to replace your checked-in legacy `config/streaming.yaml`.
+The project-agent paper/live path generates an equivalent runtime YAML from `data.streaming` inside `project.yaml`, but that compiled file is written into the run directory and is not intended to replace your checked-in legacy `config/streaming.yaml`.
 
 ## `config/position_manager.yaml`
 
 Used only by the legacy `live-trade` path.
 
-The current project-defined `model` paper-agent workflow runs without a separate position-manager YAML and relies on the engine's portfolio state plus run artifacts for the happy path.
+For project-defined live agents, the canonical source is now the top-level `position_manager` block inside `config/project.yaml`. QuantTradeAI writes that block into `runtime_position_manager_config.yaml` under `runs/agent/live/...`.
+
+Compatibility note:
+
+- `position_manager.risk_management` is still accepted as legacy input during validation
+- the top-level `risk` block is the canonical source for project-defined live guardrails
 
 ## Validation
 

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -7,8 +7,8 @@ It drives:
 - `quanttradeai init`
 - `quanttradeai validate`
 - `quanttradeai research run`
-- `quanttradeai agent run` for project-defined agents
-- `quanttradeai promote` for agent backtest-to-paper promotion
+- `quanttradeai agent run` for project-defined agents in `backtest`, `paper`, and `live`
+- `quanttradeai promote` for agent backtest-to-paper and paper-to-live promotion
 - `quanttradeai deploy` for docker-compose paper-agent bundles
 
 `live-trade` still uses the legacy runtime YAML files documented in [Runtime and Live Trading Configs](live-runtime-files.md).
@@ -31,6 +31,8 @@ poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live paper_momentum
+poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode live
 ```
 
 The `model-agent` template also creates a placeholder model artifact at `models/trained/aapl_daily_classifier/README.md`. Replace that directory with a real saved model before you run the agent.
@@ -43,6 +45,8 @@ poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live rsi_reversion
+poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode live
 ```
 
 ### LLM And Hybrid Agents
@@ -53,6 +57,8 @@ poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live breakout_gpt
+poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode live
 ```
 
 The `llm-agent` and `hybrid` templates also create starter prompt files under `prompts/` so validation can pass immediately.
@@ -61,10 +67,10 @@ Current support:
 
 | Agent kind | Backtest | Paper | Live |
 | --- | --- | --- | --- |
-| `model` | Yes | Yes | No |
-| `llm` | Yes | Yes | No |
-| `hybrid` | Yes | Yes | No |
-| `rule` | Yes | Yes | No |
+| `model` | Yes | Yes | Yes |
+| `llm` | Yes | Yes | Yes |
+| `hybrid` | Yes | Yes | Yes |
+| `rule` | Yes | Yes | Yes |
 
 Successful agent backtest runs can be promoted to paper mode with:
 
@@ -72,7 +78,14 @@ Successful agent backtest runs can be promoted to paper mode with:
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 ```
 
-This updates the matching agent's `mode` and `deployment.mode` to `paper`. Promotion to `live` remains future work.
+Successful agent paper runs can be promoted to live mode with:
+
+```bash
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live <agent_name>
+```
+
+Paper promotion updates the matching agent's `mode` and `deployment.mode` to `paper`.
+Live promotion updates only the matching agent's `mode` to `live`. `deployment.mode` stays unchanged because live deployment is still out of scope for the canonical workflow.
 
 Docker Compose deployment bundles can be generated with:
 
@@ -154,6 +167,30 @@ agents:
 deployment:
   target: "docker-compose"
   mode: "paper"
+
+risk:
+  drawdown_protection:
+    enabled: true
+    max_drawdown_pct: 0.1
+    warning_threshold: 0.8
+    soft_stop_threshold: 0.9
+    hard_stop_threshold: 1.0
+    emergency_stop_threshold: 1.05
+  turnover_limits:
+    daily_max: 2.0
+    weekly_max: 5.0
+    monthly_max: 12.0
+
+position_manager:
+  impact:
+    enabled: false
+    model: "linear"
+    alpha: 0.0
+    beta: 0.0
+  reconciliation:
+    intraday: "1m"
+    daily: "1d"
+  mode: "live"
 ```
 
 Rule-agent example:
@@ -224,9 +261,9 @@ When you use mapping syntax, validation checks `asset_class` against the asset c
 
 ### `data.streaming`
 
-Used by project-defined paper agents.
+Used by project-defined paper and live agents.
 
-Required when any agent is configured with `mode: paper`:
+Required when any agent is configured with `mode: paper` or `mode: live`:
 
 - `enabled: true`
 - `provider`
@@ -250,7 +287,7 @@ Optional passthrough sections:
 
 These values are compiled into the runtime streaming YAML consumed by the current gateway.
 
-Validation also enforces one important rule here: if any agent is configured with `mode: paper`, then `data.streaming.enabled` must be `true`.
+Validation enforces the same rule for both paper and live agents: if any agent is configured with `mode: paper` or `mode: live`, then `data.streaming.enabled` must be `true`.
 
 ### `features`
 
@@ -327,6 +364,13 @@ Paper mode:
 - writes `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, and `runtime_streaming_config.yaml`
 - does not emit `prompt_samples.json`
 
+Live mode:
+
+- requires the agent itself to already be configured with `mode: live`
+- rejects `--skip-validation`
+- compiles `data.streaming`, top-level `risk`, and top-level `position_manager` into runtime YAML snapshots inside the run directory
+- writes `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, `runtime_streaming_config.yaml`, `runtime_risk_config.yaml`, and `runtime_position_manager_config.yaml`
+
 #### `model` agents
 
 Required fields:
@@ -350,6 +394,13 @@ Paper mode:
 - runs the existing paper/live engine with the compiled feature config
 - writes `summary.json`, `metrics.json`, `executions.jsonl`, and `runtime_streaming_config.yaml`
 
+Live mode:
+
+- requires `mode: live` in the agent config before `quanttradeai agent run --mode live` is allowed
+- rejects `--skip-validation`
+- compiles runtime streaming, risk, and position-manager YAML snapshots from `project.yaml`
+- writes `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, `runtime_streaming_config.yaml`, `runtime_risk_config.yaml`, and `runtime_position_manager_config.yaml`
+
 #### `llm` and `hybrid` agents
 
 `llm` and `hybrid` require an `llm` block with:
@@ -370,6 +421,13 @@ Paper mode:
 - warm-starts with recent historical OHLCV before streaming begins
 - aggregates streaming messages into completed bars before invoking the agent
 - writes `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, `prompt_samples.json`, and `runtime_streaming_config.yaml`
+
+Live mode:
+
+- requires `mode: live` in the agent config before `quanttradeai agent run --mode live` is allowed
+- rejects `--skip-validation`
+- compiles runtime streaming, risk, and position-manager YAML snapshots from `project.yaml`
+- writes `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, `prompt_samples.json`, `runtime_streaming_config.yaml`, `runtime_risk_config.yaml`, and `runtime_position_manager_config.yaml`
 
 ### `deployment`
 
@@ -395,7 +453,34 @@ Behavior:
 - generated bundles include `docker-compose.yml`, `Dockerfile`, `.env.example`, `README.md`, `resolved_project_config.yaml`, and `deployment_manifest.json`
 - generated compose services run `quanttradeai agent run --agent <name> -c config/project.yaml --mode paper`
 
-Live deployment and live promotion remain future work.
+Live deployment remains future work.
+
+### `risk`
+
+Top-level live guardrails used by project-defined live agents.
+
+Canonical live usage:
+
+- `risk.drawdown_protection.enabled` must be `true`
+- `drawdown_protection` drives drawdown safety states
+- `turnover_limits` drives trade-throttling thresholds
+
+Compatibility note:
+
+- `position_manager.risk_management` is accepted as a legacy compatibility input during validation
+- the top-level `risk` block is the canonical source going forward
+
+### `position_manager`
+
+Top-level runtime settings for project-defined live execution.
+
+Used for:
+
+- execution impact settings
+- reconciliation cadence
+- runtime mode
+
+The canonical live compiler injects the top-level `risk` block into the generated live runtime position-manager YAML.
 
 ## Runtime Artifacts
 
@@ -431,6 +516,22 @@ Writes under `runs/agent/backtest/<timestamp>_<agent>/`.
 Writes under `runs/agent/paper/<timestamp>_<agent>/`.
 
 For `llm` and `hybrid` paper runs, the run directory includes both `decisions.jsonl` and `executions.jsonl` so prompt-driven decisions and actual paper executions can be audited separately.
+
+### `quanttradeai agent run --mode live`
+
+Writes under `runs/agent/live/<timestamp>_<agent>/`.
+
+Live run directories include:
+
+- `resolved_project_config.yaml`
+- `summary.json`
+- `metrics.json`
+- `decisions.jsonl`
+- `executions.jsonl`
+- `runtime_streaming_config.yaml`
+- `runtime_risk_config.yaml`
+- `runtime_position_manager_config.yaml`
+- `prompt_samples.json` for `llm` and `hybrid`
 
 ## Compatibility Notes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,8 @@ The model-agent template creates:
 
 - a canonical `config/project.yaml`
 - a placeholder model artifact directory at `models/trained/aapl_daily_classifier/`
-- a minimal `data.streaming` block for paper execution
+- a minimal `data.streaming` block
+- top-level `risk` and `position_manager` defaults for later live promotion
 
 Replace the placeholder model directory with a real trained model artifact before running the agent.
 
@@ -54,22 +55,31 @@ poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode paper
 ```
 
+### Promote The Same Agent To Live
+
+```bash
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live paper_momentum
+poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode live
+```
+
 ### Generate A Docker Compose Bundle
 
 ```bash
 poetry run quanttradeai deploy --agent paper_momentum -c config/project.yaml --target docker-compose
 ```
 
-Paper runs write standardized artifacts under `runs/agent/paper/...`, including:
+Paper and live runs write standardized artifacts under `runs/agent/paper/...` and `runs/agent/live/...`, including:
 
 - `summary.json`
 - `metrics.json`
 - `executions.jsonl`
 - compiled runtime YAML snapshots
 
+Live runs also write compiled `runtime_risk_config.yaml` and `runtime_position_manager_config.yaml`.
+
 ## Workflow 3: LLM Or Hybrid Agent
 
-LLM and hybrid agents are supported in both backtest and paper mode from `project.yaml`.
+LLM and hybrid agents are supported in backtest, paper, and live mode from `project.yaml`.
 
 ```bash
 poetry run quanttradeai init --template llm-agent -o config/project.yaml
@@ -77,6 +87,8 @@ poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live breakout_gpt
+poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode live
 ```
 
 Hybrid projects use the same pattern:
@@ -87,6 +99,8 @@ poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live hybrid_swing_agent
+poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode live
 ```
 
 Deployment bundles for project-defined paper agents are written under `reports/deployments/<agent>/<timestamp>/`.
@@ -104,7 +118,7 @@ poetry run quanttradeai live-trade -m <model_dir> -c config/model_config.yaml -s
 
 Important boundary:
 
-- project-defined `model` paper agents compile runtime config from `config/project.yaml`
+- project-defined paper and live agents compile runtime config from `config/project.yaml`
 - `live-trade` still uses the legacy runtime YAML files directly
 
 ## Where To Go Next

--- a/quanttradeai/agents/model_agent.py
+++ b/quanttradeai/agents/model_agent.py
@@ -116,6 +116,10 @@ def _initialize_model_agent_run(
         raise ValueError(
             f"Agent '{agent_name}' is kind={agent_config.get('kind')}; expected kind=model."
         )
+    if mode == "live" and str(agent_config.get("mode") or "").strip().lower() != "live":
+        raise ValueError(
+            f"Agent '{agent_name}' must be configured with mode=live before running `quanttradeai agent run --mode live`."
+        )
 
     model_cfg, features_cfg, backtest_cfg = compile_research_runtime_configs(
         project_config,

--- a/quanttradeai/agents/model_agent.py
+++ b/quanttradeai/agents/model_agent.py
@@ -26,6 +26,9 @@ from quanttradeai.streaming.live_trading import LiveTradingEngine
 from quanttradeai.trading.portfolio import PortfolioManager
 from quanttradeai.utils.config_validator import validate_project_config
 from quanttradeai.utils.project_config import (
+    compile_live_position_manager_runtime_config,
+    compile_live_risk_runtime_config,
+    compile_live_streaming_runtime_config,
     compile_paper_streaming_runtime_config,
     compile_research_runtime_configs,
 )
@@ -88,6 +91,8 @@ def _initialize_model_agent_run(
     Path,
     Path,
     Path | None,
+    Path | None,
+    Path | None,
 ]:
     validation = validate_project_config(
         config_path=project_config_path,
@@ -136,14 +141,39 @@ def _initialize_model_agent_run(
     summary["artifacts"]["runtime_backtest_config"] = str(runtime_backtest_path)
 
     runtime_streaming_path: Path | None = None
-    if mode == "paper":
-        streaming_cfg = compile_paper_streaming_runtime_config(project_config)
+    runtime_risk_path: Path | None = None
+    runtime_position_manager_path: Path | None = None
+    if mode in {"paper", "live"}:
+        if mode == "paper":
+            streaming_cfg = compile_paper_streaming_runtime_config(project_config)
+        else:
+            streaming_cfg = compile_live_streaming_runtime_config(project_config)
         runtime_streaming_path = run_dir / "runtime_streaming_config.yaml"
         runtime_streaming_path.write_text(
             yaml.safe_dump(streaming_cfg, sort_keys=False),
             encoding="utf-8",
         )
         summary["artifacts"]["runtime_streaming_config"] = str(runtime_streaming_path)
+    if mode == "live":
+        runtime_risk_cfg = compile_live_risk_runtime_config(project_config)
+        runtime_risk_path = run_dir / "runtime_risk_config.yaml"
+        runtime_risk_path.write_text(
+            yaml.safe_dump(runtime_risk_cfg, sort_keys=False),
+            encoding="utf-8",
+        )
+        summary["artifacts"]["runtime_risk_config"] = str(runtime_risk_path)
+
+        runtime_position_manager_cfg = compile_live_position_manager_runtime_config(
+            project_config
+        )
+        runtime_position_manager_path = run_dir / "runtime_position_manager_config.yaml"
+        runtime_position_manager_path.write_text(
+            yaml.safe_dump(runtime_position_manager_cfg, sort_keys=False),
+            encoding="utf-8",
+        )
+        summary["artifacts"]["runtime_position_manager_config"] = str(
+            runtime_position_manager_path
+        )
 
     return (
         project_config,
@@ -153,6 +183,8 @@ def _initialize_model_agent_run(
         runtime_features_path,
         runtime_backtest_path,
         runtime_streaming_path,
+        runtime_risk_path,
+        runtime_position_manager_path,
     )
 
 
@@ -228,6 +260,8 @@ def run_model_agent_backtest(
             runtime_features_path,
             runtime_backtest_path,
             _runtime_streaming_path,
+            _runtime_risk_path,
+            _runtime_position_manager_path,
         ) = _initialize_model_agent_run(
             run_dir=run_dir,
             summary=summary,
@@ -411,7 +445,7 @@ def run_model_agent_backtest(
         raise
 
 
-def _paper_metrics(engine: LiveTradingEngine) -> dict[str, Any]:
+def _streaming_metrics(engine: LiveTradingEngine) -> dict[str, Any]:
     positions: dict[str, Any] = {}
     unrealized_pnl = 0.0
     for symbol, position in engine.portfolio.positions.items():
@@ -431,7 +465,7 @@ def _paper_metrics(engine: LiveTradingEngine) -> dict[str, Any]:
         }
 
     portfolio_value = engine.portfolio.portfolio_value
-    return {
+    payload = {
         "status": "available",
         "execution_count": len(engine.execution_log),
         "realized_pnl": _safe_float(engine.portfolio.realized_pnl, 0.0),
@@ -441,6 +475,42 @@ def _paper_metrics(engine: LiveTradingEngine) -> dict[str, Any]:
         "portfolio_value": portfolio_value,
         "open_positions": positions,
     }
+    risk_manager = getattr(engine, "risk_manager", None)
+    if risk_manager is not None:
+        try:
+            payload["risk_metrics"] = dict(risk_manager.get_risk_metrics() or {})
+        except Exception:  # pragma: no cover - defensive
+            payload["risk_metrics"] = {}
+        drawdown_guard = getattr(risk_manager, "drawdown_guard", None)
+        if drawdown_guard is not None:
+            try:
+                payload["risk_status"] = drawdown_guard.check_drawdown_limits()
+            except Exception:  # pragma: no cover - defensive
+                pass
+    return payload
+
+
+def _model_decision_records_from_engine(
+    engine: LiveTradingEngine,
+) -> list[dict[str, Any]]:
+    decision_log = getattr(engine, "decision_log", None)
+    if isinstance(decision_log, list) and decision_log:
+        return list(decision_log)
+
+    decisions: list[dict[str, Any]] = []
+    for execution in list(getattr(engine, "execution_log", [])):
+        signal_value = int(execution.get("signal", 0))
+        decisions.append(
+            {
+                "symbol": execution.get("symbol"),
+                "timestamp": execution.get("timestamp"),
+                "action": signal_to_action(signal_value),
+                "target_position": signal_value,
+                "signal": signal_value,
+                "source": "model",
+            }
+        )
+    return decisions
 
 
 def run_model_agent_paper(
@@ -450,7 +520,36 @@ def run_model_agent_paper(
 ) -> dict[str, Any]:
     """Run a model agent in paper mode using the live trading engine."""
 
-    run_dir, summary = _start_model_agent_run(agent_name=agent_name, mode="paper")
+    return _run_model_agent_streaming(
+        project_config_path=project_config_path,
+        agent_name=agent_name,
+        mode="paper",
+    )
+
+
+def run_model_agent_live(
+    *,
+    project_config_path: str = "config/project.yaml",
+    agent_name: str,
+) -> dict[str, Any]:
+    """Run a model agent in live mode using the live trading engine."""
+
+    return _run_model_agent_streaming(
+        project_config_path=project_config_path,
+        agent_name=agent_name,
+        mode="live",
+    )
+
+
+def _run_model_agent_streaming(
+    *,
+    project_config_path: str,
+    agent_name: str,
+    mode: str,
+) -> dict[str, Any]:
+    """Run a model agent in paper or live mode using the live trading engine."""
+
+    run_dir, summary = _start_model_agent_run(agent_name=agent_name, mode=mode)
 
     try:
         (
@@ -461,15 +560,19 @@ def run_model_agent_paper(
             runtime_features_path,
             _runtime_backtest_path,
             runtime_streaming_path,
+            runtime_risk_path,
+            runtime_position_manager_path,
         ) = _initialize_model_agent_run(
             run_dir=run_dir,
             summary=summary,
             project_config_path=project_config_path,
             agent_name=agent_name,
-            mode="paper",
+            mode=mode,
         )
         if runtime_streaming_path is None:
-            raise ValueError("Paper mode requires a compiled runtime streaming config.")
+            raise ValueError(
+                f"{mode.capitalize()} mode requires a compiled runtime streaming config."
+            )
 
         model_path = resolve_project_path(
             project_config_path,
@@ -487,8 +590,12 @@ def run_model_agent_paper(
             model_path=str(model_path),
             features_config=str(runtime_features_path),
             streaming_config=str(runtime_streaming_path),
-            risk_config=None,
-            position_manager_config=None,
+            risk_config=str(runtime_risk_path) if runtime_risk_path else None,
+            position_manager_config=(
+                str(runtime_position_manager_path)
+                if runtime_position_manager_path
+                else None
+            ),
             initial_capital=initial_capital,
             max_risk_per_trade=max_risk_per_trade,
             max_portfolio_risk=max_portfolio_risk,
@@ -496,8 +603,12 @@ def run_model_agent_paper(
         )
         asyncio.run(engine.start())
 
+        decision_records = _model_decision_records_from_engine(engine)
+        if decision_records:
+            _write_jsonl(run_dir / "decisions.jsonl", decision_records)
         _write_jsonl(run_dir / "executions.jsonl", list(engine.execution_log))
-        metrics_payload = _paper_metrics(engine)
+        metrics_payload = _streaming_metrics(engine)
+        metrics_payload["decision_count"] = len(decision_records)
         _write_json(run_dir / "metrics.json", metrics_payload)
 
         artifacts = {
@@ -505,6 +616,8 @@ def run_model_agent_paper(
             "metrics": str(run_dir / "metrics.json"),
             "executions": str(run_dir / "executions.jsonl"),
         }
+        if decision_records:
+            artifacts["decisions"] = str(run_dir / "decisions.jsonl")
         summary.update(
             {
                 "status": "success",
@@ -517,6 +630,7 @@ def run_model_agent_paper(
                         .get("symbols", [])
                     )
                 ),
+                "decision_count": len(decision_records),
                 "execution_count": len(engine.execution_log),
                 "artifacts": artifacts,
                 "metrics": metrics_payload,
@@ -527,7 +641,7 @@ def run_model_agent_paper(
             summary,
             run_dir=run_dir,
             run_type="agent",
-            mode="paper",
+            mode=mode,
             name=agent_name,
         )
         _write_json(run_dir / "summary.json", summary)
@@ -541,7 +655,7 @@ def run_model_agent_paper(
             summary,
             run_dir=run_dir,
             run_type="agent",
-            mode="paper",
+            mode=mode,
             name=agent_name,
         )
         _write_json(run_dir / "summary.json", summary)

--- a/quanttradeai/agents/paper.py
+++ b/quanttradeai/agents/paper.py
@@ -19,8 +19,20 @@ from quanttradeai.data.loader import DataLoader
 from quanttradeai.data.processor import DataProcessor
 from quanttradeai.streaming.gateway import StreamingGateway
 from quanttradeai.trading.portfolio import PortfolioManager
+from quanttradeai.trading.position_manager import (
+    PositionManager as RealtimePositionManager,
+)
+from quanttradeai.trading.drawdown_guard import DrawdownGuard
+from quanttradeai.trading.risk_manager import RiskManager
 from quanttradeai.utils.config_validator import validate_project_config
+from quanttradeai.utils.config_schemas import (
+    PositionManagerConfig,
+    RiskManagementConfig,
+)
 from quanttradeai.utils.project_config import (
+    compile_live_position_manager_runtime_config,
+    compile_live_risk_runtime_config,
+    compile_live_streaming_runtime_config,
     compile_paper_streaming_runtime_config,
     compile_research_runtime_configs,
 )
@@ -73,6 +85,32 @@ def _safe_float(value: Any, default: float) -> float:
         return float(value)
     except (TypeError, ValueError):
         return default
+
+
+def _load_risk_guard(config_path: str | None) -> DrawdownGuard | None:
+    if not config_path:
+        return None
+    path = Path(config_path)
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    cfg = RiskManagementConfig(**raw.get("risk_management", raw))
+    if cfg.drawdown_protection.enabled:
+        return DrawdownGuard(cfg)
+    return None
+
+
+def _load_position_manager(
+    config_path: str | None,
+    *,
+    cash: float,
+) -> RealtimePositionManager | None:
+    if not config_path:
+        return None
+    path = Path(config_path)
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    cfg = PositionManagerConfig(**raw.get("position_manager", raw))
+    manager = RealtimePositionManager.from_config(cfg)
+    manager.cash = cash
+    return manager
 
 
 def _copy_artifact(source: str | Path, destination: Path) -> str:
@@ -177,9 +215,11 @@ def _build_paper_runtime_model_config(
     return runtime_model_cfg
 
 
-def _paper_metrics(
+def _streaming_metrics(
     portfolio: PortfolioManager,
     execution_log: list[dict[str, Any]],
+    *,
+    risk_manager: RiskManager | None = None,
 ) -> dict[str, Any]:
     positions: dict[str, Any] = {}
     unrealized_pnl = 0.0
@@ -200,7 +240,7 @@ def _paper_metrics(
         }
 
     portfolio_value = portfolio.portfolio_value
-    return {
+    payload = {
         "status": "available",
         "execution_count": len(execution_log),
         "realized_pnl": _safe_float(portfolio.realized_pnl, 0.0),
@@ -210,6 +250,12 @@ def _paper_metrics(
         "portfolio_value": portfolio_value,
         "open_positions": positions,
     }
+    if risk_manager is not None:
+        payload["risk_metrics"] = dict(risk_manager.get_risk_metrics() or {})
+        drawdown_guard = getattr(risk_manager, "drawdown_guard", None)
+        if drawdown_guard is not None:
+            payload["risk_status"] = drawdown_guard.check_drawdown_limits()
+    return payload
 
 
 @dataclass(slots=True)
@@ -276,7 +322,7 @@ class OpenBar:
 
 @dataclass
 class PaperAgentEngine:
-    """Run a rule, LLM, or hybrid agent in paper mode from streaming bars."""
+    """Run a rule, LLM, or hybrid agent in paper or live mode from streaming bars."""
 
     project_config_path: str
     agent_config: dict[str, Any]
@@ -284,6 +330,9 @@ class PaperAgentEngine:
     runtime_features_config: str
     runtime_streaming_config: str
     feature_definitions: list[dict[str, Any]]
+    mode: str = "paper"
+    runtime_risk_config: str | None = None
+    runtime_position_manager_config: str | None = None
     model_signal_runtimes: list[ModelSignalRuntime] = field(default_factory=list)
     gateway: StreamingGateway | None = None
     data_loader: DataLoader | None = None
@@ -317,10 +366,22 @@ class PaperAgentEngine:
             "llm",
             "hybrid",
         }
+        risk_manager = None
+        if self.mode == "live":
+            drawdown_guard = _load_risk_guard(self.runtime_risk_config)
+            risk_manager = RiskManager(drawdown_guard=drawdown_guard)
+            self.position_manager = _load_position_manager(
+                self.runtime_position_manager_config,
+                cash=self.initial_capital,
+            )
+        else:
+            self.position_manager = None
+        self.risk_manager = risk_manager
         self.portfolio = PortfolioManager(
             capital=self.initial_capital,
             max_risk_per_trade=self.max_risk_per_trade,
             max_portfolio_risk=self.max_portfolio_risk,
+            risk_manager=self.risk_manager,
         )
         with open(self.runtime_model_config, "r", encoding="utf-8") as handle:
             runtime_model = yaml.safe_load(handle) or {}
@@ -437,9 +498,24 @@ class PaperAgentEngine:
         volume_f = _safe_float(volume, default=0.0)
         return open_f, high_f, low_f, close_f, volume_f
 
-    def _mark_to_market(self, symbol: str, price: float) -> None:
+    def _mark_to_market(
+        self,
+        symbol: str,
+        price: float,
+        *,
+        timestamp: pd.Timestamp | None = None,
+    ) -> None:
         if symbol in self.portfolio.positions:
             self.portfolio.positions[symbol]["price"] = price
+        if self.risk_manager is not None:
+            self.risk_manager.update(
+                self.portfolio.portfolio_value,
+                (timestamp or pd.Timestamp(datetime.now(timezone.utc))).to_pydatetime(),
+            )
+
+    def _sync_position_manager(self) -> None:
+        if self.position_manager is not None:
+            self.position_manager.cash = self.portfolio.cash
 
     def _append_history(self, symbol: str, frame: pd.DataFrame) -> None:
         history = self._history.get(symbol)
@@ -576,6 +652,14 @@ class PaperAgentEngine:
                     stop_loss_pct=self.stop_loss_pct,
                 )
                 if qty > 0:
+                    if self.position_manager is not None:
+                        self.position_manager.open_position(
+                            symbol,
+                            qty,
+                            price,
+                            timestamp=timestamp.to_pydatetime(),
+                        )
+                        self._sync_position_manager()
                     execution_status = "executed"
                     execution_payload = {
                         "action": "buy",
@@ -594,6 +678,13 @@ class PaperAgentEngine:
             else:
                 qty = self.portfolio.close_position(symbol, price)
                 if qty > 0:
+                    if self.position_manager is not None:
+                        self.position_manager.close_position(
+                            symbol,
+                            price,
+                            timestamp=timestamp.to_pydatetime(),
+                        )
+                        self._sync_position_manager()
                     execution_status = "executed"
                     execution_payload = {
                         "action": "sell",
@@ -607,7 +698,7 @@ class PaperAgentEngine:
                 else:
                     execution_status = "blocked"
 
-        self._mark_to_market(symbol, price)
+        self._mark_to_market(symbol, price, timestamp=timestamp)
         position_after = 1 if symbol in self.portfolio.positions else 0
         state = self._states.setdefault(symbol, AgentSimulationState())
         state.target_position = position_after
@@ -712,7 +803,7 @@ class PaperAgentEngine:
                 if close <= 0:
                     continue
 
-                self._mark_to_market(symbol, close)
+                self._mark_to_market(symbol, close, timestamp=timestamp)
                 completed = self._update_open_bar(
                     symbol=symbol,
                     timestamp=timestamp,
@@ -730,6 +821,7 @@ class PaperAgentEngine:
                 self._mark_to_market(
                     symbol,
                     _safe_float(frame["Close"].iloc[-1], close),
+                    timestamp=completed_timestamp,
                 )
                 self._process_completed_bar(
                     symbol=symbol,
@@ -766,10 +858,39 @@ def run_agent_paper(
 ) -> dict[str, Any]:
     """Run a rule, LLM, or hybrid agent in paper mode using streaming input."""
 
+    return _run_agent_streaming(
+        project_config_path=project_config_path,
+        agent_name=agent_name,
+        mode="paper",
+    )
+
+
+def run_agent_live(
+    *,
+    project_config_path: str = "config/project.yaml",
+    agent_name: str,
+) -> dict[str, Any]:
+    """Run a rule, LLM, or hybrid agent in live mode using streaming input."""
+
+    return _run_agent_streaming(
+        project_config_path=project_config_path,
+        agent_name=agent_name,
+        mode="live",
+    )
+
+
+def _run_agent_streaming(
+    *,
+    project_config_path: str,
+    agent_name: str,
+    mode: str,
+) -> dict[str, Any]:
+    """Run a rule, LLM, or hybrid agent in paper or live mode using streaming input."""
+
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     run_dir, run_id = create_run_dir(
         run_type="agent",
-        mode="paper",
+        mode=mode,
         name=agent_name,
         timestamp=timestamp,
     )
@@ -785,7 +906,7 @@ def run_agent_paper(
         summary,
         run_dir=run_dir,
         run_type="agent",
-        mode="paper",
+        mode=mode,
         name=agent_name,
     )
     summary["run_id"] = run_id
@@ -822,6 +943,13 @@ def run_agent_paper(
             raise ValueError(
                 f"Agent '{agent_name}' is kind={agent_config.get('kind')}; expected kind=rule, kind=llm, or kind=hybrid."
             )
+        if (
+            mode == "live"
+            and str(agent_config.get("mode") or "").strip().lower() != "live"
+        ):
+            raise ValueError(
+                f"Agent '{agent_name}' must be configured with mode=live before running `quanttradeai agent run --mode live`."
+            )
 
         model_cfg, features_cfg, _ = compile_research_runtime_configs(
             project_config,
@@ -831,6 +959,8 @@ def run_agent_paper(
         runtime_model_path = run_dir / "runtime_model_config.yaml"
         runtime_features_path = run_dir / "runtime_features_config.yaml"
         runtime_streaming_path = run_dir / "runtime_streaming_config.yaml"
+        runtime_risk_path: Path | None = None
+        runtime_position_manager_path: Path | None = None
         runtime_model_path.write_text(
             yaml.safe_dump(runtime_model_cfg, sort_keys=False),
             encoding="utf-8",
@@ -839,7 +969,14 @@ def run_agent_paper(
             yaml.safe_dump(features_cfg, sort_keys=False),
             encoding="utf-8",
         )
-        runtime_streaming_cfg = compile_paper_streaming_runtime_config(project_config)
+        if mode == "paper":
+            runtime_streaming_cfg = compile_paper_streaming_runtime_config(
+                project_config
+            )
+        else:
+            runtime_streaming_cfg = compile_live_streaming_runtime_config(
+                project_config
+            )
         runtime_streaming_path.write_text(
             yaml.safe_dump(runtime_streaming_cfg, sort_keys=False),
             encoding="utf-8",
@@ -847,6 +984,28 @@ def run_agent_paper(
         summary["artifacts"]["runtime_model_config"] = str(runtime_model_path)
         summary["artifacts"]["runtime_features_config"] = str(runtime_features_path)
         summary["artifacts"]["runtime_streaming_config"] = str(runtime_streaming_path)
+        if mode == "live":
+            runtime_risk_cfg = compile_live_risk_runtime_config(project_config)
+            runtime_risk_path = run_dir / "runtime_risk_config.yaml"
+            runtime_risk_path.write_text(
+                yaml.safe_dump(runtime_risk_cfg, sort_keys=False),
+                encoding="utf-8",
+            )
+            summary["artifacts"]["runtime_risk_config"] = str(runtime_risk_path)
+
+            runtime_position_manager_cfg = compile_live_position_manager_runtime_config(
+                project_config
+            )
+            runtime_position_manager_path = (
+                run_dir / "runtime_position_manager_config.yaml"
+            )
+            runtime_position_manager_path.write_text(
+                yaml.safe_dump(runtime_position_manager_cfg, sort_keys=False),
+                encoding="utf-8",
+            )
+            summary["artifacts"]["runtime_position_manager_config"] = str(
+                runtime_position_manager_path
+            )
 
         feature_definitions = list(
             (project_config.get("features") or {}).get("definitions") or []
@@ -886,6 +1045,15 @@ def run_agent_paper(
             runtime_features_config=str(runtime_features_path),
             runtime_streaming_config=str(runtime_streaming_path),
             feature_definitions=feature_definitions,
+            mode=mode,
+            runtime_risk_config=(
+                str(runtime_risk_path) if runtime_risk_path is not None else None
+            ),
+            runtime_position_manager_config=(
+                str(runtime_position_manager_path)
+                if runtime_position_manager_path is not None
+                else None
+            ),
             model_signal_runtimes=model_signal_runtimes,
             initial_capital=initial_capital,
             max_risk_per_trade=max_risk_per_trade,
@@ -897,7 +1065,11 @@ def run_agent_paper(
 
         _write_jsonl(run_dir / "decisions.jsonl", engine.decision_log)
         _write_jsonl(run_dir / "executions.jsonl", engine.execution_log)
-        metrics_payload = _paper_metrics(engine.portfolio, engine.execution_log)
+        metrics_payload = _streaming_metrics(
+            engine.portfolio,
+            engine.execution_log,
+            risk_manager=engine.risk_manager,
+        )
         metrics_payload["decision_count"] = len(engine.decision_log)
         _write_json(run_dir / "metrics.json", metrics_payload)
 
@@ -930,7 +1102,7 @@ def run_agent_paper(
             summary,
             run_dir=run_dir,
             run_type="agent",
-            mode="paper",
+            mode=mode,
             name=agent_name,
         )
         _write_json(run_dir / "summary.json", summary)
@@ -944,7 +1116,7 @@ def run_agent_paper(
             summary,
             run_dir=run_dir,
             run_type="agent",
-            mode="paper",
+            mode=mode,
             name=agent_name,
         )
         _write_json(run_dir / "summary.json", summary)

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -164,6 +164,32 @@ PROJECT_TEMPLATES = {
             "evaluation": {},
             "backtest": {},
         },
+        "risk": {
+            "drawdown_protection": {
+                "enabled": True,
+                "max_drawdown_pct": 0.15,
+                "warning_threshold": 0.8,
+                "soft_stop_threshold": 0.9,
+                "hard_stop_threshold": 1.0,
+                "emergency_stop_threshold": 1.1,
+                "lookback_periods": [1, 7, 30],
+            },
+            "turnover_limits": {
+                "daily_max": 2.0,
+                "weekly_max": 5.0,
+                "monthly_max": 15.0,
+            },
+        },
+        "position_manager": {
+            "impact": {
+                "enabled": False,
+                "model": "linear",
+                "alpha": 0.0,
+                "beta": 0.0,
+            },
+            "reconciliation": {"intraday": "1m", "daily": "1d"},
+            "mode": "live",
+        },
         "agents": [
             {
                 "name": "breakout_gpt",
@@ -234,6 +260,32 @@ PROJECT_TEMPLATES = {
             },
             "evaluation": {"split": "time_aware", "use_configured_test_window": True},
             "backtest": {"costs": {"enabled": True, "bps": 5}},
+        },
+        "risk": {
+            "drawdown_protection": {
+                "enabled": True,
+                "max_drawdown_pct": 0.15,
+                "warning_threshold": 0.8,
+                "soft_stop_threshold": 0.9,
+                "hard_stop_threshold": 1.0,
+                "emergency_stop_threshold": 1.1,
+                "lookback_periods": [1, 7, 30],
+            },
+            "turnover_limits": {
+                "daily_max": 2.0,
+                "weekly_max": 5.0,
+                "monthly_max": 15.0,
+            },
+        },
+        "position_manager": {
+            "impact": {
+                "enabled": False,
+                "model": "linear",
+                "alpha": 0.0,
+                "beta": 0.0,
+            },
+            "reconciliation": {"intraday": "1m", "daily": "1d"},
+            "mode": "live",
         },
         "agents": [
             {
@@ -306,6 +358,32 @@ PROJECT_TEMPLATES = {
             "evaluation": {"split": "time_aware", "use_configured_test_window": True},
             "backtest": {"costs": {"enabled": True, "bps": 5}},
         },
+        "risk": {
+            "drawdown_protection": {
+                "enabled": True,
+                "max_drawdown_pct": 0.15,
+                "warning_threshold": 0.8,
+                "soft_stop_threshold": 0.9,
+                "hard_stop_threshold": 1.0,
+                "emergency_stop_threshold": 1.1,
+                "lookback_periods": [1, 7, 30],
+            },
+            "turnover_limits": {
+                "daily_max": 2.0,
+                "weekly_max": 5.0,
+                "monthly_max": 15.0,
+            },
+        },
+        "position_manager": {
+            "impact": {
+                "enabled": False,
+                "model": "linear",
+                "alpha": 0.0,
+                "beta": 0.0,
+            },
+            "reconciliation": {"intraday": "1m", "daily": "1d"},
+            "mode": "live",
+        },
         "agents": [
             {
                 "name": "paper_momentum",
@@ -362,6 +440,32 @@ PROJECT_TEMPLATES = {
             "model": {},
             "evaluation": {},
             "backtest": {},
+        },
+        "risk": {
+            "drawdown_protection": {
+                "enabled": True,
+                "max_drawdown_pct": 0.15,
+                "warning_threshold": 0.8,
+                "soft_stop_threshold": 0.9,
+                "hard_stop_threshold": 1.0,
+                "emergency_stop_threshold": 1.1,
+                "lookback_periods": [1, 7, 30],
+            },
+            "turnover_limits": {
+                "daily_max": 2.0,
+                "weekly_max": 5.0,
+                "monthly_max": 15.0,
+            },
+        },
+        "position_manager": {
+            "impact": {
+                "enabled": False,
+                "model": "linear",
+                "alpha": 0.0,
+                "beta": 0.0,
+            },
+            "reconciliation": {"intraday": "1m", "daily": "1d"},
+            "mode": "live",
         },
         "agents": [
             {
@@ -1118,15 +1222,20 @@ def cmd_promote(
     target: str = typer.Option(
         "paper",
         "--to",
-        help="Target mode. Only paper is supported in this release.",
+        help="Target mode. Supported targets are paper and live.",
     ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
         help="Show the proposed promotion without writing project.yaml",
     ),
+    acknowledge_live: Optional[str] = typer.Option(
+        None,
+        "--acknowledge-live",
+        help="Required for --to live. Must exactly match the agent name being promoted.",
+    ),
 ):
-    """Promote a successful agent backtest run to paper mode."""
+    """Promote a successful agent run to the next supported mode."""
 
     from .utils.promotion import promote_agent_run
 
@@ -1136,6 +1245,7 @@ def cmd_promote(
             config_path=config,
             target_mode=target,
             dry_run=dry_run,
+            acknowledge_live=acknowledge_live,
         )
     except Exception as exc:
         typer.echo(f"Promotion failed: {exc}", err=True)
@@ -1201,7 +1311,7 @@ def cmd_agent_run(
     mode: str = typer.Option(
         "backtest",
         "--mode",
-        help="Execution mode. backtest and paper are implemented; live remains future work.",
+        help="Execution mode. Supported modes are backtest, paper, and live.",
     ),
     skip_validation: bool = typer.Option(
         False,
@@ -1209,11 +1319,15 @@ def cmd_agent_run(
         help="Skip data-quality validation before backtesting",
     ),
 ):
-    """Run a first-class project agent in backtest or paper mode."""
+    """Run a first-class project agent in backtest, paper, or live mode."""
 
     from .agents.backtest import run_agent_backtest
-    from .agents.model_agent import run_model_agent_backtest, run_model_agent_paper
-    from .agents.paper import run_agent_paper
+    from .agents.model_agent import (
+        run_model_agent_backtest,
+        run_model_agent_live,
+        run_model_agent_paper,
+    )
+    from .agents.paper import run_agent_live, run_agent_paper
 
     try:
         loaded_project = load_project_config(config_path=config)
@@ -1229,7 +1343,16 @@ def cmd_agent_run(
             raise ValueError(f"Agent '{agent}' not found in project config.")
 
         configured_mode = str(agent_config.get("mode") or "").strip().lower()
-        if configured_mode and configured_mode != mode:
+        if mode == "live":
+            if skip_validation:
+                raise ValueError(
+                    "--skip-validation is not supported for live agent runs."
+                )
+            if configured_mode != "live":
+                raise ValueError(
+                    f"Agent '{agent}' must be configured with mode=live before running `quanttradeai agent run --mode live`."
+                )
+        elif configured_mode and configured_mode != mode:
             typer.echo(
                 f"Warning: agent '{agent}' is configured with mode={configured_mode} but CLI requested mode={mode}; continuing with CLI mode.",
                 err=True,
@@ -1253,9 +1376,14 @@ def cmd_agent_run(
                     project_config_path=config,
                     agent_name=agent,
                 )
+            elif mode == "live":
+                summary = run_model_agent_live(
+                    project_config_path=config,
+                    agent_name=agent,
+                )
             else:
                 raise ValueError(
-                    "Model agents currently support only --mode backtest or --mode paper."
+                    "Model agents currently support only --mode backtest, --mode paper, or --mode live."
                 )
         elif agent_kind in {"llm", "hybrid", "rule"}:
             if mode == "backtest":
@@ -1275,9 +1403,14 @@ def cmd_agent_run(
                     project_config_path=config,
                     agent_name=agent,
                 )
+            elif mode == "live":
+                summary = run_agent_live(
+                    project_config_path=config,
+                    agent_name=agent,
+                )
             else:
                 raise ValueError(
-                    "Rule, LLM, and hybrid agents currently support only --mode backtest or --mode paper. Live remains future work."
+                    "Rule, LLM, and hybrid agents currently support only --mode backtest, --mode paper, or --mode live."
                 )
         else:
             raise ValueError(f"Unsupported agent kind: {agent_kind}")

--- a/quanttradeai/streaming/__init__.py
+++ b/quanttradeai/streaming/__init__.py
@@ -1,29 +1,37 @@
-"""Streaming infrastructure package."""
+"""Streaming infrastructure package.
 
-from .gateway import StreamingGateway
-from .auth_manager import AuthManager
-from .rate_limiter import AdaptiveRateLimiter
-from .connection_pool import ConnectionPool
-from .monitoring import StreamingHealthMonitor
-from .providers import (
-    ProviderConfigValidator,
-    ProviderDiscovery,
-    ProviderHealthMonitor,
-    ProviderRegistry,
-    StreamingProviderAdapter,
-)
-from .live_trading import LiveTradingEngine
+Keep package imports lightweight so callers can import specific submodules
+without eagerly loading the full streaming stack.
+"""
 
-__all__ = [
-    "StreamingGateway",
-    "AuthManager",
-    "AdaptiveRateLimiter",
-    "ConnectionPool",
-    "StreamingHealthMonitor",
-    "ProviderConfigValidator",
-    "ProviderDiscovery",
-    "ProviderHealthMonitor",
-    "ProviderRegistry",
-    "StreamingProviderAdapter",
-    "LiveTradingEngine",
-]
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+
+_EXPORTS = {
+    "StreamingGateway": (".gateway", "StreamingGateway"),
+    "AuthManager": (".auth_manager", "AuthManager"),
+    "AdaptiveRateLimiter": (".rate_limiter", "AdaptiveRateLimiter"),
+    "ConnectionPool": (".connection_pool", "ConnectionPool"),
+    "StreamingHealthMonitor": (".monitoring", "StreamingHealthMonitor"),
+    "ProviderConfigValidator": (".providers", "ProviderConfigValidator"),
+    "ProviderDiscovery": (".providers", "ProviderDiscovery"),
+    "ProviderHealthMonitor": (".providers", "ProviderHealthMonitor"),
+    "ProviderRegistry": (".providers", "ProviderRegistry"),
+    "StreamingProviderAdapter": (".providers", "StreamingProviderAdapter"),
+    "LiveTradingEngine": (".live_trading", "LiveTradingEngine"),
+}
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attr_name = _EXPORTS[name]
+    module = import_module(module_name, __name__)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/quanttradeai/streaming/live_trading.py
+++ b/quanttradeai/streaming/live_trading.py
@@ -36,6 +36,16 @@ from quanttradeai.main import _load_feature_preprocessor
 ExecutionHook = Callable[[dict], None]
 
 
+def _signal_to_action(signal: int | None) -> str:
+    if signal is None:
+        return "hold"
+    if signal > 0:
+        return "buy"
+    if signal < 0:
+        return "sell"
+    return "hold"
+
+
 def _load_risk_guard(risk_config: str | None) -> DrawdownGuard | None:
     if not risk_config:
         return None
@@ -100,6 +110,7 @@ class LiveTradingEngine:
     _history: Dict[str, pd.DataFrame] = field(default_factory=dict, init=False)
     _consumer: asyncio.Task | None = field(default=None, init=False)
     execution_log: list[dict] = field(default_factory=list, init=False)
+    decision_log: list[dict] = field(default_factory=list, init=False)
     feature_preprocessor: object | None = field(default=None, init=False)
 
     def __post_init__(self) -> None:
@@ -420,6 +431,15 @@ class LiveTradingEngine:
                 signal = self._predict_signal(features)
                 if signal is None:
                     continue
+                self.decision_log.append(
+                    {
+                        "symbol": symbol,
+                        "timestamp": timestamp,
+                        "signal": int(signal),
+                        "action": _signal_to_action(int(signal)),
+                        "source": "model",
+                    }
+                )
                 self._handle_signal(symbol, price, signal, timestamp)
                 self._mark_to_market(symbol, price, timestamp)
             except Exception as exc:  # pragma: no cover - runtime guard

--- a/quanttradeai/trading/__init__.py
+++ b/quanttradeai/trading/__init__.py
@@ -1,30 +1,28 @@
-"""Trading utilities.
+"""Trading helpers exposed at the package level."""
 
-Expose portfolio management and risk helper functions.
+from __future__ import annotations
 
-Public API:
-    - :class:`PortfolioManager`
-    - :func:`apply_stop_loss_take_profit`
-    - :func:`position_size`
+from importlib import import_module
+from typing import Any
 
-Quick Start:
-    ```python
-    from quanttradeai.trading import PortfolioManager
-    pm = PortfolioManager(100000)
-    ```
-"""
 
-from .portfolio import PortfolioManager
-from .position_manager import PositionManager
-from .risk import apply_stop_loss_take_profit, position_size
-from .drawdown_guard import DrawdownGuard
-from .risk_manager import RiskManager
+_EXPORTS = {
+    "PortfolioManager": (".portfolio", "PortfolioManager"),
+    "PositionManager": (".position_manager", "PositionManager"),
+    "apply_stop_loss_take_profit": (".risk", "apply_stop_loss_take_profit"),
+    "position_size": (".risk", "position_size"),
+    "DrawdownGuard": (".drawdown_guard", "DrawdownGuard"),
+    "RiskManager": (".risk_manager", "RiskManager"),
+}
 
-__all__ = [
-    "PortfolioManager",
-    "PositionManager",
-    "apply_stop_loss_take_profit",
-    "position_size",
-    "DrawdownGuard",
-    "RiskManager",
-]
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attr_name = _EXPORTS[name]
+    module = import_module(module_name, __name__)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -514,6 +514,14 @@ class PositionManagerConfig(BaseModel):
     mode: Literal["paper", "live"] = "paper"
 
 
+class ProjectPositionManagerSection(BaseModel):
+    """Canonical position-manager settings for project-defined live agents."""
+
+    impact: MarketImpactConfig = MarketImpactConfig()
+    reconciliation: Dict[str, str] = {"intraday": "1m", "daily": "1d"}
+    mode: Literal["paper", "live"] = "live"
+
+
 class ProjectSection(BaseModel):
     name: str
     profile: str
@@ -710,14 +718,33 @@ class ProjectConfigSchema(BaseModel):
     research: ProjectResearchSection
     agents: List[ProjectAgentConfig]
     deployment: ProjectDeploymentSection
+    risk: Optional[RiskManagementConfig] = None
+    position_manager: Optional[ProjectPositionManagerSection] = None
 
     @model_validator(mode="after")
-    def validate_paper_streaming_requirements(self) -> "ProjectConfigSchema":
-        requires_streaming = any(agent.mode == "paper" for agent in self.agents)
+    def validate_agent_runtime_requirements(self) -> "ProjectConfigSchema":
+        requires_streaming = any(
+            agent.mode in {"paper", "live"} for agent in self.agents
+        )
         if requires_streaming and (
             self.data.streaming is None or not self.data.streaming.enabled
         ):
             raise ValueError(
-                "data.streaming.enabled must be true when an agent is configured with mode=paper."
+                "data.streaming.enabled must be true when an agent is configured with mode=paper or mode=live."
             )
+
+        requires_live = any(agent.mode == "live" for agent in self.agents)
+        if requires_live:
+            if self.risk is None:
+                raise ValueError(
+                    "risk is required when an agent is configured with mode=live."
+                )
+            if not self.risk.drawdown_protection.enabled:
+                raise ValueError(
+                    "risk.drawdown_protection.enabled must be true when an agent is configured with mode=live."
+                )
+            if self.position_manager is None:
+                raise ValueError(
+                    "position_manager is required when an agent is configured with mode=live."
+                )
         return self

--- a/quanttradeai/utils/config_validator.py
+++ b/quanttradeai/utils/config_validator.py
@@ -96,6 +96,12 @@ def _validate_agent_project_sections(
     }
     feature_names = set(feature_definitions)
     data_streaming_cfg = dict((resolved.get("data") or {}).get("streaming") or {})
+    position_manager_cfg = dict(resolved.get("position_manager") or {})
+
+    if "risk_management" in position_manager_cfg:
+        warnings.append(
+            "position_manager.risk_management is legacy compatibility only; use the top-level risk section as the canonical live risk config."
+        )
 
     for agent in resolved.get("agents") or []:
         agent_name = agent.get("name", "<unknown>")

--- a/quanttradeai/utils/project_config.py
+++ b/quanttradeai/utils/project_config.py
@@ -8,6 +8,11 @@ from typing import Any
 
 import yaml
 
+from quanttradeai.utils.config_schemas import (
+    PositionManagerConfig,
+    RiskManagementConfig,
+)
+
 
 LEGACY_CONFIG_FILES = {
     "model_config": "model_config.yaml",
@@ -32,6 +37,38 @@ class LoadedProjectConfig:
     source: str
     source_path: str
     warnings: list[str]
+
+
+def extract_canonical_live_risk_config(
+    project_config: dict[str, Any],
+) -> tuple[dict[str, Any], bool]:
+    """Return canonical live risk config, accepting nested legacy fallback."""
+
+    top_level_risk = dict(project_config.get("risk") or {})
+    position_manager_cfg = dict(project_config.get("position_manager") or {})
+    nested_risk = dict(position_manager_cfg.get("risk_management") or {})
+
+    if top_level_risk:
+        return top_level_risk, False
+    if nested_risk:
+        return nested_risk, True
+    return {}, False
+
+
+def normalize_live_risk_compatibility(
+    project_config: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Normalize legacy nested live-risk settings into canonical top-level risk."""
+
+    normalized = dict(project_config)
+    warnings: list[str] = []
+    risk_cfg, used_nested_fallback = extract_canonical_live_risk_config(normalized)
+    if used_nested_fallback:
+        normalized["risk"] = risk_cfg
+        warnings.append(
+            "position_manager.risk_management is legacy compatibility only; it was treated as the canonical top-level risk section during validation."
+        )
+    return normalized, warnings
 
 
 def _load_yaml_mapping(path: Path) -> dict[str, Any]:
@@ -97,6 +134,16 @@ def _resolve_custom_feature_key(name: str, params: dict[str, Any]) -> str:
         f"{name}' must map to one of: price_momentum, volume_momentum, "
         "mean_reversion, volatility_breakout. Set params.kind to disambiguate."
     )
+
+
+def _strip_position_manager_risk_management(
+    position_manager_cfg: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not isinstance(position_manager_cfg, dict):
+        return {}
+    sanitized = dict(position_manager_cfg)
+    sanitized.pop("risk_management", None)
+    return sanitized
 
 
 def import_legacy_project_config(
@@ -264,13 +311,31 @@ def import_legacy_project_config(
         project_cfg["models"] = model_cfg["models"]
     if backtest_cfg.get("execution") or {}:
         project_cfg["execution"] = backtest_cfg["execution"]
-    if risk_cfg:
-        project_cfg["risk"] = risk_cfg.get("risk_management", risk_cfg)
+    imported_risk_cfg = (
+        risk_cfg.get("risk_management", risk_cfg) if risk_cfg else {}
+    ) or {}
+    imported_position_manager_cfg = (
+        position_manager_cfg.get("position_manager", position_manager_cfg)
+        if position_manager_cfg
+        else {}
+    ) or {}
+
+    nested_position_risk_cfg = dict(
+        imported_position_manager_cfg.get("risk_management") or {}
+    )
+    if imported_risk_cfg:
+        project_cfg["risk"] = imported_risk_cfg
+    elif nested_position_risk_cfg:
+        project_cfg["risk"] = nested_position_risk_cfg
+        warnings.append(
+            "Legacy position_manager.risk_management was migrated into the canonical top-level risk section."
+        )
+
     if streaming_cfg:
         project_cfg["data"]["streaming"] = streaming_cfg.get("streaming", streaming_cfg)
-    if position_manager_cfg:
-        project_cfg["position_manager"] = position_manager_cfg.get(
-            "position_manager", position_manager_cfg
+    if imported_position_manager_cfg:
+        project_cfg["position_manager"] = _strip_position_manager_risk_management(
+            imported_position_manager_cfg
         )
 
     return project_cfg, warnings
@@ -292,8 +357,12 @@ def load_project_config(
 
     path = Path(config_path)
     raw = _load_yaml_mapping(path)
+    normalized_raw, _warnings = normalize_live_risk_compatibility(raw)
     return LoadedProjectConfig(
-        raw=raw, source="canonical", source_path=str(path), warnings=[]
+        raw=normalized_raw,
+        source="canonical",
+        source_path=str(path),
+        warnings=[],
     )
 
 
@@ -552,8 +621,10 @@ def compile_research_runtime_configs(
     return model_cfg, runtime_features_cfg, runtime_backtest_cfg
 
 
-def compile_paper_streaming_runtime_config(
+def compile_streaming_runtime_config(
     project_config: dict[str, Any],
+    *,
+    mode: str = "paper",
 ) -> dict[str, Any]:
     """Compile canonical project streaming settings into gateway runtime YAML."""
 
@@ -561,7 +632,7 @@ def compile_paper_streaming_runtime_config(
     streaming_cfg = dict(data_cfg.get("streaming") or {})
     if not streaming_cfg.get("enabled", False):
         raise ValueError(
-            "data.streaming.enabled must be true for `quanttradeai agent run --mode paper`."
+            f"data.streaming.enabled must be true for `quanttradeai agent run --mode {mode}`."
         )
 
     symbols = list(streaming_cfg.get("symbols") or data_cfg.get("symbols") or [])
@@ -601,3 +672,48 @@ def compile_paper_streaming_runtime_config(
         runtime_cfg["streaming_health"] = health_sections
 
     return runtime_cfg
+
+
+def compile_paper_streaming_runtime_config(
+    project_config: dict[str, Any],
+) -> dict[str, Any]:
+    return compile_streaming_runtime_config(project_config, mode="paper")
+
+
+def compile_live_streaming_runtime_config(
+    project_config: dict[str, Any],
+) -> dict[str, Any]:
+    return compile_streaming_runtime_config(project_config, mode="live")
+
+
+def compile_live_risk_runtime_config(
+    project_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Compile canonical top-level live risk settings into runtime YAML."""
+
+    risk_cfg, _used_nested_fallback = extract_canonical_live_risk_config(project_config)
+    if not risk_cfg:
+        raise ValueError("risk is required for `quanttradeai agent run --mode live`.")
+    RiskManagementConfig(**risk_cfg)
+    return {"risk_management": risk_cfg}
+
+
+def compile_live_position_manager_runtime_config(
+    project_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Compile canonical live position-manager settings into runtime YAML."""
+
+    position_manager_cfg = dict(project_config.get("position_manager") or {})
+    risk_cfg, _used_nested_fallback = extract_canonical_live_risk_config(project_config)
+    if not position_manager_cfg:
+        raise ValueError(
+            "position_manager is required for `quanttradeai agent run --mode live`."
+        )
+    if not risk_cfg:
+        raise ValueError("risk is required for `quanttradeai agent run --mode live`.")
+
+    runtime_cfg = _strip_position_manager_risk_management(position_manager_cfg)
+    runtime_cfg["risk_management"] = risk_cfg
+    runtime_cfg["mode"] = "live"
+    PositionManagerConfig(**runtime_cfg)
+    return {"position_manager": runtime_cfg}

--- a/quanttradeai/utils/promotion.py
+++ b/quanttradeai/utils/promotion.py
@@ -11,6 +11,7 @@ import yaml
 from pydantic import ValidationError
 
 from quanttradeai.utils.config_schemas import ProjectConfigSchema
+from quanttradeai.utils.project_config import extract_canonical_live_risk_config
 from quanttradeai.utils.run_records import RUNS_ROOT, discover_runs
 
 
@@ -71,14 +72,25 @@ def _summary_path_for_record(record: dict[str, Any], runs_root: Path | str) -> P
     )
 
 
-def _validate_promotable_run(record: dict[str, Any], summary: dict[str, Any]) -> str:
+def _validate_promotable_run(
+    record: dict[str, Any],
+    summary: dict[str, Any],
+    *,
+    target_mode: str,
+) -> tuple[str, str]:
     run_type = str(summary.get("run_type") or record.get("run_type") or "")
     mode = str(summary.get("mode") or record.get("mode") or "")
     status = str(summary.get("status") or record.get("status") or "")
 
-    if run_type != "agent" or mode != "backtest" or status != "success":
+    source_mode_by_target = {
+        "paper": "backtest",
+        "live": "paper",
+    }
+    required_source_mode = source_mode_by_target[target_mode]
+
+    if run_type != "agent" or mode != required_source_mode or status != "success":
         raise ValueError(
-            "Only successful agent backtest runs can be promoted to paper."
+            f"Only successful agent {required_source_mode} runs can be promoted to {target_mode}."
         )
 
     agent_name = str(
@@ -87,7 +99,7 @@ def _validate_promotable_run(record: dict[str, Any], summary: dict[str, Any]) ->
     if not agent_name:
         raise ValueError("Promotable agent run is missing an agent name.")
 
-    return agent_name
+    return agent_name, required_source_mode
 
 
 def _apply_paper_promotion(
@@ -135,33 +147,96 @@ def _apply_paper_promotion(
     return proposed, changed
 
 
+def _apply_live_promotion(
+    project_config: dict[str, Any],
+    *,
+    agent_name: str,
+) -> tuple[dict[str, Any], bool]:
+    proposed = copy.deepcopy(project_config)
+    agents = proposed.get("agents")
+    if not isinstance(agents, list):
+        raise ValueError("Project config must include an agents list.")
+
+    target_agent: dict[str, Any] | None = None
+    for agent in agents:
+        if isinstance(agent, dict) and agent.get("name") == agent_name:
+            target_agent = agent
+            break
+
+    if target_agent is None:
+        raise ValueError(f"Agent '{agent_name}' not found in project config.")
+
+    changed = False
+    if target_agent.get("mode") != "live":
+        target_agent["mode"] = "live"
+        changed = True
+
+    if (
+        not isinstance((proposed.get("data") or {}).get("streaming"), dict)
+        or (proposed.get("data") or {}).get("streaming", {}).get("enabled") is not True
+    ):
+        raise ValueError(
+            "data.streaming.enabled must be true before promoting an agent to live."
+        )
+    risk_cfg, used_nested_fallback = extract_canonical_live_risk_config(proposed)
+    if not risk_cfg:
+        raise ValueError("risk is required before promoting an agent to live.")
+    if used_nested_fallback:
+        proposed["risk"] = risk_cfg
+    if not isinstance(proposed.get("position_manager"), dict):
+        raise ValueError(
+            "position_manager is required before promoting an agent to live."
+        )
+
+    try:
+        ProjectConfigSchema(**proposed)
+    except ValidationError as exc:
+        raise ValueError(f"Promoted project config is invalid: {exc}") from exc
+
+    return proposed, changed
+
+
 def promote_agent_run(
     *,
     run_id: str | Path,
     config_path: str | Path = "config/project.yaml",
     target_mode: str = "paper",
     dry_run: bool = False,
+    acknowledge_live: str | None = None,
     runs_root: Path | str = RUNS_ROOT,
 ) -> dict[str, Any]:
-    """Promote a successful agent backtest run to paper mode in project.yaml."""
+    """Promote a successful project-defined agent run to paper or live."""
 
     target_mode = target_mode.strip().lower()
-    if target_mode != "paper":
-        raise ValueError(
-            "Only promotion to paper is supported. Live promotion remains future work."
-        )
+    if target_mode not in {"paper", "live"}:
+        raise ValueError("Only promotion to paper or live is supported.")
 
     record = _find_run_record(run_id, runs_root=runs_root)
     summary_path = _summary_path_for_record(record, runs_root)
     summary = _load_json(summary_path)
-    agent_name = _validate_promotable_run(record, summary)
+    agent_name, source_mode = _validate_promotable_run(
+        record,
+        summary,
+        target_mode=target_mode,
+    )
+    if target_mode == "live":
+        if acknowledge_live != agent_name:
+            raise ValueError(
+                f"Promoting to live requires --acknowledge-live {agent_name}"
+            )
 
     project_config_path = Path(config_path)
     project_config = _load_yaml_mapping(project_config_path)
-    promoted_config, changed = _apply_paper_promotion(
-        project_config,
-        agent_name=agent_name,
-    )
+    if target_mode == "paper":
+        promoted_config, changed = _apply_paper_promotion(
+            project_config,
+            agent_name=agent_name,
+        )
+    else:
+        promoted_config, changed = _apply_live_promotion(
+            project_config,
+            agent_name=agent_name,
+        )
 
     if changed and not dry_run:
         project_config_path.write_text(
@@ -172,14 +247,14 @@ def promote_agent_run(
     config_path_display = project_config_path.as_posix()
     next_command = (
         f"quanttradeai agent run --agent {agent_name} "
-        f"-c {config_path_display} --mode paper"
+        f"-c {config_path_display} --mode {target_mode}"
     )
     return {
         "status": "success",
         "source_run_id": str(record.get("run_id") or _normalize_run_id(run_id)),
         "agent_name": agent_name,
-        "from_mode": "backtest",
-        "to_mode": "paper",
+        "from_mode": source_mode,
+        "to_mode": target_mode,
         "changed": changed,
         "config_path": config_path_display,
         "dry_run": dry_run,

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,6 @@
 # QuantTradeAI Roadmap
 
-Last updated: 2026-04-01
+Last updated: 2026-04-10
 
 This document is the product source of truth for QuantTradeAI.
 It is written for both human contributors and coding agents.
@@ -317,21 +317,25 @@ Deliverables:
 - Make feature selection explicit and shared across research and agent flows.
 - Fix time-aware preprocessing and evaluation defaults.
 
-Status on 2026-03-29:
+Status on 2026-04-10:
 
 - Implemented for the research happy path: canonical `config/project.yaml`, `init`, `validate`, legacy config import via flags, resolved-config artifacts, standardized research run directories, automatic backtests from `research run`, and time-aware preprocessing/evaluation defaults.
 - `quanttradeai agent run --agent <name> -c config/project.yaml --mode backtest|paper` is implemented for `llm` and `hybrid` agents.
 - `quanttradeai agent run --agent <name> -c config/project.yaml --mode backtest|paper` is implemented for `model` agents.
 - `quanttradeai agent run --agent <name> -c config/project.yaml --mode backtest|paper` is implemented for `rule` agents.
+- `quanttradeai agent run --agent <name> -c config/project.yaml --mode live` is implemented for `rule`, `model`, `llm`, and `hybrid` agents.
 - Agent templates now write the referenced prompt markdown assets.
 - Agent backtest runs now persist resolved config, runtime YAML snapshots, metrics, equity curve, ledger, decisions, sampled prompt/response payloads where applicable, and standardized run metadata under `runs/agent/backtest/...`.
 - Model-agent paper runs now persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, and `executions.jsonl` under `runs/agent/paper/...`.
 - LLM and hybrid paper runs now persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, and sampled prompt payloads under `runs/agent/paper/...`.
 - Rule-agent paper runs now persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, `decisions.jsonl`, and `executions.jsonl` under `runs/agent/paper/...`.
+- Live agent runs now persist resolved config, runtime streaming/risk/position-manager YAML snapshots, `summary.json`, `metrics.json`, `executions.jsonl`, and `decisions.jsonl` under `runs/agent/live/...`, with `prompt_samples.json` for `llm` and `hybrid`.
 - `quanttradeai runs list` is implemented for local research and agent run discovery.
 - `quanttradeai promote --run <run_id>` is implemented for successful agent backtest-to-paper promotion.
+- `quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live <agent_name>` is implemented for successful paper-to-live promotion with an explicit safety acknowledgement.
+- Top-level `risk` and `position_manager` are now the canonical live safety/runtime sections in `config/project.yaml`.
 - `quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` now generates a paper-agent deployment bundle with compose, Dockerfile, env placeholders, resolved config, and a deployment manifest.
-- Remaining Stage 1 work includes project-agent live execution and live promotion safety gates.
+- `live-trade`, `config/risk_config.yaml`, `config/position_manager.yaml`, and `config/streaming.yaml` remain supported as legacy compatibility paths, but they are no longer the primary live workflow for project-defined agents.
 
 ### Stage 2: Multi-Agent Lab
 
@@ -426,11 +430,13 @@ quanttradeai init --template model-agent -o config/project.yaml
 quanttradeai validate -c config/project.yaml
 quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
 quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode paper
+quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live paper_momentum
+quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode live
 quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
 ```
 
 Current implementation note:
-`model`, `llm`, and `hybrid` agents support `--mode backtest` and `--mode paper` today. `deploy --target docker-compose` generates paper-agent bundles today. `live` remains roadmap work.
+`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. `deploy --target docker-compose` still generates paper-agent bundles only.
 
 ### Hybrid track
 
@@ -438,10 +444,12 @@ Current implementation note:
 quanttradeai init --template hybrid -o config/project.yaml
 quanttradeai research run -c config/project.yaml
 quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode paper
+quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live hybrid_swing_agent
+quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode live
 ```
 
 Current implementation note:
-Hybrid agents are currently runnable in `backtest` and `paper` mode. Promotion to `live` remains future roadmap work.
+Hybrid agents are runnable in `backtest`, `paper`, and `live` mode. Live deployment remains future roadmap work.
 
 ## Definition of Done for the Happy Path
 

--- a/tests/agents/test_model_agent.py
+++ b/tests/agents/test_model_agent.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from quanttradeai.agents.model_agent import run_model_agent_backtest
+from quanttradeai.agents.model_agent import _initialize_model_agent_run, run_model_agent_backtest
 
 
 def test_model_agent_backtest_writes_failure_summary_for_init_errors(tmp_path, monkeypatch):
@@ -22,3 +22,33 @@ def test_model_agent_backtest_writes_failure_summary_for_init_errors(tmp_path, m
     assert summary_payload["agent_name"] == "momentum"
     assert "error" in summary_payload
     assert summary_payload["timestamps"].get("completed_at")
+
+
+def test_initialize_model_agent_run_rejects_live_when_agent_mode_is_not_live(tmp_path, monkeypatch):
+    resolved_config_path = tmp_path / "resolved_project_config.yaml"
+    resolved_config_path.write_text(
+        """
+agents:
+  - name: momentum
+    kind: model
+    mode: paper
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "quanttradeai.agents.model_agent.validate_project_config",
+        lambda **_: {
+            "artifacts": {"resolved_config": str(resolved_config_path)},
+            "warnings": [],
+        },
+    )
+
+    with pytest.raises(ValueError, match="must be configured with mode=live"):
+        _initialize_model_agent_run(
+            run_dir=tmp_path,
+            summary={"artifacts": {}},
+            project_config_path="config/project.yaml",
+            agent_name="momentum",
+            mode="live",
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Test-session compatibility shims."""
+
+from __future__ import annotations
+
+import os
+import platform
+import sys
+
+
+if sys.platform == "win32":
+    _SAFE_UNAME = platform.uname_result(
+        "Windows",
+        os.environ.get("COMPUTERNAME", "localhost"),
+        os.environ.get("OS", "Windows_NT"),
+        os.environ.get("PROCESSOR_REVISION", ""),
+        os.environ.get("PROCESSOR_ARCHITECTURE", "AMD64"),
+    )
+
+    platform.uname = lambda: _SAFE_UNAME  # type: ignore[assignment]
+    platform.system = lambda: _SAFE_UNAME.system  # type: ignore[assignment]
+    platform.machine = lambda: _SAFE_UNAME.machine  # type: ignore[assignment]
+    platform.processor = lambda: _SAFE_UNAME.processor  # type: ignore[assignment]

--- a/tests/integration/test_agent_cli.py
+++ b/tests/integration/test_agent_cli.py
@@ -1,4 +1,7 @@
 import json
+import asyncio
+import sys
+import types
 from pathlib import Path
 from unittest.mock import patch
 
@@ -8,7 +11,6 @@ import yaml
 from typer.testing import CliRunner
 
 from quanttradeai.cli import app
-from quanttradeai.streaming.stream_buffer import StreamBuffer
 
 
 runner = CliRunner()
@@ -85,6 +87,32 @@ def _completion_from_actions(actions: list[str]):
         }
 
     return _fake_completion
+
+
+def _stub_prometheus_client(monkeypatch) -> None:
+    return None
+
+
+def _stub_live_trading_module(monkeypatch) -> None:
+    live_trading_module = types.ModuleType("quanttradeai.streaming.live_trading")
+    live_trading_module.LiveTradingEngine = object
+    monkeypatch.setitem(
+        sys.modules,
+        "quanttradeai.streaming.live_trading",
+        live_trading_module,
+    )
+    sys.modules.pop("quanttradeai.agents.model_agent", None)
+
+
+def _stub_streaming_gateway_module(monkeypatch) -> None:
+    gateway_module = types.ModuleType("quanttradeai.streaming.gateway")
+    gateway_module.StreamingGateway = object
+    monkeypatch.setitem(
+        sys.modules,
+        "quanttradeai.streaming.gateway",
+        gateway_module,
+    )
+    sys.modules.pop("quanttradeai.agents.paper", None)
 
 
 def test_agent_run_backtest_writes_artifacts(tmp_path: Path, monkeypatch):
@@ -312,9 +340,64 @@ class FakePaperEngine:
         ]
 
 
+class FakeDrawdownGuard:
+    def check_drawdown_limits(self) -> dict[str, object]:
+        return {"status": "ok", "halted": False}
+
+
+class FakeRiskManager:
+    def __init__(self) -> None:
+        self.drawdown_guard = FakeDrawdownGuard()
+
+    def get_risk_metrics(self) -> dict[str, float]:
+        return {
+            "current_drawdown_pct": 0.01,
+            "current_drawdown_abs": 100.0,
+        }
+
+
+class FakeLiveEngine(FakePaperEngine):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.risk_manager = FakeRiskManager()
+        self.decision_log = []
+
+    async def start(self) -> None:
+        self.decision_log = [
+            {
+                "symbol": "AAPL",
+                "timestamp": pd.Timestamp("2024-01-01T00:00:00Z"),
+                "signal": 1,
+                "action": "buy",
+                "source": "model",
+            }
+        ]
+        self.execution_log = [
+            {
+                "action": "buy",
+                "symbol": "AAPL",
+                "qty": 10,
+                "price": 100.0,
+                "timestamp": pd.Timestamp("2024-01-01T00:00:00Z"),
+                "signal": 1,
+            }
+        ]
+
+
+class FakeStreamBuffer:
+    def __init__(self, maxsize: int) -> None:
+        self.queue = asyncio.Queue(maxsize)
+
+    async def put(self, item: dict) -> None:
+        await self.queue.put(item)
+
+    async def get(self) -> dict:
+        return await self.queue.get()
+
+
 class FakeStreamingGateway:
     def __init__(self, messages: list[dict]) -> None:
-        self.buffer = StreamBuffer(32)
+        self.buffer = FakeStreamBuffer(32)
         self.messages = messages
 
     async def _start(self) -> None:
@@ -493,6 +576,8 @@ def test_model_agent_backtest_writes_standardized_artifacts(
     tmp_path: Path, monkeypatch
 ):
     monkeypatch.chdir(tmp_path)
+    _stub_prometheus_client(monkeypatch)
+    _stub_live_trading_module(monkeypatch)
 
     init_result = runner.invoke(
         app,
@@ -568,6 +653,8 @@ def test_model_agent_paper_run_writes_metrics_and_execution_log(
     tmp_path: Path, monkeypatch
 ):
     monkeypatch.chdir(tmp_path)
+    _stub_prometheus_client(monkeypatch)
+    _stub_live_trading_module(monkeypatch)
 
     init_result = runner.invoke(
         app,
@@ -617,9 +704,77 @@ def test_model_agent_paper_run_writes_metrics_and_execution_log(
     assert metrics_payload["open_positions"]["AAPL"]["unrealized_pnl"] == 50.0
 
 
+def test_model_agent_live_run_writes_live_artifacts_and_risk_metrics(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    _stub_prometheus_client(monkeypatch)
+    _stub_live_trading_module(monkeypatch)
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "model-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["agents"][0]["mode"] = "live"
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    observed: dict[str, str] = {}
+
+    def _engine_factory(**kwargs):
+        observed.update({key: str(value) for key, value in kwargs.items()})
+        return FakeLiveEngine(**kwargs)
+
+    with patch(
+        "quanttradeai.agents.model_agent.LiveTradingEngine",
+        side_effect=_engine_factory,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--agent",
+                "paper_momentum",
+                "--config",
+                str(config_path),
+                "--mode",
+                "live",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    run_dir = Path(payload["run_dir"])
+    assert payload["status"] == "success"
+    assert payload["mode"] == "live"
+    assert payload["agent_kind"] == "model"
+    assert (run_dir / "runtime_streaming_config.yaml").is_file()
+    assert (run_dir / "runtime_risk_config.yaml").is_file()
+    assert (run_dir / "runtime_position_manager_config.yaml").is_file()
+    assert (run_dir / "decisions.jsonl").is_file()
+    assert (run_dir / "executions.jsonl").is_file()
+    assert (run_dir / "metrics.json").is_file()
+    assert Path(observed["risk_config"]).is_file()
+    assert Path(observed["position_manager_config"]).is_file()
+
+    metrics_payload = json.loads((run_dir / "metrics.json").read_text("utf-8"))
+    assert metrics_payload["decision_count"] == 1
+    assert metrics_payload["execution_count"] == 1
+    assert metrics_payload["risk_metrics"]["current_drawdown_pct"] == 0.01
+    assert metrics_payload["risk_status"]["status"] == "ok"
+
+
 def test_llm_agent_paper_run_writes_standardized_artifacts(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    _stub_streaming_gateway_module(monkeypatch)
 
     init_result = runner.invoke(
         app,
@@ -727,6 +882,7 @@ def test_rule_agent_paper_run_writes_metrics_and_execution_log(
     tmp_path: Path, monkeypatch
 ):
     monkeypatch.chdir(tmp_path)
+    _stub_streaming_gateway_module(monkeypatch)
 
     init_result = runner.invoke(
         app,
@@ -831,11 +987,120 @@ def test_rule_agent_paper_run_writes_metrics_and_execution_log(
     assert metrics_payload["execution_count"] == 2
 
 
+def test_rule_agent_live_run_writes_live_artifacts_and_risk_metrics(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    _stub_streaming_gateway_module(monkeypatch)
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["data"]["start_date"] = "2024-01-01"
+    config_payload["data"]["end_date"] = "2024-02-09"
+    config_payload["data"]["test_start"] = "2024-02-01"
+    config_payload["data"]["test_end"] = "2024-02-09"
+    config_payload["agents"][0]["mode"] = "live"
+    config_payload["agents"][0]["rule"]["buy_below"] = 50.0
+    config_payload["agents"][0]["rule"]["sell_above"] = 60.0
+    config_payload["risk"]["drawdown_protection"]["max_drawdown_pct"] = 1.0
+    config_payload["risk"]["turnover_limits"]["daily_max"] = 1_000_000.0
+    config_payload["risk"]["turnover_limits"]["weekly_max"] = 1_000_000.0
+    config_payload["risk"]["turnover_limits"]["monthly_max"] = 1_000_000.0
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    gateway = FakeStreamingGateway(
+        [
+            {
+                "symbol": "AAPL",
+                "price": 121.0,
+                "volume": 10,
+                "timestamp": "2024-02-10T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 123.0,
+                "volume": 12,
+                "timestamp": "2024-02-11T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 124.0,
+                "volume": 14,
+                "timestamp": "2024-02-12T00:00:00Z",
+            },
+        ]
+    )
+
+    with (
+        patch(
+            "quanttradeai.agents.paper.StreamingGateway",
+            return_value=gateway,
+        ),
+        patch(
+            "quanttradeai.agents.paper.DataLoader.fetch_data",
+            return_value={"AAPL": _mock_history()},
+        ),
+        patch(
+            "quanttradeai.agents.paper.DataProcessor.generate_features",
+            _rule_paper_features,
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--agent",
+                "rsi_reversion",
+                "--config",
+                str(config_path),
+                "--mode",
+                "live",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    run_dir = sorted((Path("runs") / "agent" / "live").iterdir())[-1]
+    payload = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+    assert payload["status"] == "success"
+    assert payload["mode"] == "live"
+    assert payload["agent_kind"] == "rule"
+    assert (run_dir / "runtime_streaming_config.yaml").is_file()
+    assert (run_dir / "runtime_risk_config.yaml").is_file()
+    assert (run_dir / "runtime_position_manager_config.yaml").is_file()
+    assert (run_dir / "decisions.jsonl").is_file()
+    assert (run_dir / "executions.jsonl").is_file()
+    assert (run_dir / "metrics.json").is_file()
+
+    metrics_payload = json.loads((run_dir / "metrics.json").read_text("utf-8"))
+    assert metrics_payload["decision_count"] == 2
+    assert metrics_payload["execution_count"] == 2
+    assert "risk_metrics" in metrics_payload
+    assert metrics_payload["risk_status"]["status"] in {
+        "ok",
+        "normal",
+        "warning",
+        "soft_stop",
+        "hard_stop",
+        "emergency_stop",
+    }
+
+
 def test_hybrid_agent_paper_run_includes_model_signals_in_decisions(
     tmp_path: Path, monkeypatch
 ):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    _stub_streaming_gateway_module(monkeypatch)
 
     init_result = runner.invoke(
         app,
@@ -1009,3 +1274,70 @@ def test_agent_run_warns_when_cli_mode_differs_from_configured_mode(
         "configured with mode=paper but cli requested mode=backtest"
         in combined_output.lower()
     )
+
+
+def test_agent_run_live_rejects_skip_validation(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["agents"][0]["mode"] = "live"
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--agent",
+            "rsi_reversion",
+            "--config",
+            str(config_path),
+            "--mode",
+            "live",
+            "--skip-validation",
+        ],
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert "--skip-validation is not supported for live agent runs" in combined_output
+
+
+def test_agent_run_live_requires_agent_to_be_configured_live(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--agent",
+            "rsi_reversion",
+            "--config",
+            "config/project.yaml",
+            "--mode",
+            "live",
+        ],
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert "must be configured with mode=live before running" in combined_output

--- a/tests/integration/test_promote_cli.py
+++ b/tests/integration/test_promote_cli.py
@@ -16,6 +16,9 @@ def _write_project_config(
     agent_mode: str = "backtest",
     deployment_mode: str = "backtest",
     streaming_enabled: bool = True,
+    include_risk: bool = True,
+    include_position_manager: bool = True,
+    use_nested_position_manager_risk: bool = False,
 ) -> dict:
     payload = yaml.safe_load(
         yaml.safe_dump(PROJECT_TEMPLATES["llm-agent"], sort_keys=False)
@@ -23,6 +26,13 @@ def _write_project_config(
     payload["agents"][0]["mode"] = agent_mode
     payload["deployment"]["mode"] = deployment_mode
     payload["data"]["streaming"]["enabled"] = streaming_enabled
+    if not include_risk:
+        payload.pop("risk", None)
+    if not include_position_manager:
+        payload.pop("position_manager", None)
+    if use_nested_position_manager_risk:
+        payload.setdefault("position_manager", {})
+        payload["position_manager"]["risk_management"] = payload.pop("risk")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
     return payload
@@ -181,6 +191,15 @@ def test_promote_failure_cases_do_not_mutate_project_yaml(
         mode="research",
         agent_name=None,
     )
+    _write_run_summary(
+        run_id="agent/paper/20260101_030000_failed_paper_breakout_gpt",
+        mode="paper",
+        status="failed",
+    )
+    _write_run_summary(
+        run_id="agent/paper/20260101_040000_breakout_gpt",
+        mode="paper",
+    )
 
     cases = [
         (
@@ -223,7 +242,33 @@ def test_promote_failure_cases_do_not_mutate_project_yaml(
                 "--to",
                 "live",
             ],
-            "Only promotion to paper is supported",
+            "Only successful agent paper runs can be promoted to live",
+        ),
+        (
+            [
+                "promote",
+                "--run",
+                "agent/paper/20260101_030000_failed_paper_breakout_gpt",
+                "--config",
+                str(config_path),
+                "--to",
+                "live",
+                "--acknowledge-live",
+                "breakout_gpt",
+            ],
+            "Only successful agent paper runs can be promoted to live",
+        ),
+        (
+            [
+                "promote",
+                "--run",
+                "agent/paper/20260101_040000_breakout_gpt",
+                "--config",
+                str(config_path),
+                "--to",
+                "live",
+            ],
+            "Promoting to live requires --acknowledge-live breakout_gpt",
         ),
     ]
 
@@ -260,3 +305,168 @@ def test_promote_requires_streaming_before_writing_paper_config(
     combined_output = f"{result.stdout}\n{result.stderr}"
     assert "data.streaming.enabled must be true" in combined_output
     assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_promote_agent_paper_to_live_updates_only_agent_mode(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_project_config(
+        config_path,
+        agent_mode="paper",
+        deployment_mode="paper",
+    )
+    run_id = "agent/paper/20260101_010000_breakout_gpt"
+    _write_run_summary(run_id=run_id, mode="paper")
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "--run",
+            run_id,
+            "--config",
+            str(config_path),
+            "--to",
+            "live",
+            "--acknowledge-live",
+            "breakout_gpt",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    updated = _load_project_config(config_path)
+
+    assert payload["status"] == "success"
+    assert payload["source_run_id"] == run_id
+    assert payload["from_mode"] == "paper"
+    assert payload["to_mode"] == "live"
+    assert payload["changed"] is True
+    assert payload["next_command"] == (
+        "quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode live"
+    )
+    assert updated["agents"][0]["mode"] == "live"
+    assert updated["deployment"]["mode"] == "paper"
+
+
+def test_promote_agent_paper_to_live_dry_run_is_non_mutating(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_project_config(
+        config_path,
+        agent_mode="paper",
+        deployment_mode="paper",
+    )
+    original = config_path.read_text(encoding="utf-8")
+    _write_run_summary(
+        run_id="agent/paper/20260101_010000_breakout_gpt",
+        mode="paper",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "--run",
+            "agent/paper/20260101_010000_breakout_gpt",
+            "--config",
+            str(config_path),
+            "--to",
+            "live",
+            "--acknowledge-live",
+            "breakout_gpt",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["changed"] is True
+    assert payload["dry_run"] is True
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_promote_to_live_requires_live_safety_sections(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_project_config(
+        config_path,
+        agent_mode="paper",
+        deployment_mode="paper",
+        include_position_manager=False,
+    )
+    original = config_path.read_text(encoding="utf-8")
+    _write_run_summary(
+        run_id="agent/paper/20260101_010000_breakout_gpt",
+        mode="paper",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "--run",
+            "agent/paper/20260101_010000_breakout_gpt",
+            "--config",
+            str(config_path),
+            "--to",
+            "live",
+            "--acknowledge-live",
+            "breakout_gpt",
+        ],
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert (
+        "position_manager is required before promoting an agent to live"
+        in combined_output
+    )
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_promote_to_live_accepts_legacy_nested_position_manager_risk(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_project_config(
+        config_path,
+        agent_mode="paper",
+        deployment_mode="paper",
+        use_nested_position_manager_risk=True,
+    )
+    _write_run_summary(
+        run_id="agent/paper/20260101_010000_breakout_gpt",
+        mode="paper",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "--run",
+            "agent/paper/20260101_010000_breakout_gpt",
+            "--config",
+            str(config_path),
+            "--to",
+            "live",
+            "--acknowledge-live",
+            "breakout_gpt",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    updated = _load_project_config(config_path)
+    assert updated["agents"][0]["mode"] == "live"
+    assert "risk" in updated

--- a/tests/integration/test_runs_cli.py
+++ b/tests/integration/test_runs_cli.py
@@ -131,3 +131,36 @@ def test_runs_list_filters_by_type_status_and_limit(tmp_path: Path, monkeypatch)
     assert payload[0]["symbols"] == ["TSLA"]
     assert payload[0]["warnings"] == ["legacy"]
     assert Path(payload[0]["run_dir"]).name == "20251231_230000_legacy_agent"
+
+
+def test_runs_list_surfaces_live_agent_runs_and_filters_by_live_mode(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _seed_runs(runs_root)
+    _write_run_summary(
+        runs_root / "agent" / "live" / "20260101_020000_breakout_live" / "summary.json",
+        {
+            "run_type": "agent",
+            "mode": "live",
+            "name": "breakout_live",
+            "agent_name": "breakout_live",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "timestamps": {"started_at": "2026-01-01T02:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "agent/live/20260101_020000_breakout_live",
+            "run_dir": "runs/agent/live/20260101_020000_breakout_live",
+        },
+    )
+
+    result = runner.invoke(app, ["runs", "list", "--mode", "live", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert len(payload) == 1
+    assert payload[0]["run_id"] == "agent/live/20260101_020000_breakout_live"
+    assert payload[0]["mode"] == "live"
+    assert payload[0]["name"] == "breakout_live"

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -284,6 +284,29 @@ def test_llm_and_hybrid_templates_include_canonical_streaming_block(
         cfg_path.unlink()
 
 
+def test_agent_templates_include_live_risk_and_position_manager_defaults(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    for template_name in ("rule-agent", "llm-agent", "hybrid", "model-agent"):
+        cfg_path = Path("config/project.yaml")
+        result = runner.invoke(
+            app,
+            ["init", "--template", template_name, "--output", str(cfg_path)],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+        assert payload["risk"]["drawdown_protection"]["enabled"] is True
+        assert payload["position_manager"]["mode"] == "live"
+        assert payload["position_manager"]["reconciliation"] == {
+            "intraday": "1m",
+            "daily": "1d",
+        }
+        cfg_path.unlink()
+
+
 def test_validate_fails_when_model_agent_path_missing(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     cfg_path = Path("config/project.yaml")
@@ -507,6 +530,166 @@ def test_validate_fails_when_llm_agent_paper_streaming_is_missing(
     assert "data.streaming.enabled must be true" in result.stderr.lower()
 
 
+def test_validate_passes_when_live_agent_has_canonical_risk_and_position_manager(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    config_payload["agents"][0]["mode"] = "live"
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Resolved project config summary:" in result.stdout
+
+
+def test_validate_fails_when_live_agent_streaming_is_disabled(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    config_payload["agents"][0]["mode"] = "live"
+    config_payload["data"]["streaming"]["enabled"] = False
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert "data.streaming.enabled must be true" in result.stderr.lower()
+
+
+def test_validate_fails_when_live_agent_missing_top_level_risk(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    config_payload["agents"][0]["mode"] = "live"
+    config_payload.pop("risk", None)
+    config_payload["position_manager"].pop("risk_management", None)
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert (
+        "risk is required when an agent is configured with mode=live" in result.stderr
+    )
+
+
+def test_validate_fails_when_live_agent_drawdown_protection_is_disabled(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    config_payload["agents"][0]["mode"] = "live"
+    config_payload["risk"]["drawdown_protection"]["enabled"] = False
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert "risk.drawdown_protection.enabled must be true" in result.stderr.lower()
+
+
+def test_validate_fails_when_live_agent_position_manager_is_invalid(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    config_payload["agents"][0]["mode"] = "live"
+    config_payload["position_manager"]["mode"] = "intraday"
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert "position_manager.mode" in result.stderr.lower()
+
+
+def test_validate_warns_for_legacy_nested_live_risk_compatibility(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    config_payload["agents"][0]["mode"] = "live"
+    config_payload["position_manager"]["risk_management"] = config_payload.pop("risk")
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "position_manager.risk_management is legacy compatibility only" in (
+        f"{result.stdout}\n{result.stderr}"
+    )
+
+
 def test_validate_fails_when_agent_prompt_file_missing(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     cfg_path = Path("config/project.yaml")
@@ -581,7 +764,9 @@ def test_validate_preserves_unknown_fields_in_resolved_artifact(
     resolved_path = Path(payload["artifacts"]["resolved_config"])
     resolved = yaml.safe_load(resolved_path.read_text(encoding="utf-8"))
 
-    assert resolved["risk"] == {"enabled": True, "max_drawdown": 0.15}
+    assert resolved["risk"]["enabled"] is True
+    assert resolved["risk"]["max_drawdown"] == 0.15
+    assert "drawdown_protection" in resolved["risk"]
     assert resolved["data"]["streaming"]["enabled"] is True
     assert resolved["data"]["streaming"]["provider"] == "paper-feed"
     assert resolved["data"]["streaming"]["websocket_url"] == "wss://example.test/stream"

--- a/tests/utils/test_project_runtime.py
+++ b/tests/utils/test_project_runtime.py
@@ -1,4 +1,9 @@
-from quanttradeai.utils.project_config import compile_research_runtime_configs
+from quanttradeai.utils.project_config import (
+    compile_live_position_manager_runtime_config,
+    compile_live_risk_runtime_config,
+    compile_live_streaming_runtime_config,
+    compile_research_runtime_configs,
+)
 from quanttradeai.utils.project_runtime import project_to_runtime_configs
 
 
@@ -74,3 +79,84 @@ def test_project_runtime_matches_canonical_compiler_for_agent_flows():
     assert runtime_features_cfg == expected_features_cfg
     assert runtime_model_cfg["data"]["test_start"] is None
     assert runtime_model_cfg["data"]["test_end"] is None
+
+
+def test_compile_live_runtime_configs_emit_canonical_streaming_risk_and_position_manager():
+    project_cfg = {
+        "data": {
+            "symbols": ["AAPL"],
+            "streaming": {
+                "enabled": True,
+                "provider": "alpaca",
+                "websocket_url": "wss://example.test/stream",
+                "auth_method": "api_key",
+                "symbols": ["AAPL"],
+                "channels": ["trades", "quotes"],
+            },
+        },
+        "risk": {
+            "drawdown_protection": {
+                "enabled": True,
+                "max_drawdown_pct": 0.1,
+            },
+            "turnover_limits": {"daily_max": 2.0},
+        },
+        "position_manager": {
+            "impact": {"enabled": False},
+            "reconciliation": {"intraday": "1m", "daily": "1d"},
+            "mode": "live",
+        },
+    }
+
+    streaming_cfg = compile_live_streaming_runtime_config(project_cfg)
+    risk_cfg = compile_live_risk_runtime_config(project_cfg)
+    position_manager_cfg = compile_live_position_manager_runtime_config(project_cfg)
+
+    assert streaming_cfg["streaming"]["providers"][0]["name"] == "alpaca"
+    assert risk_cfg["risk_management"]["drawdown_protection"]["enabled"] is True
+    assert (
+        position_manager_cfg["position_manager"]["risk_management"]["turnover_limits"][
+            "daily_max"
+        ]
+        == 2.0
+    )
+    assert position_manager_cfg["position_manager"]["mode"] == "live"
+
+
+def test_compile_live_runtime_accepts_legacy_nested_position_manager_risk():
+    project_cfg = {
+        "data": {
+            "symbols": ["AAPL"],
+            "streaming": {
+                "enabled": True,
+                "provider": "alpaca",
+                "websocket_url": "wss://example.test/stream",
+                "symbols": ["AAPL"],
+                "channels": ["trades"],
+            },
+        },
+        "position_manager": {
+            "impact": {"enabled": False},
+            "reconciliation": {"intraday": "1m", "daily": "1d"},
+            "mode": "live",
+            "risk_management": {
+                "drawdown_protection": {
+                    "enabled": True,
+                    "max_drawdown_pct": 0.15,
+                }
+            },
+        },
+    }
+
+    risk_cfg = compile_live_risk_runtime_config(project_cfg)
+    position_manager_cfg = compile_live_position_manager_runtime_config(project_cfg)
+
+    assert (
+        risk_cfg["risk_management"]["drawdown_protection"]["max_drawdown_pct"] == 0.15
+    )
+    assert (
+        position_manager_cfg["position_manager"]["risk_management"][
+            "drawdown_protection"
+        ]["max_drawdown_pct"]
+        == 0.15
+    )


### PR DESCRIPTION
## Summary
- add canonical `project.yaml` live execution for `rule`, `model`, `llm`, and `hybrid` agents
- add paper-to-live promotion with explicit acknowledgement and standardized live run artifacts
- document the canonical live path, keep legacy `live-trade` as compatibility, and add targeted validation/runtime tests

## Details
- add top-level canonical live `risk` and `position_manager` handling, plus compatibility fallback for legacy nested `position_manager.risk_management`
- compile runtime streaming, risk, and position-manager YAML snapshots into `runs/agent/live/...`
- support `quanttradeai agent run --mode live` while requiring the agent to already be configured for live and rejecting `--skip-validation`
- extend promotion to support `--to live --acknowledge-live <agent_name>` from successful paper runs without changing `deployment.mode`
- make package-level `streaming` and `trading` imports lazy to avoid dragging heavy runtime dependencies into unrelated imports
- add Windows-safe test shims and update `make test` to run pytest deterministically with `pytest_asyncio.plugin`

## Verification
- `make format`
- `make lint`
- `make test`