### PR TITLE
[codex] add research model promotion workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format format-check lint test pipeline
+.PHONY: format format-check lint test lint.format.test pipeline
 
 format:
 	poetry run black quanttradeai/
@@ -12,6 +12,12 @@ lint:
 test:
 	poetry run python -c "import os; os.environ.setdefault('PYTEST_DISABLE_PLUGIN_AUTOLOAD', '1'); import pytest; raise SystemExit(pytest.main(['-p', 'pytest_asyncio.plugin']))"
 
+lint.format.test:
+	$(MAKE) format
+	$(MAKE) lint
+	$(MAKE) test
+
 pipeline:
-	poetry run quanttradeai train -c config/model_config.yaml
+	poetry run quanttradeai validate -c config/project.yaml
+	poetry run quanttradeai research run -c config/project.yaml
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 
 | I want to... | Best path today | What I get |
 | --- | --- | --- |
-| Research a strategy end to end | `init` -> `validate` -> `research run` | Time-aware evaluation, backtests, metrics, run records |
+| Research a strategy end to end | `init` -> `validate` -> `research run` -> `promote --run research/<run_id>` | Time-aware evaluation, backtests, metrics, run records, and a stable promoted model path |
 | Run a deterministic rule agent | `init --template rule-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | A YAML-only agent that can move through backtest, paper, and live with explicit promotion gates |
-| Run a trained model as an agent | `init --template model-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | One YAML-defined model agent that can be backtested, promoted, paper-run, and live-run |
+| Run a trained model as an agent | `init --template model-agent` -> `validate` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | One YAML-defined model agent wired to a stable `models/promoted/...` path that can be backtested, promoted, paper-run, and live-run |
 | Run an LLM agent | `init --template llm-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Prompt-driven agent logic using project config across all three modes |
-| Run a hybrid agent | `init --template hybrid` -> `research run` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Model signals plus LLM reasoning in one project, with the same YAML agent definition promoted through environments |
+| Run a hybrid agent | `init --template hybrid` -> `research run` -> `promote --run research/<run_id>` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Model signals plus LLM reasoning in one project, with research outputs promoted into a stable path before the agent is promoted through environments |
 | Generate a Docker Compose deployment bundle | `deploy --agent <name> --target docker-compose` | A paper-agent bundle with compose, Dockerfile, env placeholders, and resolved config |
 | Keep using the older live loop | `live-trade` with runtime YAML files | Legacy compatibility for existing setups |
 
@@ -44,12 +44,14 @@ flowchart LR
     A["config/project.yaml"] --> B["validate"]
     A --> C["research run"]
     A --> D["agent run"]
-    C --> E["trained model artifact"]
-    E --> D
-    C --> F["runs/research/..."]
-    D --> G["runs/agent/backtest/..."]
-    D --> H["runs/agent/paper/..."]
-    D --> I["runs/agent/live/..."]
+    C --> E["models/experiments/..."]
+    E --> F["promote --run research/..."]
+    F --> G["models/promoted/..."]
+    G --> D
+    C --> K["runs/research/..."]
+    D --> H["runs/agent/backtest/..."]
+    D --> I["runs/agent/paper/..."]
+    D --> J["runs/agent/live/..."]
 ```
 
 QuantTradeAI is one framework with two connected tracks:
@@ -71,6 +73,7 @@ QuantTradeAI is one framework with two connected tracks:
 | `agent run` for `llm` and `hybrid` agents in `backtest` | Supported |
 | `agent run` for `llm` and `hybrid` agents in `paper` | Supported |
 | `agent run` for `llm` and `hybrid` agents in `live` | Supported |
+| Research-run promotion to stable model paths | Supported |
 | Agent backtest-to-paper promotion | Supported |
 | Agent paper-to-live promotion with acknowledgement | Supported |
 | `deploy --target docker-compose` for paper agents | Supported |
@@ -112,6 +115,12 @@ This path gives you:
 - a research run with metrics and artifacts
 - standardized outputs under `runs/research/...`
 
+To make a winning research artifact available to model or hybrid agents through a stable path:
+
+```bash
+poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
+```
+
 ### Run A Rule Agent
 
 Use this if you want the smallest deterministic agent workflow with no LLM dependency.
@@ -148,7 +157,7 @@ Use this if you already have a trained model artifact and want one YAML-defined 
 poetry run quanttradeai init --template model-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 
-# Replace models/trained/aapl_daily_classifier/ with a real trained model artifact
+# Replace models/promoted/aapl_daily_classifier/ with a real trained model artifact
 
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
@@ -158,7 +167,7 @@ poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml 
 ```
 
 > [!IMPORTANT]
-> The `model-agent` template creates a placeholder model directory so the project structure is obvious. Replace it with a real trained model artifact before running the agent.
+> The `model-agent` template creates a placeholder directory at `models/promoted/aapl_daily_classifier/`. Replace it with a promoted research model artifact or another compatible saved model before running the agent.
 
 ### Run An LLM Agent
 
@@ -180,13 +189,17 @@ Use this if you want to combine trained model signals and LLM reasoning in one p
 
 ```bash
 poetry run quanttradeai init --template hybrid -o config/project.yaml
+poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode paper
 poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live hybrid_swing_agent
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode live
 ```
+
+The default hybrid template is prewired to `models/promoted/aapl_daily_classifier`, so you do not need to hand-edit timestamped experiment paths after the research run.
 
 ### Deploy A Paper Agent
 
@@ -233,7 +246,7 @@ agents:
     kind: "model"
     mode: "paper"
     model:
-      path: "models/trained/aapl_daily_classifier"
+      path: "models/promoted/aapl_daily_classifier"
 ```
 
 For the full shape, field reference, and supported agent modes, see [Project YAML](docs/configuration/project-yaml.md).

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -47,6 +47,11 @@ research:
     costs:
       enabled: true
       bps: 5
+  promotion:
+    targets:
+      - name: aapl_daily_classifier
+        symbol: AAPL
+        path: models/promoted/aapl_daily_classifier
 
 agents: []
 

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -8,7 +8,7 @@ It drives:
 - `quanttradeai validate`
 - `quanttradeai research run`
 - `quanttradeai agent run` for project-defined agents in `backtest`, `paper`, and `live`
-- `quanttradeai promote` for agent backtest-to-paper and paper-to-live promotion
+- `quanttradeai promote` for research-model promotion plus agent backtest-to-paper and paper-to-live promotion
 - `quanttradeai deploy` for docker-compose paper-agent bundles
 
 `live-trade` still uses the legacy runtime YAML files documented in [Runtime and Live Trading Configs](live-runtime-files.md).
@@ -21,6 +21,7 @@ It drives:
 poetry run quanttradeai init --template research -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 ```
 
 ### Model Agents
@@ -35,7 +36,7 @@ poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yam
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode live
 ```
 
-The `model-agent` template also creates a placeholder model artifact at `models/trained/aapl_daily_classifier/README.md`. Replace that directory with a real saved model before you run the agent.
+The `model-agent` template also creates a placeholder model artifact at `models/promoted/aapl_daily_classifier/README.md`. Replace that directory with a promoted research model artifact or another compatible saved model before you run the agent.
 
 ### Rule Agents
 
@@ -63,6 +64,22 @@ poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --
 
 The `llm-agent` and `hybrid` templates also create starter prompt files under `prompts/` so validation can pass immediately.
 
+Hybrid projects add the research promotion handoff before agent runs:
+
+```bash
+poetry run quanttradeai init --template hybrid -o config/project.yaml
+poetry run quanttradeai validate -c config/project.yaml
+poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
+poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
+poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live hybrid_swing_agent
+poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode live
+```
+
+The default hybrid template already points `model_signal_sources` at `models/promoted/aapl_daily_classifier`, so the happy path does not require editing timestamped experiment directories.
+
 Current support:
 
 | Agent kind | Backtest | Paper | Live |
@@ -71,6 +88,14 @@ Current support:
 | `llm` | Yes | Yes | Yes |
 | `hybrid` | Yes | Yes | Yes |
 | `rule` | Yes | Yes | Yes |
+
+Successful research runs can promote trained model artifacts into stable project paths with:
+
+```bash
+poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
+```
+
+Research promotion copies the configured symbol artifact directories from the run's `artifacts.experiment_dir` into each `research.promotion.targets[].path` and writes a `promotion_manifest.json` file in each promoted destination.
 
 Successful agent backtest runs can be promoted to paper mode with:
 
@@ -84,6 +109,7 @@ Successful agent paper runs can be promoted to live mode with:
 poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live <agent_name>
 ```
 
+Research promotion updates model directories only and does not change `deployment.mode`.
 Paper promotion updates the matching agent's `mode` and `deployment.mode` to `paper`.
 Live promotion updates only the matching agent's `mode` to `live`. `deployment.mode` stays unchanged because live deployment is still out of scope for the canonical workflow.
 
@@ -150,13 +176,18 @@ research:
     use_configured_test_window: true
   backtest:
     costs: { enabled: true, bps: 5 }
+  promotion:
+    targets:
+      - name: "aapl_daily_classifier"
+        symbol: "AAPL"
+        path: "models/promoted/aapl_daily_classifier"
 
 agents:
   - name: "paper_momentum"
     kind: "model"
     mode: "paper"
     model:
-      path: "models/trained/aapl_daily_classifier"
+      path: "models/promoted/aapl_daily_classifier"
     context:
       features: ["rsi_14"]
       positions: true
@@ -315,6 +346,7 @@ The canonical research compiler reads:
 - `model`
 - `evaluation.use_configured_test_window`
 - `backtest.costs`
+- `promotion.targets`
 
 Practical notes:
 
@@ -322,6 +354,11 @@ Practical notes:
 - setting it to `false` clears those fields and lets the downstream research runtime fall back to its chronological split behavior
 - `model.tuning.enabled` and `model.tuning.trials` flow directly into the training run
 - `backtest.costs.bps` becomes the transaction cost setting in the compiled runtime backtest config
+- `promotion.targets` maps promoted symbol artifacts into stable project-relative destinations under `models/`
+- each promotion target requires `name`, `symbol`, and `path`
+- `promotion.targets[].symbol` must exist in `data.symbols`
+- `promotion.targets[].path` must be project-relative and resolve under `models/`
+- promotion target names and paths must be unique
 
 Even when `research.enabled` is `false`, the agent runtime still reuses these defaults to compile consistent runtime configs.
 
@@ -448,7 +485,8 @@ deployment:
 
 Behavior:
 
-- `quanttradeai promote --run <run_id>` updates `deployment.mode` to `paper` when promoting a successful agent backtest run
+- `quanttradeai promote --run research/<run_id> -c config/project.yaml` copies trained model artifacts into stable `models/...` destinations and writes `promotion_manifest.json`
+- `quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml` updates `deployment.mode` to `paper` when promoting a successful agent backtest run
 - `quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` generates a bundle under `reports/deployments/<agent>/<timestamp>/`
 - generated bundles include `docker-compose.yml`, `Dockerfile`, `.env.example`, `README.md`, `resolved_project_config.yaml`, and `deployment_manifest.json`
 - generated compose services run `quanttradeai agent run --agent <name> -c config/project.yaml --mode paper`
@@ -506,6 +544,14 @@ Alongside `summary.json` and `metrics.json`, QuantTradeAI writes:
 - `runtime_features_config.yaml`
 - `runtime_backtest_config.yaml`
 - `backtest_summary.json` when automatic post-train backtests produce output
+
+Successful research runs also record `artifacts.experiment_dir` in `summary.json`, which is the source used by `quanttradeai promote --run research/<run_id>`.
+
+### `quanttradeai promote`
+
+Research promotion does not create a new run directory. It copies the configured symbol model directories into stable destinations under `models/` and writes `promotion_manifest.json` in each promoted destination.
+
+Agent promotion updates `config/project.yaml` in place. Backtest-to-paper promotion also updates `deployment.mode` to `paper`; paper-to-live promotion changes only the matching agent's mode.
 
 ### `quanttradeai agent run --mode backtest`
 

--- a/docs/examples/execution-costs.md
+++ b/docs/examples/execution-costs.md
@@ -3,8 +3,11 @@
 Run a simple backtest with and without execution costs and slippage.
 
 ```bash
-poetry run quanttradeai backtest --config config/backtest_config.yaml
-poetry run quanttradeai backtest --cost-bps 5 --slippage-bps 10
+poetry run quanttradeai backtest-model -m models/experiments/<timestamp>/<SYMBOL> \
+  -c config/model_config.yaml -b config/backtest_config.yaml
+poetry run quanttradeai backtest-model -m models/experiments/<timestamp>/<SYMBOL> \
+  -c config/model_config.yaml -b config/backtest_config.yaml \
+  --cost-bps 5 --slippage-bps 10
 ```
 
 The second command applies 5 bps transaction costs and 10 bps slippage, producing lower Sharpe ratio and PnL compared to the gross run.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,6 +26,12 @@ This path gives you:
 - a full research run with metrics and artifacts
 - standardized run records under `runs/research/...`
 
+To promote a successful research run into the stable model path used by the `model-agent` and `hybrid` templates:
+
+```bash
+poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
+```
+
 ## Workflow 2: Model Agent From `project.yaml`
 
 ```bash
@@ -36,11 +42,11 @@ poetry run quanttradeai validate -c config/project.yaml
 The model-agent template creates:
 
 - a canonical `config/project.yaml`
-- a placeholder model artifact directory at `models/trained/aapl_daily_classifier/`
+- a placeholder model artifact directory at `models/promoted/aapl_daily_classifier/`
 - a minimal `data.streaming` block
 - top-level `risk` and `position_manager` defaults for later live promotion
 
-Replace the placeholder model directory with a real trained model artifact before running the agent.
+Replace the placeholder model directory with a promoted research model artifact or another compatible saved model before running the agent.
 
 ### Backtest The Agent
 
@@ -95,13 +101,17 @@ Hybrid projects use the same pattern:
 
 ```bash
 poetry run quanttradeai init --template hybrid -o config/project.yaml
+poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode paper
 poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live hybrid_swing_agent
 poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode live
 ```
+
+The hybrid template already points `model_signal_sources` at `models/promoted/aapl_daily_classifier`, so the happy path does not require editing timestamped experiment directories by hand.
 
 Deployment bundles for project-defined paper agents are written under `reports/deployments/<agent>/<timestamp>/`.
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -14,6 +14,7 @@ poetry run quanttradeai validate -c config/project.yaml
 
 # Run canonical research workflow
 poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 poetry run quanttradeai runs list
 
 # Run a YAML-defined llm or hybrid agent
@@ -41,10 +42,6 @@ poetry run quanttradeai train --skip-validation  # bypass data-quality gate
 
 # Evaluate model
 poetry run quanttradeai evaluate -m models/experiments/<timestamp>/<SYMBOL>
-
-# Run backtest
-poetry run quanttradeai backtest --config config/backtest_config.yaml
-poetry run quanttradeai backtest --cost-bps 5 --slippage-bps 10
 
 # Backtest a saved model (end-to-end)
 poetry run quanttradeai backtest-model -m models/experiments/<timestamp>/<SYMBOL> \
@@ -161,7 +158,7 @@ X, y = classifier.prepare_data(df_labeled)
 classifier.train(X, y)
 
 # Save model
-classifier.save_model("models/trained/AAPL")
+classifier.save_model("models/promoted/aapl_daily_classifier")
 ```
 
 ### Backtesting

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -120,6 +120,15 @@ PROJECT_TEMPLATES = {
             },
             "evaluation": {"split": "time_aware", "use_configured_test_window": True},
             "backtest": {"costs": {"enabled": True, "bps": 5}},
+            "promotion": {
+                "targets": [
+                    {
+                        "name": "aapl_daily_classifier",
+                        "symbol": "AAPL",
+                        "path": "models/promoted/aapl_daily_classifier",
+                    }
+                ]
+            },
         },
         "agents": [],
         "deployment": {"target": "docker-compose", "mode": "paper"},
@@ -219,7 +228,7 @@ PROJECT_TEMPLATES = {
             "live": {"mode": "live"},
         },
         "data": {
-            "symbols": ["AAPL", "TSLA"],
+            "symbols": ["AAPL"],
             "start_date": "2018-01-01",
             "end_date": "2024-12-31",
             "timeframe": "1d",
@@ -230,7 +239,7 @@ PROJECT_TEMPLATES = {
                 "provider": "alpaca",
                 "websocket_url": "wss://stream.data.alpaca.markets/v2/iex",
                 "auth_method": "api_key",
-                "symbols": ["AAPL", "TSLA"],
+                "symbols": ["AAPL"],
                 "channels": ["trades", "quotes"],
                 "buffer_size": 1000,
                 "reconnect_attempts": 5,
@@ -260,6 +269,15 @@ PROJECT_TEMPLATES = {
             },
             "evaluation": {"split": "time_aware", "use_configured_test_window": True},
             "backtest": {"costs": {"enabled": True, "bps": 5}},
+            "promotion": {
+                "targets": [
+                    {
+                        "name": "aapl_daily_classifier",
+                        "symbol": "AAPL",
+                        "path": "models/promoted/aapl_daily_classifier",
+                    }
+                ]
+            },
         },
         "risk": {
             "drawdown_protection": {
@@ -292,7 +310,12 @@ PROJECT_TEMPLATES = {
                 "name": "hybrid_swing_agent",
                 "kind": "hybrid",
                 "mode": "paper",
-                "model_signal_sources": [],
+                "model_signal_sources": [
+                    {
+                        "name": "aapl_daily_classifier",
+                        "path": "models/promoted/aapl_daily_classifier",
+                    }
+                ],
                 "llm": {
                     "provider": "openai",
                     "model": "gpt-5.3",
@@ -300,7 +323,7 @@ PROJECT_TEMPLATES = {
                 },
                 "context": {
                     "features": ["rsi_14"],
-                    "model_signals": [],
+                    "model_signals": ["aapl_daily_classifier"],
                     "positions": True,
                 },
                 "tools": ["get_quote", "place_order"],
@@ -389,7 +412,7 @@ PROJECT_TEMPLATES = {
                 "name": "paper_momentum",
                 "kind": "model",
                 "mode": "paper",
-                "model": {"path": "models/trained/aapl_daily_classifier"},
+                "model": {"path": "models/promoted/aapl_daily_classifier"},
                 "context": {
                     "features": ["rsi_14"],
                     "positions": True,
@@ -507,9 +530,13 @@ Review the provided market data, engineered features, current position state, ri
 Treat model signals as one input, not an automatic order.
 Use the available tools only as reference context; do not invent tool output.
 """,
+        "models/promoted/aapl_daily_classifier/README.md": """# Placeholder Model Artifact
+
+Replace this directory with a promoted research model artifact before running the hybrid agent.
+""",
     },
     "model-agent": {
-        "models/trained/aapl_daily_classifier/README.md": """# Placeholder Model Artifact
+        "models/promoted/aapl_daily_classifier/README.md": """# Placeholder Model Artifact
 
 Replace this directory with a trained model artifact before running the model agent.
 """
@@ -1214,7 +1241,9 @@ def cmd_runs_list(
 @app.command("promote")
 def cmd_promote(
     run: str = typer.Option(
-        ..., "--run", help="Run id to promote, for example agent/backtest/<run>"
+        ...,
+        "--run",
+        help="Run id to promote, for example research/<run> or agent/backtest/<run>",
     ),
     config: str = typer.Option(
         "config/project.yaml", "-c", "--config", help="Path to project config YAML"
@@ -1235,12 +1264,12 @@ def cmd_promote(
         help="Required for --to live. Must exactly match the agent name being promoted.",
     ),
 ):
-    """Promote a successful agent run to the next supported mode."""
+    """Promote a successful research or agent run in the canonical workflow."""
 
-    from .utils.promotion import promote_agent_run
+    from .utils.promotion import promote_run
 
     try:
-        result = promote_agent_run(
+        result = promote_run(
             run_id=run,
             config_path=config,
             target_mode=target,

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -577,6 +577,26 @@ class ProjectResearchBacktestConfig(BaseModel):
     )
 
 
+class ProjectResearchPromotionTargetConfig(BaseModel):
+    name: str
+    symbol: str
+    path: str
+
+    @model_validator(mode="after")
+    def validate_required_strings(self) -> "ProjectResearchPromotionTargetConfig":
+        if not self.name.strip():
+            raise ValueError("research.promotion.targets[].name must not be blank.")
+        if not self.symbol.strip():
+            raise ValueError("research.promotion.targets[].symbol must not be blank.")
+        if not self.path.strip():
+            raise ValueError("research.promotion.targets[].path must not be blank.")
+        return self
+
+
+class ProjectResearchPromotionConfig(BaseModel):
+    targets: List[ProjectResearchPromotionTargetConfig] = Field(default_factory=list)
+
+
 class ProjectResearchSection(BaseModel):
     enabled: bool = True
     labels: ProjectResearchLabelsConfig = Field(
@@ -590,6 +610,9 @@ class ProjectResearchSection(BaseModel):
     )
     backtest: ProjectResearchBacktestConfig = Field(
         default_factory=ProjectResearchBacktestConfig
+    )
+    promotion: ProjectResearchPromotionConfig = Field(
+        default_factory=ProjectResearchPromotionConfig
     )
 
 

--- a/quanttradeai/utils/config_validator.py
+++ b/quanttradeai/utils/config_validator.py
@@ -29,7 +29,7 @@ from quanttradeai.utils.config_schemas import (
     RiskManagementConfig,
 )
 from quanttradeai.utils.impact_loader import ImpactConfigError, load_impact_config
-from quanttradeai.utils.project_paths import resolve_project_path
+from quanttradeai.utils.project_paths import infer_project_root, resolve_project_path
 from quanttradeai.utils.project_config import load_project_config
 
 
@@ -79,6 +79,93 @@ def _rule_feature_is_rsi_resolvable(feature_definition: dict[str, Any]) -> bool:
         {"rsi", "macd", "macd_signal", "macd_hist"},
     )
     return len(resolved_columns) == 1 and resolved_columns[0] == "rsi"
+
+
+def _validate_models_relative_path(
+    *,
+    config_path: Path,
+    raw_path: str,
+    field_name: str,
+) -> Path:
+    candidate = str(raw_path or "").strip()
+    if not candidate:
+        raise ValueError(f"{field_name} must not be blank.")
+
+    path = Path(candidate)
+    if path.is_absolute():
+        raise ValueError(f"{field_name} must be project-relative and under models/.")
+
+    project_root = infer_project_root(config_path)
+    resolved_path = resolve_project_path(config_path, candidate)
+    try:
+        relative = resolved_path.resolve().relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must resolve inside the project root under models/."
+        ) from exc
+
+    if not relative.parts or relative.parts[0] != "models":
+        raise ValueError(f"{field_name} must resolve under models/.")
+
+    return resolved_path
+
+
+def _validate_research_project_sections(
+    *,
+    resolved: dict[str, Any],
+    config_path: Path,
+) -> None:
+    errors: list[str] = []
+    symbols = {
+        str(symbol) for symbol in (resolved.get("data") or {}).get("symbols", [])
+    }
+    promotion_targets = list(
+        ((resolved.get("research") or {}).get("promotion") or {}).get("targets") or []
+    )
+
+    seen_names: set[str] = set()
+    seen_paths: set[str] = set()
+    for index, target in enumerate(promotion_targets):
+        target_name = str(target.get("name") or "").strip()
+        target_symbol = str(target.get("symbol") or "").strip()
+        target_path = str(target.get("path") or "").strip()
+        target_label = f"research.promotion.targets[{index}]"
+
+        if not target_name:
+            errors.append(f"{target_label}.name must not be blank.")
+        elif target_name in seen_names:
+            errors.append(
+                f"{target_label}.name duplicates research promotion target name '{target_name}'."
+            )
+        else:
+            seen_names.add(target_name)
+
+        if target_symbol not in symbols:
+            errors.append(
+                f"{target_label}.symbol must reference one of data.symbols. Received: {target_symbol or '<blank>'}"
+            )
+
+        try:
+            resolved_path = _validate_models_relative_path(
+                config_path=config_path,
+                raw_path=target_path,
+                field_name=f"{target_label}.path",
+            )
+        except ValueError as exc:
+            errors.append(str(exc))
+        else:
+            normalized_path = resolved_path.relative_to(
+                infer_project_root(config_path)
+            ).as_posix()
+            if normalized_path in seen_paths:
+                errors.append(
+                    f"{target_label}.path duplicates research promotion target path '{normalized_path}'."
+                )
+            else:
+                seen_paths.add(normalized_path)
+
+    if errors:
+        raise ValueError("\n".join(errors))
 
 
 def _validate_agent_project_sections(
@@ -304,6 +391,10 @@ def validate_project_config(
 
     cfg = ProjectConfigSchema(**raw)
     resolved = _merge_preserving_unknown(raw, cfg.model_dump(mode="json"))
+    _validate_research_project_sections(
+        resolved=resolved,
+        config_path=path,
+    )
 
     unused_legacy_sections = sorted(LEGACY_PROJECT_SECTIONS.intersection(raw.keys()))
     warnings = list(loaded.warnings)

--- a/quanttradeai/utils/promotion.py
+++ b/quanttradeai/utils/promotion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import posixpath
 import shutil
 import tempfile
 from datetime import datetime, timezone
@@ -270,7 +271,7 @@ def _resolve_research_promotion_targets(
             )
         seen_names.add(target["name"])
 
-        normalized_path = Path(target["path"]).as_posix()
+        normalized_path = posixpath.normpath(Path(target["path"]).as_posix())
         if normalized_path in seen_paths:
             raise ValueError(
                 "research promotion target paths must be unique. "

--- a/quanttradeai/utils/promotion.py
+++ b/quanttradeai/utils/promotion.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import copy
 import json
+import shutil
+import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +15,7 @@ from pydantic import ValidationError
 
 from quanttradeai.utils.config_schemas import ProjectConfigSchema
 from quanttradeai.utils.project_config import extract_canonical_live_risk_config
+from quanttradeai.utils.project_paths import infer_project_root, resolve_project_path
 from quanttradeai.utils.run_records import RUNS_ROOT, discover_runs
 
 
@@ -72,7 +76,7 @@ def _summary_path_for_record(record: dict[str, Any], runs_root: Path | str) -> P
     )
 
 
-def _validate_promotable_run(
+def _validate_agent_promotable_run(
     record: dict[str, Any],
     summary: dict[str, Any],
     *,
@@ -100,6 +104,39 @@ def _validate_promotable_run(
         raise ValueError("Promotable agent run is missing an agent name.")
 
     return agent_name, required_source_mode
+
+
+def _validate_research_promotable_run(
+    record: dict[str, Any],
+    summary: dict[str, Any],
+    *,
+    target_mode: str,
+    acknowledge_live: str | None,
+) -> tuple[str, str]:
+    run_type = str(summary.get("run_type") or record.get("run_type") or "")
+    mode = str(summary.get("mode") or record.get("mode") or "")
+    status = str(summary.get("status") or record.get("status") or "")
+
+    if run_type != "research" or mode != "research" or status != "success":
+        raise ValueError(
+            "Only successful research runs can promote models into stable project paths."
+        )
+    if target_mode != "paper":
+        raise ValueError(
+            "Research run promotion does not support --to. Omit --to and use the default promote behavior."
+        )
+    if acknowledge_live is not None:
+        raise ValueError(
+            "--acknowledge-live is only supported when promoting agent paper runs to live."
+        )
+
+    project_name = str(
+        summary.get("project_name") or summary.get("name") or record.get("name") or ""
+    ).strip()
+    if not project_name:
+        raise ValueError("Promotable research run is missing a project name.")
+
+    return project_name, "research"
 
 
 def _apply_paper_promotion(
@@ -196,37 +233,262 @@ def _apply_live_promotion(
     return proposed, changed
 
 
-def promote_agent_run(
+def _resolve_research_promotion_targets(
+    project_config: dict[str, Any],
+) -> list[dict[str, str]]:
+    try:
+        resolved_config = ProjectConfigSchema(**project_config)
+    except ValidationError as exc:
+        raise ValueError(f"Project config is invalid: {exc}") from exc
+
+    targets = [
+        {
+            "name": target.name,
+            "symbol": target.symbol,
+            "path": target.path,
+        }
+        for target in resolved_config.research.promotion.targets
+    ]
+    if not targets:
+        raise ValueError(
+            "research.promotion.targets must define at least one target before promoting a research run."
+        )
+
+    available_symbols = set(resolved_config.data.symbols)
+    seen_names: set[str] = set()
+    seen_paths: set[str] = set()
+    for target in targets:
+        if target["symbol"] not in available_symbols:
+            raise ValueError(
+                "research promotion target symbol must reference one of data.symbols. "
+                f"Received: {target['symbol']}"
+            )
+
+        if target["name"] in seen_names:
+            raise ValueError(
+                f"research promotion target names must be unique. Duplicate: {target['name']}"
+            )
+        seen_names.add(target["name"])
+
+        normalized_path = Path(target["path"]).as_posix()
+        if normalized_path in seen_paths:
+            raise ValueError(
+                "research promotion target paths must be unique. "
+                f"Duplicate: {normalized_path}"
+            )
+        seen_paths.add(normalized_path)
+
+    return targets
+
+
+def _research_experiment_dir(
     *,
-    run_id: str | Path,
-    config_path: str | Path = "config/project.yaml",
-    target_mode: str = "paper",
-    dry_run: bool = False,
-    acknowledge_live: str | None = None,
-    runs_root: Path | str = RUNS_ROOT,
+    summary: dict[str, Any],
+    config_path: Path,
+) -> Path:
+    artifacts = dict(summary.get("artifacts") or {})
+    experiment_dir_raw = str(artifacts.get("experiment_dir") or "").strip()
+    if not experiment_dir_raw:
+        raise ValueError(
+            "Research run summary is missing artifacts.experiment_dir; cannot locate trained models to promote."
+        )
+
+    experiment_dir = resolve_project_path(config_path, experiment_dir_raw)
+    if not experiment_dir.is_dir():
+        raise ValueError(
+            f"Research run experiment directory does not exist: {experiment_dir}"
+        )
+    return experiment_dir
+
+
+def _resolve_promoted_model_destination(
+    *,
+    config_path: Path,
+    relative_path: str,
+) -> Path:
+    raw_path = str(relative_path or "").strip()
+    path = Path(raw_path)
+    if not raw_path:
+        raise ValueError("research promotion destination path must not be blank.")
+    if path.is_absolute():
+        raise ValueError(
+            "research promotion destination path must be project-relative and under models/."
+        )
+
+    project_root = infer_project_root(config_path)
+    resolved_path = resolve_project_path(config_path, raw_path)
+    try:
+        relative = resolved_path.resolve().relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise ValueError(
+            "research promotion destination path must resolve inside the project root under models/."
+        ) from exc
+
+    if not relative.parts or relative.parts[0] != "models":
+        raise ValueError(
+            "research promotion destination path must resolve under models/."
+        )
+    return resolved_path
+
+
+def _stage_promoted_directory(
+    *,
+    source_dir: Path,
+    destination_dir: Path,
+    manifest: dict[str, Any],
+) -> tuple[Path, Path]:
+    destination_dir.parent.mkdir(parents=True, exist_ok=True)
+    temp_root = Path(
+        tempfile.mkdtemp(
+            prefix=f".quanttradeai-promote-{destination_dir.name}-",
+            dir=destination_dir.parent,
+        )
+    )
+    staged_dir = temp_root / destination_dir.name
+    shutil.copytree(source_dir, staged_dir)
+    (staged_dir / "promotion_manifest.json").write_text(
+        json.dumps(manifest, indent=2),
+        encoding="utf-8",
+    )
+    return temp_root, staged_dir
+
+
+def _commit_promoted_directory(
+    *,
+    staged_dir: Path,
+    temp_root: Path,
+    destination_dir: Path,
+) -> None:
+    if destination_dir.exists() and not destination_dir.is_dir():
+        raise ValueError(
+            f"Promotion destination already exists and is not a directory: {destination_dir}"
+        )
+
+    backup_dir: Path | None = None
+    try:
+        if destination_dir.exists():
+            backup_dir = destination_dir.parent / (
+                f".quanttradeai-backup-{destination_dir.name}-"
+                f"{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S_%f')}"
+            )
+            destination_dir.rename(backup_dir)
+
+        staged_dir.rename(destination_dir)
+        if backup_dir is not None and backup_dir.exists():
+            shutil.rmtree(backup_dir)
+    except Exception:
+        if (
+            backup_dir is not None
+            and backup_dir.exists()
+            and not destination_dir.exists()
+        ):
+            backup_dir.rename(destination_dir)
+        raise
+    finally:
+        if temp_root.exists():
+            shutil.rmtree(temp_root, ignore_errors=True)
+
+
+def _promote_research_run(
+    *,
+    record: dict[str, Any],
+    summary: dict[str, Any],
+    config_path: Path,
+    dry_run: bool,
 ) -> dict[str, Any]:
-    """Promote a successful project-defined agent run to paper or live."""
+    project_config = _load_yaml_mapping(config_path)
+    targets = _resolve_research_promotion_targets(project_config)
+    experiment_dir = _research_experiment_dir(summary=summary, config_path=config_path)
 
-    target_mode = target_mode.strip().lower()
-    if target_mode not in {"paper", "live"}:
-        raise ValueError("Only promotion to paper or live is supported.")
+    promoted_targets: list[dict[str, Any]] = []
+    staged_targets: list[tuple[Path, Path, Path]] = []
+    promoted_at = datetime.now(timezone.utc).isoformat()
 
-    record = _find_run_record(run_id, runs_root=runs_root)
-    summary_path = _summary_path_for_record(record, runs_root)
-    summary = _load_json(summary_path)
-    agent_name, source_mode = _validate_promotable_run(
+    for target in targets:
+        source_dir = experiment_dir / target["symbol"]
+        if not source_dir.is_dir():
+            raise ValueError(
+                f"Research run is missing a trained model artifact for symbol '{target['symbol']}' at {source_dir}"
+            )
+
+        destination_dir = _resolve_promoted_model_destination(
+            config_path=config_path,
+            relative_path=target["path"],
+        )
+        manifest = {
+            "source_run_id": str(record.get("run_id") or summary.get("run_id") or ""),
+            "project_name": summary.get("project_name"),
+            "target_name": target["name"],
+            "symbol": target["symbol"],
+            "source_path": source_dir.as_posix(),
+            "destination_path": destination_dir.as_posix(),
+            "promoted_at": promoted_at,
+        }
+        temp_root, staged_dir = _stage_promoted_directory(
+            source_dir=source_dir,
+            destination_dir=destination_dir,
+            manifest=manifest,
+        )
+        staged_targets.append((temp_root, staged_dir, destination_dir))
+        promoted_targets.append(
+            {
+                "name": target["name"],
+                "symbol": target["symbol"],
+                "source_path": source_dir.as_posix(),
+                "destination_path": destination_dir.as_posix(),
+                "manifest_path": (
+                    destination_dir / "promotion_manifest.json"
+                ).as_posix(),
+            }
+        )
+
+    try:
+        if not dry_run:
+            for temp_root, staged_dir, destination_dir in staged_targets:
+                _commit_promoted_directory(
+                    staged_dir=staged_dir,
+                    temp_root=temp_root,
+                    destination_dir=destination_dir,
+                )
+    finally:
+        if dry_run:
+            for temp_root, _staged_dir, _destination_dir in staged_targets:
+                if temp_root.exists():
+                    shutil.rmtree(temp_root, ignore_errors=True)
+
+    return {
+        "status": "success",
+        "source_run_id": str(
+            record.get("run_id") or _normalize_run_id(summary.get("run_id") or "")
+        ),
+        "run_type": "research",
+        "project_name": summary.get("project_name"),
+        "config_path": config_path.as_posix(),
+        "dry_run": dry_run,
+        "changed": bool(promoted_targets),
+        "experiment_dir": experiment_dir.as_posix(),
+        "promoted_targets": promoted_targets,
+    }
+
+
+def _promote_agent_run(
+    *,
+    record: dict[str, Any],
+    summary: dict[str, Any],
+    config_path: Path,
+    target_mode: str,
+    dry_run: bool,
+    acknowledge_live: str | None,
+) -> dict[str, Any]:
+    agent_name, source_mode = _validate_agent_promotable_run(
         record,
         summary,
         target_mode=target_mode,
     )
-    if target_mode == "live":
-        if acknowledge_live != agent_name:
-            raise ValueError(
-                f"Promoting to live requires --acknowledge-live {agent_name}"
-            )
+    if target_mode == "live" and acknowledge_live != agent_name:
+        raise ValueError(f"Promoting to live requires --acknowledge-live {agent_name}")
 
-    project_config_path = Path(config_path)
-    project_config = _load_yaml_mapping(project_config_path)
+    project_config = _load_yaml_mapping(config_path)
     if target_mode == "paper":
         promoted_config, changed = _apply_paper_promotion(
             project_config,
@@ -239,19 +501,22 @@ def promote_agent_run(
         )
 
     if changed and not dry_run:
-        project_config_path.write_text(
+        config_path.write_text(
             yaml.safe_dump(promoted_config, sort_keys=False),
             encoding="utf-8",
         )
 
-    config_path_display = project_config_path.as_posix()
+    config_path_display = config_path.as_posix()
     next_command = (
         f"quanttradeai agent run --agent {agent_name} "
         f"-c {config_path_display} --mode {target_mode}"
     )
     return {
         "status": "success",
-        "source_run_id": str(record.get("run_id") or _normalize_run_id(run_id)),
+        "source_run_id": str(
+            record.get("run_id") or _normalize_run_id(summary.get("run_id") or "")
+        ),
+        "run_type": "agent",
         "agent_name": agent_name,
         "from_mode": source_mode,
         "to_mode": target_mode,
@@ -260,3 +525,69 @@ def promote_agent_run(
         "dry_run": dry_run,
         "next_command": next_command,
     }
+
+
+def promote_run(
+    *,
+    run_id: str | Path,
+    config_path: str | Path = "config/project.yaml",
+    target_mode: str = "paper",
+    dry_run: bool = False,
+    acknowledge_live: str | None = None,
+    runs_root: Path | str = RUNS_ROOT,
+) -> dict[str, Any]:
+    """Promote a successful research or agent run through the canonical workflow."""
+
+    target_mode = target_mode.strip().lower()
+    if target_mode not in {"paper", "live"}:
+        raise ValueError("Only promotion to paper or live is supported.")
+
+    record = _find_run_record(run_id, runs_root=runs_root)
+    summary_path = _summary_path_for_record(record, runs_root)
+    summary = _load_json(summary_path)
+    run_type = str(summary.get("run_type") or record.get("run_type") or "")
+    project_config_path = Path(config_path)
+
+    if run_type == "research":
+        _validate_research_promotable_run(
+            record,
+            summary,
+            target_mode=target_mode,
+            acknowledge_live=acknowledge_live,
+        )
+        return _promote_research_run(
+            record=record,
+            summary=summary,
+            config_path=project_config_path,
+            dry_run=dry_run,
+        )
+
+    return _promote_agent_run(
+        record=record,
+        summary=summary,
+        config_path=project_config_path,
+        target_mode=target_mode,
+        dry_run=dry_run,
+        acknowledge_live=acknowledge_live,
+    )
+
+
+def promote_agent_run(
+    *,
+    run_id: str | Path,
+    config_path: str | Path = "config/project.yaml",
+    target_mode: str = "paper",
+    dry_run: bool = False,
+    acknowledge_live: str | None = None,
+    runs_root: Path | str = RUNS_ROOT,
+) -> dict[str, Any]:
+    """Backward-compatible wrapper around the generalized promotion entrypoint."""
+
+    return promote_run(
+        run_id=run_id,
+        config_path=config_path,
+        target_mode=target_mode,
+        dry_run=dry_run,
+        acknowledge_live=acknowledge_live,
+        runs_root=runs_root,
+    )

--- a/roadmap.md
+++ b/roadmap.md
@@ -141,6 +141,11 @@ research:
     use_configured_test_window: true
   backtest:
     costs: { enabled: true, bps: 5 }
+  promotion:
+    targets:
+      - name: "aapl_daily_classifier"
+        symbol: "AAPL"
+        path: "models/promoted/aapl_daily_classifier"
 
 agents:
   - name: "breakout_gpt"
@@ -170,7 +175,7 @@ agents:
     mode: "paper"
     model_signal_sources:
       - name: "aapl_daily_classifier"
-        path: "models/experiments/aapl_daily_classifier"
+        path: "models/promoted/aapl_daily_classifier"
     llm:
       provider: "openai"
       model: "gpt-5.3"
@@ -331,7 +336,9 @@ Status on 2026-04-10:
 - Rule-agent paper runs now persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, `decisions.jsonl`, and `executions.jsonl` under `runs/agent/paper/...`.
 - Live agent runs now persist resolved config, runtime streaming/risk/position-manager YAML snapshots, `summary.json`, `metrics.json`, `executions.jsonl`, and `decisions.jsonl` under `runs/agent/live/...`, with `prompt_samples.json` for `llm` and `hybrid`.
 - `quanttradeai runs list` is implemented for local research and agent run discovery.
-- `quanttradeai promote --run <run_id>` is implemented for successful agent backtest-to-paper promotion.
+- `quanttradeai promote --run research/<run_id> -c config/project.yaml` is implemented for successful research-model promotion into stable `models/...` paths, with `promotion_manifest.json` written in each promoted destination.
+- The `research` and `hybrid` templates now include `research.promotion.targets`, and the `hybrid` and `model-agent` templates are wired to stable `models/promoted/...` paths for the happy path.
+- `quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml` is implemented for successful agent backtest-to-paper promotion.
 - `quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live <agent_name>` is implemented for successful paper-to-live promotion with an explicit safety acknowledgement.
 - Top-level `risk` and `position_manager` are now the canonical live safety/runtime sections in `config/project.yaml`.
 - `quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` now generates a paper-agent deployment bundle with compose, Dockerfile, env placeholders, resolved config, and a deployment manifest.
@@ -402,10 +409,10 @@ The roadmap is only successful if these workflows feel excellent.
 ### Workflow C: Build a hybrid agent from research outputs
 
 1. Train a model in the research track.
-2. Reference that model's signals from an agent in the same project.
-3. Combine engineered features, model signals, and prompt context in one agent config.
-4. Run in paper mode.
-5. Promote to live with explicit operator acknowledgement.
+2. Promote the winning research artifact into a stable `models/promoted/...` path.
+3. Reference that model's signals from an agent in the same project.
+4. Combine engineered features, model signals, and prompt context in one agent config.
+5. Run in paper mode, then promote to live with explicit operator acknowledgement.
 
 ## Happy-Path CLI
 
@@ -420,7 +427,7 @@ quanttradeai init --template research -o config/project.yaml
 quanttradeai validate -c config/project.yaml
 quanttradeai research run -c config/project.yaml
 quanttradeai runs list
-quanttradeai promote --run <run_id>
+quanttradeai promote --run research/<run_id> -c config/project.yaml
 ```
 
 ### Agent track
@@ -429,6 +436,7 @@ quanttradeai promote --run <run_id>
 quanttradeai init --template model-agent -o config/project.yaml
 quanttradeai validate -c config/project.yaml
 quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
+quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode paper
 quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live paper_momentum
 quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode live
@@ -442,7 +450,11 @@ Current implementation note:
 
 ```bash
 quanttradeai init --template hybrid -o config/project.yaml
+quanttradeai validate -c config/project.yaml
 quanttradeai research run -c config/project.yaml
+quanttradeai promote --run research/<run_id> -c config/project.yaml
+quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode backtest
+quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode paper
 quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live hybrid_swing_agent
 quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode live

--- a/tests/integration/test_agent_cli.py
+++ b/tests/integration/test_agent_cli.py
@@ -415,7 +415,7 @@ def test_hybrid_agent_run_includes_model_signals(tmp_path: Path, monkeypatch):
     )
     assert init_result.exit_code == 0, init_result.stdout
 
-    model_dir = Path("models/trained/aapl_daily_classifier")
+    model_dir = Path("models/promoted/aapl_daily_classifier")
     model_dir.mkdir(parents=True, exist_ok=True)
 
     config_path = Path("config/project.yaml")
@@ -424,13 +424,6 @@ def test_hybrid_agent_run_includes_model_signals(tmp_path: Path, monkeypatch):
     config_payload["data"]["end_date"] = "2024-02-09"
     config_payload["data"]["test_start"] = "2024-01-26"
     config_payload["data"]["test_end"] = "2024-01-31"
-    config_payload["agents"][0]["model_signal_sources"] = [
-        {
-            "name": "aapl_daily_classifier",
-            "path": "models/trained/aapl_daily_classifier",
-        }
-    ]
-    config_payload["agents"][0]["context"]["model_signals"] = ["aapl_daily_classifier"]
     config_path.write_text(
         yaml.safe_dump(config_payload, sort_keys=False),
         encoding="utf-8",
@@ -1108,7 +1101,7 @@ def test_hybrid_agent_paper_run_includes_model_signals_in_decisions(
     )
     assert init_result.exit_code == 0, init_result.stdout
 
-    model_dir = Path("models/trained/aapl_daily_classifier")
+    model_dir = Path("models/promoted/aapl_daily_classifier")
     model_dir.mkdir(parents=True, exist_ok=True)
 
     config_path = Path("config/project.yaml")
@@ -1118,13 +1111,6 @@ def test_hybrid_agent_paper_run_includes_model_signals_in_decisions(
     config_payload["data"]["test_start"] = "2024-02-01"
     config_payload["data"]["test_end"] = "2024-02-09"
     config_payload["agents"][0]["mode"] = "paper"
-    config_payload["agents"][0]["model_signal_sources"] = [
-        {
-            "name": "aapl_daily_classifier",
-            "path": "models/trained/aapl_daily_classifier",
-        }
-    ]
-    config_payload["agents"][0]["context"]["model_signals"] = ["aapl_daily_classifier"]
     config_path.write_text(
         yaml.safe_dump(config_payload, sort_keys=False),
         encoding="utf-8",

--- a/tests/integration/test_promote_cli.py
+++ b/tests/integration/test_promote_cli.py
@@ -512,6 +512,42 @@ def test_promote_research_run_rejects_incompatible_flags_and_missing_artifacts(
         assert not (destination_dir / "promotion_manifest.json").exists()
 
 
+def test_promote_research_run_rejects_canonical_duplicate_target_paths(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    payload = _write_research_project_config(config_path)
+    payload["research"]["promotion"]["targets"].append(
+        {
+            "name": "aapl_daily_classifier_alias",
+            "symbol": "AAPL",
+            "path": "models/promoted/../promoted/aapl_daily_classifier",
+        }
+    )
+    config_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    run_id = "research/20260101_010000_research_lab"
+    _write_run_summary(
+        run_id=run_id,
+        run_type="research",
+        mode="research",
+        agent_name=None,
+        artifacts={"experiment_dir": "models/experiments/20260101_010000"},
+    )
+
+    result = runner.invoke(
+        app,
+        ["promote", "--run", run_id, "--config", str(config_path)],
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert "research promotion target paths must be unique" in combined_output
+    assert "models/promoted/aapl_daily_classifier" in combined_output
+
+
 def test_promote_requires_streaming_before_writing_paper_config(
     tmp_path: Path,
     monkeypatch,

--- a/tests/integration/test_promote_cli.py
+++ b/tests/integration/test_promote_cli.py
@@ -38,6 +38,15 @@ def _write_project_config(
     return payload
 
 
+def _write_research_project_config(path: Path) -> dict:
+    payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return payload
+
+
 def _write_run_summary(
     *,
     run_id: str = "agent/backtest/20260101_010000_breakout_gpt",
@@ -45,6 +54,8 @@ def _write_run_summary(
     mode: str = "backtest",
     status: str = "success",
     agent_name: str | None = "breakout_gpt",
+    artifacts: dict | None = None,
+    project_name: str | None = None,
 ) -> Path:
     run_dir = Path("runs").joinpath(*run_id.split("/"))
     summary = {
@@ -57,7 +68,7 @@ def _write_run_summary(
             "started_at": "2026-01-01T01:00:00+00:00",
             "completed_at": "2026-01-01T01:05:00+00:00",
         },
-        "artifacts": {},
+        "artifacts": dict(artifacts or {}),
         "warnings": [],
         "run_id": run_id,
         "run_dir": str(run_dir),
@@ -65,7 +76,7 @@ def _write_run_summary(
     if agent_name is not None:
         summary["agent_name"] = agent_name
     if run_type == "research":
-        summary["project_name"] = "research_lab"
+        summary["project_name"] = project_name or "research_lab"
 
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "summary.json").write_text(
@@ -189,6 +200,7 @@ def test_promote_failure_cases_do_not_mutate_project_yaml(
         run_id="research/20260101_000000_research_lab",
         run_type="research",
         mode="research",
+        status="failed",
         agent_name=None,
     )
     _write_run_summary(
@@ -230,7 +242,7 @@ def test_promote_failure_cases_do_not_mutate_project_yaml(
                 "--config",
                 str(config_path),
             ],
-            "Only successful agent backtest runs",
+            "Only successful research runs can promote models into stable project paths",
         ),
         (
             [
@@ -278,6 +290,226 @@ def test_promote_failure_cases_do_not_mutate_project_yaml(
         combined_output = f"{result.stdout}\n{result.stderr}"
         assert expected in combined_output
         assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_promote_research_run_copies_models_to_promoted_paths(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_research_project_config(config_path)
+
+    experiment_dir = Path("models/experiments/20260101_010000")
+    source_dir = experiment_dir / "AAPL"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "model.pkl").write_text("binary-placeholder", encoding="utf-8")
+    nested_dir = source_dir / "metadata"
+    nested_dir.mkdir(parents=True, exist_ok=True)
+    (nested_dir / "features.json").write_text(
+        json.dumps({"features": ["rsi_14"]}),
+        encoding="utf-8",
+    )
+
+    destination_dir = Path("models/promoted/aapl_daily_classifier")
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    (destination_dir / "stale.txt").write_text("old-model", encoding="utf-8")
+
+    run_id = "research/20260101_010000_research_lab"
+    _write_run_summary(
+        run_id=run_id,
+        run_type="research",
+        mode="research",
+        agent_name=None,
+        artifacts={"experiment_dir": experiment_dir.as_posix()},
+    )
+
+    result = runner.invoke(
+        app,
+        ["promote", "--run", run_id, "--config", str(config_path)],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    manifest_path = destination_dir / "promotion_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert payload["status"] == "success"
+    assert payload["run_type"] == "research"
+    assert payload["source_run_id"] == run_id
+    assert payload["changed"] is True
+    assert payload["dry_run"] is False
+    assert payload["promoted_targets"] == [
+        {
+            "name": "aapl_daily_classifier",
+            "symbol": "AAPL",
+            "source_path": source_dir.resolve().as_posix(),
+            "destination_path": destination_dir.resolve().as_posix(),
+            "manifest_path": manifest_path.resolve().as_posix(),
+        }
+    ]
+    assert (destination_dir / "model.pkl").read_text(encoding="utf-8") == (
+        "binary-placeholder"
+    )
+    assert json.loads(
+        (destination_dir / "metadata" / "features.json").read_text(encoding="utf-8")
+    ) == {"features": ["rsi_14"]}
+    assert not (destination_dir / "stale.txt").exists()
+    assert manifest["source_run_id"] == run_id
+    assert manifest["symbol"] == "AAPL"
+    assert manifest["target_name"] == "aapl_daily_classifier"
+    assert manifest["source_path"] == source_dir.resolve().as_posix()
+
+
+def test_promote_research_run_dry_run_is_non_mutating(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_research_project_config(config_path)
+
+    experiment_dir = Path("models/experiments/20260101_010000")
+    source_dir = experiment_dir / "AAPL"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "model.pkl").write_text("binary-placeholder", encoding="utf-8")
+
+    destination_dir = Path("models/promoted/aapl_daily_classifier")
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    original = destination_dir / "keep.txt"
+    original.write_text("stable-model", encoding="utf-8")
+
+    run_id = "research/20260101_010000_research_lab"
+    _write_run_summary(
+        run_id=run_id,
+        run_type="research",
+        mode="research",
+        agent_name=None,
+        artifacts={"experiment_dir": experiment_dir.as_posix()},
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "--run",
+            run_id,
+            "--config",
+            str(config_path),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["changed"] is True
+    assert payload["dry_run"] is True
+    assert original.read_text(encoding="utf-8") == "stable-model"
+    assert not (destination_dir / "promotion_manifest.json").exists()
+    assert not any(
+        path.name.startswith(".quanttradeai-promote-")
+        for path in destination_dir.parent.iterdir()
+    )
+
+
+def test_promote_research_run_rejects_incompatible_flags_and_missing_artifacts(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_research_project_config(config_path)
+
+    destination_dir = Path("models/promoted/aapl_daily_classifier")
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    preserved = destination_dir / "keep.txt"
+    preserved.write_text("stable-model", encoding="utf-8")
+
+    failed_run_id = "research/20260101_000000_failed_research_lab"
+    _write_run_summary(
+        run_id=failed_run_id,
+        run_type="research",
+        mode="research",
+        status="failed",
+        agent_name=None,
+        artifacts={"experiment_dir": "models/experiments/20260101_000000"},
+    )
+
+    missing_artifact_run_id = "research/20260101_010000_research_lab"
+    experiment_dir = Path("models/experiments/20260101_010000")
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+    _write_run_summary(
+        run_id=missing_artifact_run_id,
+        run_type="research",
+        mode="research",
+        agent_name=None,
+        artifacts={"experiment_dir": experiment_dir.as_posix()},
+    )
+
+    cases = [
+        (
+            [
+                "promote",
+                "--run",
+                "research/missing",
+                "--config",
+                str(config_path),
+            ],
+            "Run not found",
+        ),
+        (
+            [
+                "promote",
+                "--run",
+                failed_run_id,
+                "--config",
+                str(config_path),
+            ],
+            "Only successful research runs can promote models into stable project paths",
+        ),
+        (
+            [
+                "promote",
+                "--run",
+                missing_artifact_run_id,
+                "--config",
+                str(config_path),
+            ],
+            "Research run is missing a trained model artifact for symbol 'AAPL'",
+        ),
+        (
+            [
+                "promote",
+                "--run",
+                missing_artifact_run_id,
+                "--config",
+                str(config_path),
+                "--to",
+                "live",
+            ],
+            "Research run promotion does not support --to",
+        ),
+        (
+            [
+                "promote",
+                "--run",
+                missing_artifact_run_id,
+                "--config",
+                str(config_path),
+                "--acknowledge-live",
+                "research_lab",
+            ],
+            "--acknowledge-live is only supported when promoting agent paper runs to live",
+        ),
+    ]
+
+    for command, expected in cases:
+        result = runner.invoke(app, command)
+        assert result.exit_code == 1
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        assert expected in combined_output
+        assert preserved.read_text(encoding="utf-8") == "stable-model"
+        assert not (destination_dir / "promotion_manifest.json").exists()
 
 
 def test_promote_requires_streaming_before_writing_paper_config(

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -203,11 +203,16 @@ def test_validate_writes_resolved_artifacts(tmp_path: Path, monkeypatch):
 def test_init_writes_prompt_assets_for_agent_templates(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
-    for template_name, prompt_file in (
-        ("llm-agent", "prompts/breakout.md"),
-        ("hybrid", "prompts/hybrid_swing.md"),
-        ("model-agent", "models/trained/aapl_daily_classifier/README.md"),
-    ):
+    expected_assets = {
+        "llm-agent": ["prompts/breakout.md"],
+        "hybrid": [
+            "prompts/hybrid_swing.md",
+            "models/promoted/aapl_daily_classifier/README.md",
+        ],
+        "model-agent": ["models/promoted/aapl_daily_classifier/README.md"],
+    }
+
+    for template_name, prompt_files in expected_assets.items():
         cfg_path = Path("config") / template_name / "project.yaml"
         result = runner.invoke(
             app,
@@ -215,7 +220,8 @@ def test_init_writes_prompt_assets_for_agent_templates(tmp_path: Path, monkeypat
         )
 
         assert result.exit_code == 0, result.stdout
-        assert (tmp_path / "config" / template_name / prompt_file).is_file()
+        for prompt_file in prompt_files:
+            assert (tmp_path / "config" / template_name / prompt_file).is_file()
 
 
 def test_model_agent_template_includes_canonical_streaming_block(
@@ -233,6 +239,9 @@ def test_model_agent_template_includes_canonical_streaming_block(
     payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert payload["agents"][0]["kind"] == "model"
     assert payload["agents"][0]["mode"] == "paper"
+    assert (
+        payload["agents"][0]["model"]["path"] == "models/promoted/aapl_daily_classifier"
+    )
     assert payload["data"]["streaming"]["enabled"] is True
     assert payload["data"]["streaming"]["provider"] == "alpaca"
     assert payload["data"]["streaming"]["channels"] == ["trades", "quotes"]
@@ -267,7 +276,7 @@ def test_llm_and_hybrid_templates_include_canonical_streaming_block(
 
     for template_name, expected_symbols in (
         ("llm-agent", ["AAPL"]),
-        ("hybrid", ["AAPL", "TSLA"]),
+        ("hybrid", ["AAPL"]),
     ):
         cfg_path = Path("config/project.yaml")
         result = runner.invoke(
@@ -282,6 +291,52 @@ def test_llm_and_hybrid_templates_include_canonical_streaming_block(
         assert payload["data"]["streaming"]["provider"] == "alpaca"
         assert payload["data"]["streaming"]["symbols"] == expected_symbols
         cfg_path.unlink()
+
+
+def test_research_and_hybrid_templates_include_research_promotion_targets(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    for template_name in ("research", "hybrid"):
+        cfg_path = Path("config/project.yaml")
+        result = runner.invoke(
+            app,
+            ["init", "--template", template_name, "--output", str(cfg_path)],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+        assert payload["research"]["promotion"]["targets"] == [
+            {
+                "name": "aapl_daily_classifier",
+                "symbol": "AAPL",
+                "path": "models/promoted/aapl_daily_classifier",
+            }
+        ]
+        cfg_path.unlink()
+
+
+def test_hybrid_template_is_prewired_to_promoted_model_signal(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    result = runner.invoke(
+        app,
+        ["init", "--template", "hybrid", "--output", str(cfg_path)],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert payload["agents"][0]["model_signal_sources"] == [
+        {
+            "name": "aapl_daily_classifier",
+            "path": "models/promoted/aapl_daily_classifier",
+        }
+    ]
+    assert payload["agents"][0]["context"]["model_signals"] == ["aapl_daily_classifier"]
 
 
 def test_agent_templates_include_live_risk_and_position_manager_defaults(
@@ -317,7 +372,7 @@ def test_validate_fails_when_model_agent_path_missing(tmp_path: Path, monkeypatc
     )
     assert init_result.exit_code == 0, init_result.stdout
 
-    model_dir = Path("models/trained/aapl_daily_classifier")
+    model_dir = Path("models/promoted/aapl_daily_classifier")
     for child in list(model_dir.iterdir()):
         child.unlink()
     model_dir.rmdir()
@@ -496,7 +551,7 @@ def test_validate_fails_when_model_agent_paper_streaming_is_incomplete(
         yaml.safe_dump(config_payload, sort_keys=False),
         encoding="utf-8",
     )
-    model_dir = Path("models/trained/aapl_daily_classifier")
+    model_dir = Path("models/promoted/aapl_daily_classifier")
     model_dir.mkdir(parents=True, exist_ok=True)
 
     result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
@@ -731,6 +786,98 @@ def test_validate_warns_for_deprecated_model_signal_source_strings(
 
     assert result.exit_code == 0, result.stdout
     assert "deprecated string model_signal_sources entry" in result.stderr.lower()
+
+
+def test_validate_research_promotion_targets_accepts_promoted_model_paths(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False), encoding="utf-8"
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 0, result.stdout
+
+
+def test_validate_fails_when_research_promotion_symbol_is_unknown(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    config_payload["research"]["promotion"]["targets"][0]["symbol"] = "NVDA"
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False), encoding="utf-8"
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert "must reference one of data.symbols" in result.stderr
+
+
+def test_validate_fails_when_research_promotion_path_is_outside_models(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    config_payload["research"]["promotion"]["targets"][0][
+        "path"
+    ] = "reports/promoted/aapl_daily_classifier"
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False), encoding="utf-8"
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert "must resolve under models/" in result.stderr
+
+
+def test_validate_fails_when_research_promotion_target_names_or_paths_duplicate(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    config_payload["data"]["symbols"] = ["AAPL", "MSFT"]
+    config_payload["research"]["promotion"]["targets"].append(
+        {
+            "name": "aapl_daily_classifier",
+            "symbol": "MSFT",
+            "path": "models/promoted/aapl_daily_classifier",
+        }
+    )
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False), encoding="utf-8"
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert "duplicates research promotion target name" in result.stderr
+    assert "duplicates research promotion target path" in result.stderr
 
 
 def test_validate_preserves_unknown_fields_in_resolved_artifact(


### PR DESCRIPTION
## Summary
- add first-class research-run promotion into stable `models/promoted/...` paths
- wire the `research`, `model-agent`, and `hybrid` templates to the promoted-model happy path
- update validation, tests, roadmap, docs, and Makefile support for the new workflow

## Why
The Stage 1 happy path was missing the research-to-agent handoff. Research runs produced timestamped experiment artifacts, but the canonical workflow did not provide a stable path for model or hybrid agents to consume those outputs without manual config edits.

## What changed
- added `research.promotion.targets` to the canonical project schema and validation rules
- extended `quanttradeai promote` to support `research/<run_id>` with staged directory replacement and `promotion_manifest.json`
- prewired `model-agent` and `hybrid` templates to `models/promoted/aapl_daily_classifier`
- updated shipped docs and `config/project.yaml` to show `research run -> promote --run research/<run_id>`
- added a `make lint.format.test` target and verified it succeeds

## Validation
- `make lint.format.test`
- `poetry run pytest -q`
- `poetry build`