### PR TITLE
[codex] add runs scoreboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,8 @@ Thanks for your interest in contributing! This guide covers setup, workflow, and
    - Test: `make test`
 4. Optional: quick sanity run
    - CLI help: `poetry run quanttradeai --help`
-   - Pipeline: `poetry run quanttradeai train -c config/model_config.yaml`
+   - Canonical research workflow: `poetry run quanttradeai validate -c config/project.yaml`
+   - Run comparison: `poetry run quanttradeai runs list --scoreboard`
 
 ## Style & Conventions
 - Formatting: Black (line length 88); lint: Flake8 (see `.flake8`).
@@ -30,7 +31,7 @@ Thanks for your interest in contributing! This guide covers setup, workflow, and
 
 ## Configuration & Secrets
 - Keep credentials in env vars (e.g., `OPENAI_API_KEY`); do not commit `.env`.
-- Use YAML in `config/` to change behavior; validate with `verify_config_loading.py` if modified.
+- Use YAML in `config/` to change behavior; validate canonical project changes with `poetry run quanttradeai validate -c config/project.yaml`.
 
 ## Getting Help
 - Check `README.md` and `docs/` for usage details.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ poetry run quanttradeai init --template research -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai runs list
+poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
 ```
 
 This path gives you:
@@ -114,6 +115,7 @@ This path gives you:
 - resolved-config validation output
 - a research run with metrics and artifacts
 - standardized outputs under `runs/research/...`
+- a quick scoreboard view for ranking local runs by the metrics that matter
 
 To make a winning research artifact available to model or hybrid agents through a stable path:
 
@@ -261,6 +263,14 @@ For the full shape, field reference, and supported agent modes, see [Project YAM
 | Agent live | `runs/agent/live/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime streaming/risk/position-manager YAML snapshots |
 
 This makes it easier to compare runs, audit what actually executed, and reuse winning configurations.
+
+To compare local runs directly from the CLI, use the metrics-aware scoreboard:
+
+```bash
+poetry run quanttradeai runs list --scoreboard
+poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
+poetry run quanttradeai runs list --type agent --mode live --scoreboard --sort-by total_pnl
+```
 
 ## Documentation Map
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -16,6 +16,7 @@ poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 poetry run quanttradeai runs list
+poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
 
 # Run a YAML-defined llm or hybrid agent
 poetry run quanttradeai init --template llm-agent -o config/project.yaml
@@ -270,6 +271,7 @@ Use these pages instead of copying large config blocks out of the quick referenc
 Quick decision rule:
 
 - Use `config/project.yaml` for `validate`, `research run`, and `agent run`
+- Use `quanttradeai runs list --scoreboard` to compare local research and agent runs by metrics
 - Use the runtime YAML files for `live-trade`, `backtest-model`, and operational streaming setup
 
 ## Time-Aware Splitting

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -31,6 +31,12 @@ from .utils.run_records import (
     discover_runs,
     filter_runs,
 )
+from .utils.run_scoreboard import (
+    SCOREBOARD_SORT_FIELDS,
+    attach_scoreboard,
+    render_scoreboard_table,
+    sort_run_records,
+)
 
 
 app = typer.Typer(add_completion=False, help="QuantTradeAI command line interface")
@@ -1203,12 +1209,31 @@ def cmd_runs_list(
         "all", "--status", help="Run status filter: all, success, or failed"
     ),
     limit: int = typer.Option(20, "--limit", min=1, help="Maximum runs to show"),
+    scoreboard: bool = typer.Option(
+        False,
+        "--scoreboard",
+        help="Render a metrics-aware run scoreboard using metrics.json artifacts",
+    ),
+    sort_by: str = typer.Option(
+        "started_at",
+        "--sort-by",
+        help=(
+            "Sort field: started_at, name, status, accuracy, f1, net_sharpe, "
+            "net_pnl, total_pnl, execution_count, or decision_count"
+        ),
+    ),
+    ascending: bool = typer.Option(
+        False,
+        "--ascending",
+        help="Sort ascending instead of using the default direction for the field",
+    ),
     json_output: bool = typer.Option(
         False, "--json", help="Emit normalized run records as JSON"
     ),
 ):
     """List normalized research and agent runs from the local runs directory."""
 
+    discovered = discover_runs()
     filters = RunFilters(
         run_type=_normalize_choice(
             run_type, allowed={"all", "research", "agent"}, field_name="type"
@@ -1223,9 +1248,31 @@ def cmd_runs_list(
             allowed={"all", "success", "failed"},
             field_name="status",
         ),
-        limit=limit,
+        limit=max(len(discovered), 1),
     )
-    records = filter_runs(discover_runs(), filters)
+    normalized_sort_by = _normalize_choice(
+        sort_by,
+        allowed=SCOREBOARD_SORT_FIELDS,
+        field_name="sort-by",
+    )
+    records = filter_runs(discovered, filters)
+    needs_scoreboard = scoreboard or normalized_sort_by not in {
+        "started_at",
+        "name",
+        "status",
+    }
+    if needs_scoreboard:
+        records = attach_scoreboard(records)
+    records = sort_run_records(
+        records,
+        sort_by=normalized_sort_by,
+        ascending=ascending,
+    )[:limit]
+    if needs_scoreboard and not scoreboard:
+        records = [
+            {key: value for key, value in record.items() if key != "scoreboard"}
+            for record in records
+        ]
 
     if json_output:
         typer.echo(json.dumps(records, indent=2))
@@ -1233,6 +1280,10 @@ def cmd_runs_list(
 
     if not records:
         typer.echo("No runs found.")
+        return
+
+    if scoreboard:
+        typer.echo(render_scoreboard_table(records))
         return
 
     typer.echo(_render_runs_table(records))

--- a/quanttradeai/utils/run_scoreboard.py
+++ b/quanttradeai/utils/run_scoreboard.py
@@ -92,6 +92,13 @@ def _normalize_risk_status(value: Any) -> str | None:
     return str(value)
 
 
+def _first_non_none(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
 def _resolve_metrics_path(record: dict[str, Any]) -> Path:
     run_dir = Path(str(record.get("run_dir") or ""))
     artifacts = dict(record.get("artifacts") or {})
@@ -170,9 +177,10 @@ def load_scoreboard_record(record: dict[str, Any]) -> dict[str, Any]:
         scoreboard["net_sharpe"] = _coerce_float(metrics_payload.get("net_sharpe"))
         scoreboard["net_pnl"] = _coerce_float(metrics_payload.get("net_pnl"))
         scoreboard["net_mdd"] = _coerce_float(metrics_payload.get("net_mdd"))
-        scoreboard["decision_count"] = _coerce_int(
-            summary_payload.get("decision_count")
-        ) or _coerce_int(metrics_payload.get("decision_count"))
+        scoreboard["decision_count"] = _first_non_none(
+            _coerce_int(summary_payload.get("decision_count")),
+            _coerce_int(metrics_payload.get("decision_count")),
+        )
         if scoreboard["net_sharpe"] is not None:
             scoreboard["primary_metric_name"] = "net_sharpe"
             scoreboard["primary_metric"] = scoreboard["net_sharpe"]
@@ -183,12 +191,14 @@ def load_scoreboard_record(record: dict[str, Any]) -> dict[str, Any]:
         scoreboard["portfolio_value"] = _coerce_float(
             metrics_payload.get("portfolio_value")
         )
-        scoreboard["execution_count"] = _coerce_int(
-            metrics_payload.get("execution_count")
-        ) or _coerce_int(summary_payload.get("execution_count"))
-        scoreboard["decision_count"] = _coerce_int(
-            metrics_payload.get("decision_count")
-        ) or _coerce_int(summary_payload.get("decision_count"))
+        scoreboard["execution_count"] = _first_non_none(
+            _coerce_int(metrics_payload.get("execution_count")),
+            _coerce_int(summary_payload.get("execution_count")),
+        )
+        scoreboard["decision_count"] = _first_non_none(
+            _coerce_int(metrics_payload.get("decision_count")),
+            _coerce_int(summary_payload.get("decision_count")),
+        )
         scoreboard["risk_status"] = _normalize_risk_status(
             metrics_payload.get("risk_status")
         )

--- a/quanttradeai/utils/run_scoreboard.py
+++ b/quanttradeai/utils/run_scoreboard.py
@@ -93,11 +93,15 @@ def _normalize_risk_status(value: Any) -> str | None:
 
 
 def _resolve_metrics_path(record: dict[str, Any]) -> Path:
+    run_dir = Path(str(record.get("run_dir") or ""))
     artifacts = dict(record.get("artifacts") or {})
     metrics_path = artifacts.get("metrics")
     if metrics_path:
-        return Path(str(metrics_path))
-    return Path(str(record.get("run_dir") or "")) / "metrics.json"
+        candidate = Path(str(metrics_path))
+        if candidate.is_absolute():
+            return candidate
+        return run_dir / candidate
+    return run_dir / "metrics.json"
 
 
 def _resolve_summary_path(record: dict[str, Any]) -> Path:

--- a/quanttradeai/utils/run_scoreboard.py
+++ b/quanttradeai/utils/run_scoreboard.py
@@ -1,0 +1,399 @@
+"""Scoreboard helpers for comparing research and agent runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCOREBOARD_SORT_FIELDS = {
+    "started_at",
+    "name",
+    "status",
+    "accuracy",
+    "f1",
+    "net_sharpe",
+    "net_pnl",
+    "total_pnl",
+    "execution_count",
+    "decision_count",
+}
+
+_NUMERIC_SORT_FIELDS = {
+    "accuracy",
+    "f1",
+    "net_sharpe",
+    "net_pnl",
+    "total_pnl",
+    "execution_count",
+    "decision_count",
+}
+
+_DESCENDING_DEFAULT_SORT_FIELDS = _NUMERIC_SORT_FIELDS | {"started_at"}
+
+
+def _safe_json_mapping(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, f"Missing JSON artifact: {path}"
+    except json.JSONDecodeError as exc:
+        return None, f"Invalid JSON artifact {path}: {exc}"
+    except OSError as exc:
+        return None, f"Unable to read JSON artifact {path}: {exc}"
+
+    if not isinstance(payload, dict):
+        return None, f"JSON artifact must contain an object: {path}"
+    return payload, None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _mean_metric(metrics_by_symbol: Any, key: str) -> float | None:
+    if not isinstance(metrics_by_symbol, dict):
+        return None
+
+    values = []
+    for metrics in metrics_by_symbol.values():
+        if not isinstance(metrics, dict):
+            continue
+        metric_value = _coerce_float(metrics.get(key))
+        if metric_value is not None:
+            values.append(metric_value)
+
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _normalize_risk_status(value: Any) -> str | None:
+    if isinstance(value, dict):
+        status = value.get("status")
+        return str(status) if status is not None else None
+    if value is None:
+        return None
+    return str(value)
+
+
+def _resolve_metrics_path(record: dict[str, Any]) -> Path:
+    artifacts = dict(record.get("artifacts") or {})
+    metrics_path = artifacts.get("metrics")
+    if metrics_path:
+        return Path(str(metrics_path))
+    return Path(str(record.get("run_dir") or "")) / "metrics.json"
+
+
+def _resolve_summary_path(record: dict[str, Any]) -> Path:
+    return Path(str(record.get("run_dir") or "")) / "summary.json"
+
+
+def _empty_scoreboard(
+    *,
+    metrics_path: Path,
+) -> dict[str, Any]:
+    return {
+        "metrics_path": str(metrics_path),
+        "status": "missing",
+        "error": None,
+        "primary_metric_name": None,
+        "primary_metric": None,
+        "accuracy": None,
+        "f1": None,
+        "net_sharpe": None,
+        "net_pnl": None,
+        "net_mdd": None,
+        "total_pnl": None,
+        "portfolio_value": None,
+        "execution_count": None,
+        "decision_count": None,
+        "risk_status": None,
+    }
+
+
+def load_scoreboard_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Load and normalize scoreboard metrics for a run record."""
+
+    metrics_path = _resolve_metrics_path(record)
+    summary_path = _resolve_summary_path(record)
+    scoreboard = _empty_scoreboard(metrics_path=metrics_path)
+
+    metrics_payload, metrics_error = _safe_json_mapping(metrics_path)
+    summary_payload, _summary_error = _safe_json_mapping(summary_path)
+    summary_payload = summary_payload or {}
+    run_type = str(record.get("run_type") or "")
+    mode = str(record.get("mode") or "")
+
+    if metrics_payload is None:
+        scoreboard["error"] = metrics_error
+        scoreboard["status"] = "invalid" if metrics_path.exists() else "missing"
+        return scoreboard
+
+    scoreboard["status"] = str(metrics_payload.get("status") or "available")
+
+    if run_type == "research":
+        research_metrics = metrics_payload.get("research_metrics_by_symbol") or {}
+        backtest_metrics = metrics_payload.get("backtest_metrics_by_symbol") or {}
+        scoreboard["accuracy"] = _mean_metric(research_metrics, "accuracy")
+        scoreboard["f1"] = _mean_metric(research_metrics, "f1")
+        scoreboard["net_sharpe"] = _mean_metric(backtest_metrics, "net_sharpe")
+        scoreboard["net_pnl"] = _mean_metric(backtest_metrics, "net_pnl")
+        if scoreboard["net_sharpe"] is not None:
+            scoreboard["primary_metric_name"] = "net_sharpe"
+            scoreboard["primary_metric"] = scoreboard["net_sharpe"]
+        elif scoreboard["accuracy"] is not None:
+            scoreboard["primary_metric_name"] = "accuracy"
+            scoreboard["primary_metric"] = scoreboard["accuracy"]
+        return scoreboard
+
+    if run_type == "agent" and mode == "backtest":
+        scoreboard["net_sharpe"] = _coerce_float(metrics_payload.get("net_sharpe"))
+        scoreboard["net_pnl"] = _coerce_float(metrics_payload.get("net_pnl"))
+        scoreboard["net_mdd"] = _coerce_float(metrics_payload.get("net_mdd"))
+        scoreboard["decision_count"] = _coerce_int(
+            summary_payload.get("decision_count")
+        ) or _coerce_int(metrics_payload.get("decision_count"))
+        if scoreboard["net_sharpe"] is not None:
+            scoreboard["primary_metric_name"] = "net_sharpe"
+            scoreboard["primary_metric"] = scoreboard["net_sharpe"]
+        return scoreboard
+
+    if run_type == "agent" and mode in {"paper", "live"}:
+        scoreboard["total_pnl"] = _coerce_float(metrics_payload.get("total_pnl"))
+        scoreboard["portfolio_value"] = _coerce_float(
+            metrics_payload.get("portfolio_value")
+        )
+        scoreboard["execution_count"] = _coerce_int(
+            metrics_payload.get("execution_count")
+        ) or _coerce_int(summary_payload.get("execution_count"))
+        scoreboard["decision_count"] = _coerce_int(
+            metrics_payload.get("decision_count")
+        ) or _coerce_int(summary_payload.get("decision_count"))
+        scoreboard["risk_status"] = _normalize_risk_status(
+            metrics_payload.get("risk_status")
+        )
+        if scoreboard["total_pnl"] is not None:
+            scoreboard["primary_metric_name"] = "total_pnl"
+            scoreboard["primary_metric"] = scoreboard["total_pnl"]
+        return scoreboard
+
+    return scoreboard
+
+
+def attach_scoreboard(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return run records annotated with additive scoreboard payloads."""
+
+    annotated: list[dict[str, Any]] = []
+    for record in records:
+        enriched = dict(record)
+        enriched["scoreboard"] = load_scoreboard_record(record)
+        annotated.append(enriched)
+    return annotated
+
+
+def _sort_value(record: dict[str, Any], sort_by: str) -> Any:
+    if sort_by == "started_at":
+        timestamps = dict(record.get("timestamps") or {})
+        return timestamps.get("started_at")
+    if sort_by in {"name", "status"}:
+        return record.get(sort_by)
+    scoreboard = dict(record.get("scoreboard") or {})
+    return scoreboard.get(sort_by)
+
+
+def sort_run_records(
+    records: list[dict[str, Any]],
+    *,
+    sort_by: str,
+    ascending: bool,
+) -> list[dict[str, Any]]:
+    """Sort records by base or scoreboard fields, keeping missing values last."""
+
+    with_values: list[tuple[Any, dict[str, Any]]] = []
+    missing_values: list[dict[str, Any]] = []
+    for record in records:
+        value = _sort_value(record, sort_by)
+        if value is None:
+            missing_values.append(record)
+            continue
+        with_values.append((value, record))
+
+    reverse = not ascending and sort_by in _DESCENDING_DEFAULT_SORT_FIELDS
+    with_values.sort(key=lambda item: item[0], reverse=reverse)
+    return [record for _, record in with_values] + missing_values
+
+
+def _format_symbols(symbols: list[str]) -> str:
+    if not symbols:
+        return "-"
+    if len(symbols) <= 3:
+        return ",".join(symbols)
+    return ",".join(symbols[:3]) + f"+{len(symbols) - 3}"
+
+
+def _truncate(value: str, width: int) -> str:
+    if len(value) <= width:
+        return value
+    return value[: max(0, width - 3)] + "..."
+
+
+def _format_float(value: float | None, *, decimals: int = 3) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.{decimals}f}"
+
+
+def _format_int(value: int | None) -> str:
+    if value is None:
+        return "-"
+    return str(value)
+
+
+def _metric_text(record: dict[str, Any], field_name: str) -> str:
+    scoreboard = dict(record.get("scoreboard") or {})
+
+    if field_name == "SYMBOLS":
+        return _format_symbols(list(record.get("symbols") or []))
+    if field_name == "ACC":
+        return _format_float(_coerce_float(scoreboard.get("accuracy")))
+    if field_name == "F1":
+        return _format_float(_coerce_float(scoreboard.get("f1")))
+    if field_name == "NET_SHARPE":
+        return _format_float(_coerce_float(scoreboard.get("net_sharpe")))
+    if field_name == "NET_PNL":
+        return _format_float(_coerce_float(scoreboard.get("net_pnl")))
+    if field_name == "NET_MDD":
+        return _format_float(_coerce_float(scoreboard.get("net_mdd")))
+    if field_name == "TOTAL_PNL":
+        return _format_float(_coerce_float(scoreboard.get("total_pnl")))
+    if field_name == "PORTFOLIO":
+        return _format_float(
+            _coerce_float(scoreboard.get("portfolio_value")), decimals=2
+        )
+    if field_name == "EXEC":
+        return _format_int(_coerce_int(scoreboard.get("execution_count")))
+    if field_name == "DECISIONS":
+        return _format_int(_coerce_int(scoreboard.get("decision_count")))
+    if field_name == "RISK":
+        return str(scoreboard.get("risk_status") or "-")
+    if field_name == "PRIMARY":
+        return _format_float(_coerce_float(scoreboard.get("primary_metric")))
+    if field_name == "PNL":
+        total_pnl = _coerce_float(scoreboard.get("total_pnl"))
+        if total_pnl is not None:
+            return _format_float(total_pnl)
+        return _format_float(_coerce_float(scoreboard.get("net_pnl")))
+    if field_name == "SHARPE":
+        return _format_float(_coerce_float(scoreboard.get("net_sharpe")))
+
+    if field_name == "RUN_ID":
+        return str(record.get("run_id") or "-")
+    if field_name == "TYPE":
+        return str(record.get("run_type") or "-")
+    if field_name == "MODE":
+        return str(record.get("mode") or "-")
+    if field_name == "STATUS":
+        return str(record.get("status") or "-")
+    if field_name == "NAME":
+        return str(record.get("name") or "-")
+    if field_name == "STARTED_AT":
+        timestamps = dict(record.get("timestamps") or {})
+        return str(timestamps.get("started_at") or "-")
+
+    return "-"
+
+
+def _scoreboard_columns(records: list[dict[str, Any]]) -> list[tuple[str, int]]:
+    run_shapes = {(record.get("run_type"), record.get("mode")) for record in records}
+
+    if run_shapes and all(run_type == "research" for run_type, _mode in run_shapes):
+        return [
+            ("RUN_ID", 40),
+            ("STATUS", 8),
+            ("NAME", 24),
+            ("STARTED_AT", 25),
+            ("SYMBOLS", 20),
+            ("ACC", 8),
+            ("F1", 8),
+            ("NET_SHARPE", 11),
+            ("NET_PNL", 10),
+        ]
+
+    if run_shapes and all(shape == ("agent", "backtest") for shape in run_shapes):
+        return [
+            ("RUN_ID", 40),
+            ("STATUS", 8),
+            ("NAME", 24),
+            ("STARTED_AT", 25),
+            ("SYMBOLS", 20),
+            ("NET_SHARPE", 11),
+            ("NET_PNL", 10),
+            ("NET_MDD", 10),
+            ("DECISIONS", 10),
+        ]
+
+    if run_shapes and all(
+        run_type == "agent" and mode in {"paper", "live"}
+        for run_type, mode in run_shapes
+    ):
+        return [
+            ("RUN_ID", 40),
+            ("MODE", 10),
+            ("STATUS", 8),
+            ("NAME", 24),
+            ("STARTED_AT", 25),
+            ("SYMBOLS", 20),
+            ("TOTAL_PNL", 10),
+            ("PORTFOLIO", 12),
+            ("EXEC", 6),
+            ("DECISIONS", 10),
+            ("RISK", 10),
+        ]
+
+    return [
+        ("RUN_ID", 40),
+        ("TYPE", 8),
+        ("MODE", 10),
+        ("STATUS", 8),
+        ("NAME", 24),
+        ("STARTED_AT", 25),
+        ("SYMBOLS", 20),
+        ("PRIMARY", 9),
+        ("PNL", 10),
+        ("SHARPE", 10),
+        ("EXEC", 6),
+        ("DECISIONS", 10),
+        ("RISK", 10),
+    ]
+
+
+def render_scoreboard_table(records: list[dict[str, Any]]) -> str:
+    """Render an adaptive metrics-aware scoreboard table."""
+
+    columns = _scoreboard_columns(records)
+    header = "  ".join(f"{label:<{width}}" for label, width in columns)
+    lines = [header]
+    for record in records:
+        lines.append(
+            "  ".join(
+                f"{_truncate(_metric_text(record, label), width):<{width}}"
+                for label, width in columns
+            )
+        )
+    return "\n".join(lines)

--- a/roadmap.md
+++ b/roadmap.md
@@ -349,6 +349,11 @@ Status on 2026-04-10:
 Goal:
 Make running many agents and many experiments on one machine easy and trustworthy.
 
+Status on 2026-04-11:
+
+- `quanttradeai runs list --scoreboard` is implemented for local research and agent runs, with metric-aware sorting via `--sort-by` and additive JSON scoreboard payloads.
+- Multi-agent orchestration, parameter sweeps, and richer comparison workflows remain future Stage 2 work.
+
 Deliverables:
 
 - Run many agents from one `project.yaml`.

--- a/tests/integration/test_runs_cli.py
+++ b/tests/integration/test_runs_cli.py
@@ -9,15 +9,29 @@ from quanttradeai.cli import app
 runner = CliRunner()
 
 
-def _write_run_summary(path: Path, payload: dict) -> None:
+def _write_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
+def _write_run_bundle(
+    root: Path,
+    *,
+    relative_dir: str,
+    summary_payload: dict,
+    metrics_payload: dict | None = None,
+) -> None:
+    run_dir = root / Path(relative_dir)
+    _write_json(run_dir / "summary.json", summary_payload)
+    if metrics_payload is not None:
+        _write_json(run_dir / "metrics.json", metrics_payload)
+
+
 def _seed_runs(root: Path) -> None:
-    _write_run_summary(
-        root / "research" / "20260101_000000_research_lab" / "summary.json",
-        {
+    _write_run_bundle(
+        root,
+        relative_dir="research/20260101_000000_research_lab",
+        summary_payload={
             "run_type": "research",
             "mode": "research",
             "name": "research_lab",
@@ -30,26 +44,45 @@ def _seed_runs(root: Path) -> None:
             "run_id": "research/20260101_000000_research_lab",
             "run_dir": "runs/research/20260101_000000_research_lab",
         },
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {
+                "AAPL": {"accuracy": 0.70, "f1": 0.50},
+                "MSFT": {"accuracy": 0.90, "f1": 0.70},
+            },
+            "backtest_metrics_by_symbol": {
+                "AAPL": {"net_sharpe": 1.00, "net_pnl": 0.10},
+                "MSFT": {"net_sharpe": 2.00, "net_pnl": 0.30},
+            },
+        },
     )
-    _write_run_summary(
-        root / "agent" / "backtest" / "20260101_010000_breakout_gpt" / "summary.json",
-        {
+    _write_run_bundle(
+        root,
+        relative_dir="agent/backtest/20260101_010000_breakout_gpt",
+        summary_payload={
             "run_type": "agent",
             "mode": "backtest",
             "name": "breakout_gpt",
             "agent_name": "breakout_gpt",
             "status": "success",
             "symbols": ["AAPL"],
+            "decision_count": 11,
             "timestamps": {"started_at": "2026-01-01T01:00:00+00:00"},
             "artifacts": {},
             "warnings": [],
             "run_id": "agent/backtest/20260101_010000_breakout_gpt",
             "run_dir": "runs/agent/backtest/20260101_010000_breakout_gpt",
         },
+        metrics_payload={
+            "net_sharpe": 1.25,
+            "net_pnl": 0.18,
+            "net_mdd": -0.07,
+        },
     )
-    _write_run_summary(
-        root / "20251231_230000_legacy_agent" / "summary.json",
-        {
+    _write_run_bundle(
+        root,
+        relative_dir="20251231_230000_legacy_agent",
+        summary_payload={
             "agent_name": "legacy_agent",
             "mode": "backtest",
             "status": "failed",
@@ -90,6 +123,7 @@ def test_runs_list_json_output_returns_normalized_records(tmp_path: Path, monkey
     ]
     assert payload[0]["run_id"] == "agent/backtest/20260101_010000_breakout_gpt"
     assert payload[-1]["run_type"] == "agent"
+    assert "scoreboard" not in payload[0]
 
 
 def test_runs_list_reports_empty_state(tmp_path: Path, monkeypatch):
@@ -139,9 +173,10 @@ def test_runs_list_surfaces_live_agent_runs_and_filters_by_live_mode(
     monkeypatch.chdir(tmp_path)
     runs_root = Path("runs")
     _seed_runs(runs_root)
-    _write_run_summary(
-        runs_root / "agent" / "live" / "20260101_020000_breakout_live" / "summary.json",
-        {
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/live/20260101_020000_breakout_live",
+        summary_payload={
             "run_type": "agent",
             "mode": "live",
             "name": "breakout_live",
@@ -154,6 +189,14 @@ def test_runs_list_surfaces_live_agent_runs_and_filters_by_live_mode(
             "run_id": "agent/live/20260101_020000_breakout_live",
             "run_dir": "runs/agent/live/20260101_020000_breakout_live",
         },
+        metrics_payload={
+            "status": "available",
+            "total_pnl": 120.0,
+            "portfolio_value": 100120.0,
+            "execution_count": 3,
+            "decision_count": 5,
+            "risk_status": {"status": "ok"},
+        },
     )
 
     result = runner.invoke(app, ["runs", "list", "--mode", "live", "--json"])
@@ -164,3 +207,335 @@ def test_runs_list_surfaces_live_agent_runs_and_filters_by_live_mode(
     assert payload[0]["run_id"] == "agent/live/20260101_020000_breakout_live"
     assert payload[0]["mode"] == "live"
     assert payload[0]["name"] == "breakout_live"
+
+
+def test_runs_list_scoreboard_for_research_runs_uses_research_columns(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="research/20260101_000000_research_lab",
+        summary_payload={
+            "run_type": "research",
+            "mode": "research",
+            "name": "research_lab",
+            "project_name": "research_lab",
+            "status": "success",
+            "symbols": ["AAPL", "MSFT"],
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+        },
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.8, "f1": 0.6}},
+            "backtest_metrics_by_symbol": {"AAPL": {"net_sharpe": 1.2, "net_pnl": 0.3}},
+        },
+    )
+
+    result = runner.invoke(app, ["runs", "list", "--type", "research", "--scoreboard"])
+
+    assert result.exit_code == 0, result.stdout
+    header = result.stdout.strip().splitlines()[0]
+    assert "ACC" in header
+    assert "F1" in header
+    assert "NET_SHARPE" in header
+    assert "NET_PNL" in header
+    assert "research_lab" in result.stdout
+
+
+def test_runs_list_scoreboard_for_agent_backtests_uses_backtest_columns(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/backtest/20260101_010000_breakout_gpt",
+        summary_payload={
+            "run_type": "agent",
+            "mode": "backtest",
+            "name": "breakout_gpt",
+            "agent_name": "breakout_gpt",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "decision_count": 11,
+            "timestamps": {"started_at": "2026-01-01T01:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+        },
+        metrics_payload={
+            "net_sharpe": 1.25,
+            "net_pnl": 0.18,
+            "net_mdd": -0.07,
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        ["runs", "list", "--type", "agent", "--mode", "backtest", "--scoreboard"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    header = result.stdout.strip().splitlines()[0]
+    assert "NET_SHARPE" in header
+    assert "NET_PNL" in header
+    assert "NET_MDD" in header
+    assert "DECISIONS" in header
+    assert "breakout_gpt" in result.stdout
+
+
+def test_runs_list_scoreboard_for_streaming_agents_uses_streaming_columns(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/paper/20260101_010000_breakout_gpt",
+        summary_payload={
+            "run_type": "agent",
+            "mode": "paper",
+            "name": "breakout_gpt",
+            "agent_name": "breakout_gpt",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "timestamps": {"started_at": "2026-01-01T01:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+        },
+        metrics_payload={
+            "status": "available",
+            "total_pnl": 125.0,
+            "portfolio_value": 100125.0,
+            "execution_count": 4,
+            "decision_count": 7,
+            "risk_status": {"status": "ok"},
+        },
+    )
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/live/20260101_020000_breakout_live",
+        summary_payload={
+            "run_type": "agent",
+            "mode": "live",
+            "name": "breakout_live",
+            "agent_name": "breakout_live",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "timestamps": {"started_at": "2026-01-01T02:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+        },
+        metrics_payload={
+            "status": "available",
+            "total_pnl": 220.0,
+            "portfolio_value": 100220.0,
+            "execution_count": 6,
+            "decision_count": 8,
+            "risk_status": {"status": "warning"},
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        ["runs", "list", "--type", "agent", "--scoreboard", "--sort-by", "total_pnl"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    header = result.stdout.strip().splitlines()[0]
+    assert "TOTAL_PNL" in header
+    assert "PORTFOLIO" in header
+    assert "EXEC" in header
+    assert "DECISIONS" in header
+    assert "RISK" in header
+
+
+def test_runs_list_scoreboard_for_mixed_results_uses_safe_superset(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    _seed_runs(Path("runs"))
+
+    result = runner.invoke(app, ["runs", "list", "--scoreboard"])
+
+    assert result.exit_code == 0, result.stdout
+    header = result.stdout.strip().splitlines()[0]
+    assert "PRIMARY" in header
+    assert "PNL" in header
+    assert "SHARPE" in header
+    assert "EXEC" in header
+    assert "DECISIONS" in header
+    assert "RISK" in header
+
+
+def test_runs_list_scoreboard_sorts_by_net_sharpe_descending(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/backtest/20260101_000000_low_sharpe",
+        summary_payload={
+            "run_type": "agent",
+            "mode": "backtest",
+            "name": "low_sharpe",
+            "agent_name": "low_sharpe",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "decision_count": 2,
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+        },
+        metrics_payload={"net_sharpe": 0.5, "net_pnl": 0.1, "net_mdd": -0.1},
+    )
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/backtest/20260101_010000_high_sharpe",
+        summary_payload={
+            "run_type": "agent",
+            "mode": "backtest",
+            "name": "high_sharpe",
+            "agent_name": "high_sharpe",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "decision_count": 4,
+            "timestamps": {"started_at": "2026-01-01T01:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+        },
+        metrics_payload={"net_sharpe": 2.5, "net_pnl": 0.3, "net_mdd": -0.05},
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "runs",
+            "list",
+            "--type",
+            "agent",
+            "--mode",
+            "backtest",
+            "--scoreboard",
+            "--sort-by",
+            "net_sharpe",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert [record["name"] for record in payload] == ["high_sharpe", "low_sharpe"]
+
+
+def test_runs_list_scoreboard_sorts_by_total_pnl_descending(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/live/20260101_000000_lower_pnl",
+        summary_payload={
+            "run_type": "agent",
+            "mode": "live",
+            "name": "lower_pnl",
+            "agent_name": "lower_pnl",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+        },
+        metrics_payload={
+            "status": "available",
+            "total_pnl": 80.0,
+            "portfolio_value": 100080.0,
+            "execution_count": 2,
+            "decision_count": 3,
+            "risk_status": {"status": "ok"},
+        },
+    )
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/live/20260101_010000_higher_pnl",
+        summary_payload={
+            "run_type": "agent",
+            "mode": "live",
+            "name": "higher_pnl",
+            "agent_name": "higher_pnl",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "timestamps": {"started_at": "2026-01-01T01:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+        },
+        metrics_payload={
+            "status": "available",
+            "total_pnl": 180.0,
+            "portfolio_value": 100180.0,
+            "execution_count": 6,
+            "decision_count": 5,
+            "risk_status": {"status": "warning"},
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "runs",
+            "list",
+            "--type",
+            "agent",
+            "--mode",
+            "live",
+            "--scoreboard",
+            "--sort-by",
+            "total_pnl",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert [record["name"] for record in payload] == ["higher_pnl", "lower_pnl"]
+
+
+def test_runs_list_scoreboard_sorts_by_started_at_when_requested(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    _seed_runs(Path("runs"))
+
+    result = runner.invoke(
+        app,
+        ["runs", "list", "--scoreboard", "--sort-by", "started_at", "--json"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert [record["name"] for record in payload] == [
+        "breakout_gpt",
+        "research_lab",
+        "legacy_agent",
+    ]
+
+
+def test_runs_list_scoreboard_json_includes_additive_scoreboard_payload(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    _seed_runs(Path("runs"))
+
+    result = runner.invoke(app, ["runs", "list", "--scoreboard", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert "scoreboard" in payload[0]
+    assert payload[0]["scoreboard"]["net_sharpe"] == 1.25
+    assert "scoreboard" in payload[1]
+    assert payload[1]["scoreboard"]["accuracy"] == 0.8

--- a/tests/utils/test_run_scoreboard.py
+++ b/tests/utils/test_run_scoreboard.py
@@ -188,3 +188,24 @@ def test_load_scoreboard_record_handles_malformed_metrics_file(tmp_path: Path):
     assert scoreboard["status"] == "invalid"
     assert "Invalid JSON artifact" in scoreboard["error"]
     assert scoreboard["primary_metric"] is None
+
+
+def test_load_scoreboard_record_resolves_relative_metrics_artifact_from_run_dir(
+    tmp_path: Path,
+):
+    record = _write_run_bundle(
+        tmp_path / "runs",
+        run_type="research",
+        mode="research",
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.9}},
+        },
+    )
+    record["artifacts"] = {"metrics": "metrics.json"}
+
+    scoreboard = load_scoreboard_record(record)
+
+    assert scoreboard["status"] == "available"
+    assert scoreboard["accuracy"] == 0.9
+    assert scoreboard["metrics_path"] == str(Path(record["run_dir"]) / "metrics.json")

--- a/tests/utils/test_run_scoreboard.py
+++ b/tests/utils/test_run_scoreboard.py
@@ -1,0 +1,190 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from quanttradeai.utils.run_scoreboard import load_scoreboard_record
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_run_bundle(
+    root: Path,
+    *,
+    run_type: str,
+    mode: str,
+    metrics_payload: dict | None = None,
+    summary_payload: dict | None = None,
+) -> dict:
+    run_dir = root / run_type / mode / "20260101_000000_demo"
+    _write_json(
+        run_dir / "summary.json",
+        {
+            "run_type": run_type,
+            "mode": mode,
+            "name": "demo",
+            "status": "success",
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            **(summary_payload or {}),
+        },
+    )
+    if metrics_payload is not None:
+        _write_json(run_dir / "metrics.json", metrics_payload)
+
+    return {
+        "run_id": f"{run_type}/{mode}/20260101_000000_demo",
+        "run_type": run_type,
+        "mode": mode,
+        "name": "demo",
+        "status": "success",
+        "symbols": ["AAPL"],
+        "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+        "artifacts": {},
+        "warnings": [],
+        "run_dir": str(run_dir),
+    }
+
+
+def test_load_scoreboard_record_for_research_with_research_and_backtest_metrics(
+    tmp_path: Path,
+):
+    record = _write_run_bundle(
+        tmp_path / "runs",
+        run_type="research",
+        mode="research",
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {
+                "AAPL": {"accuracy": 0.70, "f1": 0.50},
+                "MSFT": {"accuracy": 0.90, "f1": 0.70},
+            },
+            "backtest_metrics_by_symbol": {
+                "AAPL": {"net_sharpe": 1.0, "net_pnl": 0.10},
+                "MSFT": {"net_sharpe": 2.0, "net_pnl": 0.30},
+            },
+        },
+    )
+
+    scoreboard = load_scoreboard_record(record)
+
+    assert scoreboard["status"] == "available"
+    assert scoreboard["accuracy"] == 0.80
+    assert scoreboard["f1"] == 0.60
+    assert scoreboard["net_sharpe"] == 1.50
+    assert scoreboard["net_pnl"] == 0.20
+    assert scoreboard["primary_metric_name"] == "net_sharpe"
+    assert scoreboard["primary_metric"] == 1.50
+
+
+def test_load_scoreboard_record_for_research_with_research_metrics_only(
+    tmp_path: Path,
+):
+    record = _write_run_bundle(
+        tmp_path / "runs",
+        run_type="research",
+        mode="research",
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {
+                "AAPL": {"accuracy": 0.75, "f1": 0.55},
+                "MSFT": {"accuracy": 0.85, "f1": 0.65},
+            },
+            "backtest_metrics_by_symbol": {},
+        },
+    )
+
+    scoreboard = load_scoreboard_record(record)
+
+    assert scoreboard["accuracy"] == 0.80
+    assert scoreboard["f1"] == pytest.approx(0.60)
+    assert scoreboard["net_sharpe"] is None
+    assert scoreboard["primary_metric_name"] == "accuracy"
+    assert scoreboard["primary_metric"] == 0.80
+
+
+def test_load_scoreboard_record_for_agent_backtest_uses_aggregate_metrics(
+    tmp_path: Path,
+):
+    record = _write_run_bundle(
+        tmp_path / "runs",
+        run_type="agent",
+        mode="backtest",
+        metrics_payload={
+            "net_sharpe": 1.25,
+            "net_pnl": 0.18,
+            "net_mdd": -0.07,
+        },
+        summary_payload={"decision_count": 12},
+    )
+
+    scoreboard = load_scoreboard_record(record)
+
+    assert scoreboard["net_sharpe"] == 1.25
+    assert scoreboard["net_pnl"] == 0.18
+    assert scoreboard["net_mdd"] == -0.07
+    assert scoreboard["decision_count"] == 12
+    assert scoreboard["primary_metric_name"] == "net_sharpe"
+    assert scoreboard["primary_metric"] == 1.25
+
+
+def test_load_scoreboard_record_for_agent_paper_or_live_exposes_streaming_metrics(
+    tmp_path: Path,
+):
+    record = _write_run_bundle(
+        tmp_path / "runs",
+        run_type="agent",
+        mode="paper",
+        metrics_payload={
+            "status": "available",
+            "total_pnl": 150.5,
+            "portfolio_value": 100150.5,
+            "execution_count": 4,
+            "risk_status": {"status": "ok", "halted": False},
+        },
+        summary_payload={"decision_count": 9},
+    )
+
+    scoreboard = load_scoreboard_record(record)
+
+    assert scoreboard["total_pnl"] == 150.5
+    assert scoreboard["portfolio_value"] == 100150.5
+    assert scoreboard["execution_count"] == 4
+    assert scoreboard["decision_count"] == 9
+    assert scoreboard["risk_status"] == "ok"
+    assert scoreboard["primary_metric_name"] == "total_pnl"
+    assert scoreboard["primary_metric"] == 150.5
+
+
+def test_load_scoreboard_record_handles_missing_metrics_file(tmp_path: Path):
+    record = _write_run_bundle(
+        tmp_path / "runs",
+        run_type="agent",
+        mode="live",
+        metrics_payload=None,
+    )
+
+    scoreboard = load_scoreboard_record(record)
+
+    assert scoreboard["status"] == "missing"
+    assert "Missing JSON artifact" in scoreboard["error"]
+    assert scoreboard["primary_metric"] is None
+
+
+def test_load_scoreboard_record_handles_malformed_metrics_file(tmp_path: Path):
+    record = _write_run_bundle(
+        tmp_path / "runs",
+        run_type="agent",
+        mode="live",
+        metrics_payload={"status": "placeholder"},
+    )
+    metrics_path = Path(record["run_dir"]) / "metrics.json"
+    metrics_path.write_text("{not-json", encoding="utf-8")
+
+    scoreboard = load_scoreboard_record(record)
+
+    assert scoreboard["status"] == "invalid"
+    assert "Invalid JSON artifact" in scoreboard["error"]
+    assert scoreboard["primary_metric"] is None

--- a/tests/utils/test_run_scoreboard.py
+++ b/tests/utils/test_run_scoreboard.py
@@ -130,6 +130,25 @@ def test_load_scoreboard_record_for_agent_backtest_uses_aggregate_metrics(
     assert scoreboard["primary_metric"] == 1.25
 
 
+def test_load_scoreboard_record_for_agent_backtest_preserves_zero_decision_count(
+    tmp_path: Path,
+):
+    record = _write_run_bundle(
+        tmp_path / "runs",
+        run_type="agent",
+        mode="backtest",
+        metrics_payload={
+            "net_sharpe": 0.5,
+            "decision_count": None,
+        },
+        summary_payload={"decision_count": 0},
+    )
+
+    scoreboard = load_scoreboard_record(record)
+
+    assert scoreboard["decision_count"] == 0
+
+
 def test_load_scoreboard_record_for_agent_paper_or_live_exposes_streaming_metrics(
     tmp_path: Path,
 ):


### PR DESCRIPTION
## Summary
- add a metrics-aware scoreboard to `quanttradeai runs list` behind `--scoreboard`
- support metric-based sorting via `--sort-by` and `--ascending`
- attach additive scoreboard payloads for `runs list --scoreboard --json`
- document the new runs comparison flow and align contributor guidance with the canonical project workflow

## Why
`runs list` only exposed summary metadata even though the system already persisted comparable metrics in `metrics.json`. This made it hard to compare research and agent runs from the CLI and left a clear Stage 2 roadmap gap.

## Impact
Users can now rank and inspect local research, backtest, paper, and live runs without leaving the CLI, while the default `runs list` behavior remains unchanged.

## Validation
- `make format`
- `make lint`
- `make test`

## Notes
- the change is additive only; no existing run artifact formats were changed
- older runs without `metrics.json` still appear and are pushed to the bottom for metric-based sorts