### PR TITLE
[codex] Add multi-agent backtest batch runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 | Run a trained model as an agent | `init --template model-agent` -> `validate` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | One YAML-defined model agent wired to a stable `models/promoted/...` path that can be backtested, promoted, paper-run, and live-run |
 | Run an LLM agent | `init --template llm-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Prompt-driven agent logic using project config across all three modes |
 | Run a hybrid agent | `init --template hybrid` -> `research run` -> `promote --run research/<run_id>` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Model signals plus LLM reasoning in one project, with research outputs promoted into a stable path before the agent is promoted through environments |
+| Backtest every project agent together | `agent run --all --mode backtest --max-concurrency 4` | A local multi-agent backtest batch with preserved child runs plus batch-level manifests and scoreboards |
 | Generate a Docker Compose deployment bundle | `deploy --agent <name> --target docker-compose` | A paper-agent bundle with compose, Dockerfile, env placeholders, and resolved config |
 | Keep using the older live loop | `live-trade` with runtime YAML files | Legacy compatibility for existing setups |
 
@@ -202,6 +203,24 @@ poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.y
 ```
 
 The default hybrid template is prewired to `models/promoted/aapl_daily_classifier`, so you do not need to hand-edit timestamped experiment paths after the research run.
+
+### Backtest Every Project Agent
+
+Use this when one `config/project.yaml` defines several agents and you want one local batch run that keeps the normal child backtest runs intact.
+
+```bash
+poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest
+poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
+```
+
+This writes batch artifacts under `runs/agent/batches/<timestamp>_<project>_backtest/`:
+
+- `batch_manifest.json`
+- `results.json`
+- `scoreboard.json`
+- `scoreboard.txt`
+
+Each child agent still writes its normal run under `runs/agent/backtest/...`, so `quanttradeai runs list --scoreboard` continues to work without a separate comparison path.
 
 ### Deploy A Paper Agent
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,6 +115,31 @@ The hybrid template already points `model_signal_sources` at `models/promoted/aa
 
 Deployment bundles for project-defined paper agents are written under `reports/deployments/<agent>/<timestamp>/`.
 
+## Workflow 4: Multi-Agent Backtest Batch
+
+Use this when one `config/project.yaml` already defines several agents and you want one local batch run across all of them.
+
+```bash
+poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest
+poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
+```
+
+This workflow:
+
+- validates the project before enumeration
+- runs every configured agent through the existing backtest path
+- preserves the normal child runs under `runs/agent/backtest/...`
+- adds batch-level artifacts under `runs/agent/batches/<timestamp>_<project>_backtest/`
+
+Batch artifacts include:
+
+- `batch_manifest.json`
+- `results.json`
+- `scoreboard.json`
+- `scoreboard.txt`
+
+The batch workflow is backtest-only in this release. Paper and live still run one agent at a time.
+
 ## Legacy Runtime Workflows
 
 These remain supported:

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -26,6 +26,10 @@ poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
 
+# Backtest every configured project agent together
+poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest
+poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
+
 # Generate a Docker Compose bundle for the paper agent
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
 
@@ -95,6 +99,12 @@ Canonical deployment bundle artifacts:
 - `reports/deployments/<agent>/<timestamp>/README.md`
 - `reports/deployments/<agent>/<timestamp>/resolved_project_config.yaml`
 - `reports/deployments/<agent>/<timestamp>/deployment_manifest.json`
+
+Canonical multi-agent batch artifacts:
+- `runs/agent/batches/<timestamp>_<project>_backtest/batch_manifest.json`
+- `runs/agent/batches/<timestamp>_<project>_backtest/results.json`
+- `runs/agent/batches/<timestamp>_<project>_backtest/scoreboard.json`
+- `runs/agent/batches/<timestamp>_<project>_backtest/scoreboard.txt`
 
 ## Python API Patterns
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "quanttradeai"
 version = "0.1.0"
-description = "A machine learning framework for quantitative trading strategies"
+description = "Quant research workflows and trading agents from one YAML project"
 authors = [
     {name = "Akshat Joshi",email = "joshiakshat0511@gmail.com"}
 ]

--- a/quanttradeai/agents/backtest.py
+++ b/quanttradeai/agents/backtest.py
@@ -163,6 +163,7 @@ def run_agent_backtest(
     agent_name: str,
     mode: str = "backtest",
     skip_validation: bool = False,
+    run_timestamp: str | None = None,
 ) -> dict[str, Any]:
     """Run a rule, LLM, or hybrid agent over the configured backtest window."""
 
@@ -171,7 +172,7 @@ def run_agent_backtest(
             "Only --mode backtest is implemented for agent runs at this stage."
         )
 
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    timestamp = run_timestamp or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     run_dir, run_id = create_run_dir(
         run_type="agent",
         mode=mode,

--- a/quanttradeai/agents/batch.py
+++ b/quanttradeai/agents/batch.py
@@ -1,0 +1,293 @@
+"""Batch orchestration for multi-agent backtest runs."""
+
+from __future__ import annotations
+
+import json
+import re
+import traceback
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from quanttradeai.utils.config_validator import validate_project_config
+from quanttradeai.utils.project_config import load_project_config
+from quanttradeai.utils.run_scoreboard import (
+    attach_scoreboard,
+    render_scoreboard_table,
+    sort_run_records,
+)
+
+from .runner import run_project_agent
+
+
+def _slugify(value: str | None) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_-]+", "_", (value or "run").strip())
+    return normalized.strip("_").lower() or "run"
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _copy_artifact(source: str | Path, destination: Path) -> str:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(Path(source).read_text(encoding="utf-8"), encoding="utf-8")
+    return str(destination)
+
+
+def _stdout_log_path(batch_dir: Path, agent_name: str) -> Path:
+    path = batch_dir / "logs" / f"{_slugify(agent_name)}.stdout.log"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _stderr_log_path(batch_dir: Path, agent_name: str) -> Path:
+    path = batch_dir / "logs" / f"{_slugify(agent_name)}.stderr.log"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _load_summary(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _predict_child_run_dir(*, agent_name: str, run_timestamp: str) -> Path:
+    return (
+        Path("runs") / "agent" / "backtest" / f"{run_timestamp}_{_slugify(agent_name)}"
+    )
+
+
+def _child_run_timestamp(batch_timestamp: str, index: int) -> str:
+    return f"{batch_timestamp}_{index:02d}"
+
+
+def run_agent_backtest_batch(
+    *,
+    project_config_path: str = "config/project.yaml",
+    skip_validation: bool = False,
+    max_concurrency: int = 1,
+) -> dict[str, Any]:
+    """Run every configured agent through the normal backtest path."""
+
+    if max_concurrency < 1:
+        raise ValueError("--max-concurrency must be at least 1.")
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    loaded_project = load_project_config(config_path=project_config_path)
+    project_name = (loaded_project.raw.get("project") or {}).get("name") or Path(
+        project_config_path
+    ).stem
+    batch_dir = (
+        Path("runs")
+        / "agent"
+        / "batches"
+        / f"{timestamp}_{_slugify(project_name)}_backtest"
+    )
+    batch_dir.mkdir(parents=True, exist_ok=True)
+
+    validation = validate_project_config(
+        config_path=project_config_path,
+        output_dir=batch_dir / "validation",
+        timestamp_subdir=False,
+    )
+    resolved_validation_path = Path(validation["artifacts"]["resolved_config"])
+    resolved_project_path = batch_dir / "resolved_project_config.yaml"
+    _copy_artifact(resolved_validation_path, resolved_project_path)
+    resolved_project = (
+        yaml.safe_load(resolved_project_path.read_text(encoding="utf-8")) or {}
+    )
+
+    agents = sorted(
+        [dict(agent) for agent in resolved_project.get("agents") or []],
+        key=lambda agent: str(agent.get("name") or ""),
+    )
+    if not agents:
+        raise ValueError("Project config defines no agents to run with --all.")
+
+    agent_specs = [
+        {
+            "agent_name": str(agent.get("name") or ""),
+            "agent_kind": str(agent.get("kind") or ""),
+            "configured_mode": str(agent.get("mode") or ""),
+            "run_timestamp": _child_run_timestamp(timestamp, index),
+        }
+        for index, agent in enumerate(agents, start=1)
+    ]
+
+    def _run_one(spec: dict[str, Any]) -> dict[str, Any]:
+        agent_name = spec["agent_name"]
+        stdout_log = _stdout_log_path(batch_dir, agent_name)
+        stderr_log = _stderr_log_path(batch_dir, agent_name)
+
+        try:
+            summary, warnings = run_project_agent(
+                project_config_path=str(resolved_project_path),
+                agent_name=agent_name,
+                mode="backtest",
+                skip_validation=skip_validation,
+                run_timestamp=str(spec["run_timestamp"]),
+            )
+            stdout_log.write_text(
+                json.dumps({"summary": summary, "warnings": warnings}, indent=2),
+                encoding="utf-8",
+            )
+            stderr_log.write_text("", encoding="utf-8")
+            return {
+                **spec,
+                "status": "success",
+                "warnings": warnings,
+                "summary": summary,
+                "stdout_log": str(stdout_log),
+                "stderr_log": str(stderr_log),
+            }
+        except Exception as exc:
+            stderr_log.write_text(traceback.format_exc(), encoding="utf-8")
+            stdout_log.write_text("", encoding="utf-8")
+            child_run_dir = _predict_child_run_dir(
+                agent_name=agent_name,
+                run_timestamp=str(spec["run_timestamp"]),
+            )
+            child_summary = _load_summary(child_run_dir / "summary.json") or {
+                "run_id": f"agent/backtest/{child_run_dir.name}",
+                "run_type": "agent",
+                "mode": "backtest",
+                "name": agent_name,
+                "status": "failed",
+                "timestamps": {},
+                "symbols": [],
+                "warnings": [],
+                "artifacts": {},
+                "run_dir": str(child_run_dir),
+                "error": str(exc),
+            }
+            return {
+                **spec,
+                "status": "failed",
+                "error": str(exc),
+                "warnings": list(child_summary.get("warnings") or []),
+                "summary": child_summary,
+                "stdout_log": str(stdout_log),
+                "stderr_log": str(stderr_log),
+            }
+
+    results: list[dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=max_concurrency) as executor:
+        futures = [executor.submit(_run_one, spec) for spec in agent_specs]
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    results.sort(key=lambda item: item["agent_name"])
+
+    scoreboard_records = attach_scoreboard([item["summary"] for item in results])
+    scoreboard_records = sort_run_records(
+        scoreboard_records,
+        sort_by="net_sharpe",
+        ascending=False,
+    )
+
+    results_payload = {
+        "results": [
+            {
+                "agent_name": item["agent_name"],
+                "agent_kind": item["agent_kind"],
+                "configured_mode": item["configured_mode"],
+                "status": item["status"],
+                "warnings": item["warnings"],
+                "error": item.get("error"),
+                "run_timestamp": item["run_timestamp"],
+                "run_id": item["summary"].get("run_id"),
+                "run_dir": item["summary"].get("run_dir"),
+                "stdout_log": item["stdout_log"],
+                "stderr_log": item["stderr_log"],
+                "scoreboard": next(
+                    (
+                        record.get("scoreboard")
+                        for record in scoreboard_records
+                        if record.get("run_id") == item["summary"].get("run_id")
+                    ),
+                    None,
+                ),
+            }
+            for item in results
+        ]
+    }
+    scoreboard_payload = {
+        "sort_by": "net_sharpe",
+        "records": scoreboard_records,
+    }
+
+    results_path = batch_dir / "results.json"
+    scoreboard_json_path = batch_dir / "scoreboard.json"
+    scoreboard_txt_path = batch_dir / "scoreboard.txt"
+    _write_json(results_path, results_payload)
+    _write_json(scoreboard_json_path, scoreboard_payload)
+    scoreboard_txt_path.write_text(
+        render_scoreboard_table(scoreboard_records),
+        encoding="utf-8",
+    )
+
+    success_count = sum(1 for item in results if item["status"] == "success")
+    failure_count = len(results) - success_count
+    batch_status = "success" if failure_count == 0 else "failed"
+
+    manifest = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "status": batch_status,
+        "project_name": project_name,
+        "project_config_path": str(project_config_path),
+        "resolved_project_config": str(resolved_project_path),
+        "mode": "backtest",
+        "max_concurrency": max_concurrency,
+        "run_dir": str(batch_dir),
+        "agent_count": len(results),
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "artifacts": {
+            "results": str(results_path),
+            "scoreboard_json": str(scoreboard_json_path),
+            "scoreboard_txt": str(scoreboard_txt_path),
+        },
+        "agents": [
+            {
+                "agent_name": item["agent_name"],
+                "agent_kind": item["agent_kind"],
+                "configured_mode": item["configured_mode"],
+                "status": item["status"],
+                "run_timestamp": item["run_timestamp"],
+                "run_id": item["summary"].get("run_id"),
+                "run_dir": item["summary"].get("run_dir"),
+                "stdout_log": item["stdout_log"],
+                "stderr_log": item["stderr_log"],
+            }
+            for item in results
+        ],
+        "warnings": list(dict.fromkeys(validation.get("warnings", []))),
+    }
+    manifest_path = batch_dir / "batch_manifest.json"
+    _write_json(manifest_path, manifest)
+
+    return {
+        "status": batch_status,
+        "project_name": project_name,
+        "mode": "backtest",
+        "run_dir": str(batch_dir),
+        "agent_count": len(results),
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "artifacts": {
+            **manifest["artifacts"],
+            "manifest": str(manifest_path),
+        },
+        "results": results_payload["results"],
+        "warnings": manifest["warnings"],
+    }

--- a/quanttradeai/agents/batch.py
+++ b/quanttradeai/agents/batch.py
@@ -83,9 +83,10 @@ def run_agent_backtest_batch(
         raise ValueError("--max-concurrency must be at least 1.")
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    loaded_project = load_project_config(config_path=project_config_path)
+    original_project_path = Path(project_config_path).resolve()
+    loaded_project = load_project_config(config_path=original_project_path)
     project_name = (loaded_project.raw.get("project") or {}).get("name") or Path(
-        project_config_path
+        original_project_path
     ).stem
     batch_dir = (
         Path("runs")
@@ -96,7 +97,7 @@ def run_agent_backtest_batch(
     batch_dir.mkdir(parents=True, exist_ok=True)
 
     validation = validate_project_config(
-        config_path=project_config_path,
+        config_path=original_project_path,
         output_dir=batch_dir / "validation",
         timestamp_subdir=False,
     )
@@ -131,7 +132,7 @@ def run_agent_backtest_batch(
 
         try:
             summary, warnings = run_project_agent(
-                project_config_path=str(resolved_project_path),
+                project_config_path=str(original_project_path),
                 agent_name=agent_name,
                 mode="backtest",
                 skip_validation=skip_validation,
@@ -244,7 +245,7 @@ def run_agent_backtest_batch(
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "status": batch_status,
         "project_name": project_name,
-        "project_config_path": str(project_config_path),
+        "project_config_path": str(original_project_path),
         "resolved_project_config": str(resolved_project_path),
         "mode": "backtest",
         "max_concurrency": max_concurrency,

--- a/quanttradeai/agents/model_agent.py
+++ b/quanttradeai/agents/model_agent.py
@@ -193,9 +193,12 @@ def _initialize_model_agent_run(
 
 
 def _start_model_agent_run(
-    *, agent_name: str, mode: str
+    *,
+    agent_name: str,
+    mode: str,
+    run_timestamp: str | None = None,
 ) -> tuple[Path, dict[str, Any]]:
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    timestamp = run_timestamp or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     run_dir, run_id = create_run_dir(
         run_type="agent",
         mode=mode,
@@ -250,10 +253,15 @@ def run_model_agent_backtest(
     project_config_path: str = "config/project.yaml",
     agent_name: str,
     skip_validation: bool = False,
+    run_timestamp: str | None = None,
 ) -> dict[str, Any]:
     """Run a model agent over the configured backtest window."""
 
-    run_dir, summary = _start_model_agent_run(agent_name=agent_name, mode="backtest")
+    run_dir, summary = _start_model_agent_run(
+        agent_name=agent_name,
+        mode="backtest",
+        run_timestamp=run_timestamp,
+    )
 
     try:
         (
@@ -521,6 +529,7 @@ def run_model_agent_paper(
     *,
     project_config_path: str = "config/project.yaml",
     agent_name: str,
+    run_timestamp: str | None = None,
 ) -> dict[str, Any]:
     """Run a model agent in paper mode using the live trading engine."""
 
@@ -528,6 +537,7 @@ def run_model_agent_paper(
         project_config_path=project_config_path,
         agent_name=agent_name,
         mode="paper",
+        run_timestamp=run_timestamp,
     )
 
 
@@ -535,6 +545,7 @@ def run_model_agent_live(
     *,
     project_config_path: str = "config/project.yaml",
     agent_name: str,
+    run_timestamp: str | None = None,
 ) -> dict[str, Any]:
     """Run a model agent in live mode using the live trading engine."""
 
@@ -542,6 +553,7 @@ def run_model_agent_live(
         project_config_path=project_config_path,
         agent_name=agent_name,
         mode="live",
+        run_timestamp=run_timestamp,
     )
 
 
@@ -550,10 +562,15 @@ def _run_model_agent_streaming(
     project_config_path: str,
     agent_name: str,
     mode: str,
+    run_timestamp: str | None = None,
 ) -> dict[str, Any]:
     """Run a model agent in paper or live mode using the live trading engine."""
 
-    run_dir, summary = _start_model_agent_run(agent_name=agent_name, mode=mode)
+    run_dir, summary = _start_model_agent_run(
+        agent_name=agent_name,
+        mode=mode,
+        run_timestamp=run_timestamp,
+    )
 
     try:
         (

--- a/quanttradeai/agents/paper.py
+++ b/quanttradeai/agents/paper.py
@@ -855,6 +855,7 @@ def run_agent_paper(
     *,
     project_config_path: str = "config/project.yaml",
     agent_name: str,
+    run_timestamp: str | None = None,
 ) -> dict[str, Any]:
     """Run a rule, LLM, or hybrid agent in paper mode using streaming input."""
 
@@ -862,6 +863,7 @@ def run_agent_paper(
         project_config_path=project_config_path,
         agent_name=agent_name,
         mode="paper",
+        run_timestamp=run_timestamp,
     )
 
 
@@ -869,6 +871,7 @@ def run_agent_live(
     *,
     project_config_path: str = "config/project.yaml",
     agent_name: str,
+    run_timestamp: str | None = None,
 ) -> dict[str, Any]:
     """Run a rule, LLM, or hybrid agent in live mode using streaming input."""
 
@@ -876,6 +879,7 @@ def run_agent_live(
         project_config_path=project_config_path,
         agent_name=agent_name,
         mode="live",
+        run_timestamp=run_timestamp,
     )
 
 
@@ -884,10 +888,11 @@ def _run_agent_streaming(
     project_config_path: str,
     agent_name: str,
     mode: str,
+    run_timestamp: str | None = None,
 ) -> dict[str, Any]:
     """Run a rule, LLM, or hybrid agent in paper or live mode using streaming input."""
 
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    timestamp = run_timestamp or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     run_dir, run_id = create_run_dir(
         run_type="agent",
         mode=mode,

--- a/quanttradeai/agents/runner.py
+++ b/quanttradeai/agents/runner.py
@@ -1,0 +1,127 @@
+"""Shared dispatcher for project-defined agent runs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from quanttradeai.utils.project_config import load_project_config
+
+
+def _load_agent_config(
+    *,
+    project_config_path: str,
+    agent_name: str,
+) -> dict[str, Any]:
+    loaded_project = load_project_config(config_path=project_config_path)
+    agent_config = next(
+        (
+            dict(item)
+            for item in loaded_project.raw.get("agents") or []
+            if item.get("name") == agent_name
+        ),
+        None,
+    )
+    if agent_config is None:
+        raise ValueError(f"Agent '{agent_name}' not found in project config.")
+    return agent_config
+
+
+def run_project_agent(
+    *,
+    project_config_path: str = "config/project.yaml",
+    agent_name: str,
+    mode: str = "backtest",
+    skip_validation: bool = False,
+    run_timestamp: str | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Dispatch a project-defined agent run and return its summary plus warnings."""
+
+    from .backtest import run_agent_backtest
+    from .model_agent import (
+        run_model_agent_backtest,
+        run_model_agent_live,
+        run_model_agent_paper,
+    )
+    from .paper import run_agent_live, run_agent_paper
+
+    agent_config = _load_agent_config(
+        project_config_path=project_config_path,
+        agent_name=agent_name,
+    )
+    warnings: list[str] = []
+
+    configured_mode = str(agent_config.get("mode") or "").strip().lower()
+    if mode == "live":
+        if skip_validation:
+            raise ValueError("--skip-validation is not supported for live agent runs.")
+        if configured_mode != "live":
+            raise ValueError(
+                f"Agent '{agent_name}' must be configured with mode=live before running `quanttradeai agent run --mode live`."
+            )
+    elif configured_mode and configured_mode != mode:
+        warnings.append(
+            f"Warning: agent '{agent_name}' is configured with mode={configured_mode} but CLI requested mode={mode}; continuing with CLI mode."
+        )
+
+    agent_kind = agent_config.get("kind")
+    if agent_kind == "model":
+        if mode == "backtest":
+            summary = run_model_agent_backtest(
+                project_config_path=project_config_path,
+                agent_name=agent_name,
+                skip_validation=skip_validation,
+                run_timestamp=run_timestamp,
+            )
+        elif mode == "paper":
+            if skip_validation:
+                warnings.append(
+                    "Warning: --skip-validation is ignored for model agent paper runs."
+                )
+            summary = run_model_agent_paper(
+                project_config_path=project_config_path,
+                agent_name=agent_name,
+                run_timestamp=run_timestamp,
+            )
+        elif mode == "live":
+            summary = run_model_agent_live(
+                project_config_path=project_config_path,
+                agent_name=agent_name,
+                run_timestamp=run_timestamp,
+            )
+        else:
+            raise ValueError(
+                "Model agents currently support only --mode backtest, --mode paper, or --mode live."
+            )
+    elif agent_kind in {"llm", "hybrid", "rule"}:
+        if mode == "backtest":
+            summary = run_agent_backtest(
+                project_config_path=project_config_path,
+                agent_name=agent_name,
+                mode=mode,
+                skip_validation=skip_validation,
+                run_timestamp=run_timestamp,
+            )
+        elif mode == "paper":
+            if skip_validation:
+                warnings.append(
+                    "Warning: --skip-validation is ignored for rule/llm/hybrid agent paper runs."
+                )
+            summary = run_agent_paper(
+                project_config_path=project_config_path,
+                agent_name=agent_name,
+                run_timestamp=run_timestamp,
+            )
+        elif mode == "live":
+            summary = run_agent_live(
+                project_config_path=project_config_path,
+                agent_name=agent_name,
+                run_timestamp=run_timestamp,
+            )
+        else:
+            raise ValueError(
+                "Rule, LLM, and hybrid agents currently support only --mode backtest, --mode paper, or --mode live."
+            )
+    else:
+        raise ValueError(f"Unsupported agent kind: {agent_kind}")
+
+    return summary, warnings

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -1384,7 +1384,16 @@ def cmd_deploy(
 
 @agent_app.command("run")
 def cmd_agent_run(
-    agent: str = typer.Option(..., "--agent", help="Agent name from project config"),
+    agent: Optional[str] = typer.Option(
+        None,
+        "--agent",
+        help="Agent name from project config",
+    ),
+    run_all: bool = typer.Option(
+        False,
+        "--all",
+        help="Run every project-defined agent. Backtest mode only in this release.",
+    ),
     config: str = typer.Option(
         "config/project.yaml", "-c", "--config", help="Path to project config YAML"
     ),
@@ -1398,102 +1407,47 @@ def cmd_agent_run(
         "--skip-validation",
         help="Skip data-quality validation before backtesting",
     ),
+    max_concurrency: int = typer.Option(
+        1,
+        "--max-concurrency",
+        min=1,
+        help="Maximum concurrent child runs when using --all.",
+    ),
 ):
     """Run a first-class project agent in backtest, paper, or live mode."""
 
-    from .agents.backtest import run_agent_backtest
-    from .agents.model_agent import (
-        run_model_agent_backtest,
-        run_model_agent_live,
-        run_model_agent_paper,
-    )
-    from .agents.paper import run_agent_live, run_agent_paper
+    from .agents.batch import run_agent_backtest_batch
+    from .agents.runner import run_project_agent
+
+    if bool(agent) == bool(run_all):
+        raise typer.BadParameter("Choose exactly one of --agent or --all.")
 
     try:
-        loaded_project = load_project_config(config_path=config)
-        agent_config = next(
-            (
-                dict(item)
-                for item in loaded_project.raw.get("agents") or []
-                if item.get("name") == agent
-            ),
-            None,
-        )
-        if agent_config is None:
-            raise ValueError(f"Agent '{agent}' not found in project config.")
-
-        configured_mode = str(agent_config.get("mode") or "").strip().lower()
-        if mode == "live":
-            if skip_validation:
-                raise ValueError(
-                    "--skip-validation is not supported for live agent runs."
-                )
-            if configured_mode != "live":
-                raise ValueError(
-                    f"Agent '{agent}' must be configured with mode=live before running `quanttradeai agent run --mode live`."
-                )
-        elif configured_mode and configured_mode != mode:
-            typer.echo(
-                f"Warning: agent '{agent}' is configured with mode={configured_mode} but CLI requested mode={mode}; continuing with CLI mode.",
-                err=True,
+        if run_all:
+            if mode != "backtest":
+                raise ValueError("--all currently supports only --mode backtest.")
+            batch_result = run_agent_backtest_batch(
+                project_config_path=config,
+                skip_validation=skip_validation,
+                max_concurrency=max_concurrency,
             )
+            typer.echo(f"Agent batch completed: {batch_result['run_dir']}")
+            typer.echo(json.dumps(batch_result, indent=2))
+            if batch_result["status"] != "success":
+                raise typer.Exit(code=1)
+            return
 
-        agent_kind = agent_config.get("kind")
-        if agent_kind == "model":
-            if mode == "backtest":
-                summary = run_model_agent_backtest(
-                    project_config_path=config,
-                    agent_name=agent,
-                    skip_validation=skip_validation,
-                )
-            elif mode == "paper":
-                if skip_validation:
-                    typer.echo(
-                        "Warning: --skip-validation is ignored for model agent paper runs.",
-                        err=True,
-                    )
-                summary = run_model_agent_paper(
-                    project_config_path=config,
-                    agent_name=agent,
-                )
-            elif mode == "live":
-                summary = run_model_agent_live(
-                    project_config_path=config,
-                    agent_name=agent,
-                )
-            else:
-                raise ValueError(
-                    "Model agents currently support only --mode backtest, --mode paper, or --mode live."
-                )
-        elif agent_kind in {"llm", "hybrid", "rule"}:
-            if mode == "backtest":
-                summary = run_agent_backtest(
-                    project_config_path=config,
-                    agent_name=agent,
-                    mode=mode,
-                    skip_validation=skip_validation,
-                )
-            elif mode == "paper":
-                if skip_validation:
-                    typer.echo(
-                        "Warning: --skip-validation is ignored for rule/llm/hybrid agent paper runs.",
-                        err=True,
-                    )
-                summary = run_agent_paper(
-                    project_config_path=config,
-                    agent_name=agent,
-                )
-            elif mode == "live":
-                summary = run_agent_live(
-                    project_config_path=config,
-                    agent_name=agent,
-                )
-            else:
-                raise ValueError(
-                    "Rule, LLM, and hybrid agents currently support only --mode backtest, --mode paper, or --mode live."
-                )
-        else:
-            raise ValueError(f"Unsupported agent kind: {agent_kind}")
+        assert agent is not None
+        summary, warnings = run_project_agent(
+            project_config_path=config,
+            agent_name=agent,
+            mode=mode,
+            skip_validation=skip_validation,
+        )
+        for warning in warnings:
+            typer.echo(warning, err=True)
+    except typer.Exit:
+        raise
     except Exception as exc:
         typer.echo(f"Agent run failed: {exc}", err=True)
         raise typer.Exit(code=1)

--- a/quanttradeai/utils/run_scoreboard.py
+++ b/quanttradeai/utils/run_scoreboard.py
@@ -107,6 +107,8 @@ def _resolve_metrics_path(record: dict[str, Any]) -> Path:
         candidate = Path(str(metrics_path))
         if candidate.is_absolute():
             return candidate
+        if run_dir.parts and candidate.parts[: len(run_dir.parts)] == run_dir.parts:
+            return candidate
         return run_dir / candidate
     return run_dir / "metrics.json"
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -352,7 +352,8 @@ Make running many agents and many experiments on one machine easy and trustworth
 Status on 2026-04-11:
 
 - `quanttradeai runs list --scoreboard` is implemented for local research and agent runs, with metric-aware sorting via `--sort-by` and additive JSON scoreboard payloads.
-- Multi-agent orchestration, parameter sweeps, and richer comparison workflows remain future Stage 2 work.
+- `quanttradeai agent run --all -c config/project.yaml --mode backtest` is implemented for local multi-agent backtest batches, with bounded concurrency, preserved child runs, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
+- Parameter sweeps, paper/live multi-agent orchestration, and richer comparison workflows remain future Stage 2 work.
 
 Deliverables:
 

--- a/tests/integration/test_agent_batch_cli.py
+++ b/tests/integration/test_agent_batch_cli.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import re
 from unittest.mock import patch
 
 import yaml
@@ -9,6 +10,12 @@ from quanttradeai.cli import PROJECT_TEMPLATES, app
 
 
 runner = CliRunner()
+
+
+def _normalize_cli_output(stdout: str, stderr: str) -> str:
+    combined = f"{stdout}\n{stderr}"
+    combined = re.sub(r"\x1b\[[0-9;]*m", "", combined)
+    return " ".join(combined.lower().split())
 
 
 def _write_project_with_all_agent_kinds(config_path: Path) -> None:
@@ -55,8 +62,8 @@ def test_agent_run_requires_exactly_one_of_agent_or_all(tmp_path: Path, monkeypa
 
     neither = runner.invoke(app, ["agent", "run", "--config", str(config_path)])
     assert neither.exit_code == 2
-    neither_output = f"{neither.stdout}\n{neither.stderr}".lower()
-    assert "exactly one of --agent or --all" in neither_output
+    neither_output = _normalize_cli_output(neither.stdout, neither.stderr)
+    assert "choose exactly one of --agent or --all" in neither_output
 
     both = runner.invoke(
         app,
@@ -71,8 +78,8 @@ def test_agent_run_requires_exactly_one_of_agent_or_all(tmp_path: Path, monkeypa
         ],
     )
     assert both.exit_code == 2
-    both_output = f"{both.stdout}\n{both.stderr}".lower()
-    assert "exactly one of --agent or --all" in both_output
+    both_output = _normalize_cli_output(both.stdout, both.stderr)
+    assert "choose exactly one of --agent or --all" in both_output
 
 
 def test_agent_run_all_rejects_non_backtest_modes(tmp_path: Path, monkeypatch):

--- a/tests/integration/test_agent_batch_cli.py
+++ b/tests/integration/test_agent_batch_cli.py
@@ -160,6 +160,7 @@ def test_agent_run_all_writes_batch_artifacts_and_sorts_scoreboard(
     ):
         assert mode == "backtest"
         assert run_timestamp is not None
+        assert Path(project_config_path).resolve() == config_path.resolve()
         run_dir = (
             Path("runs")
             / "agent"

--- a/tests/integration/test_agent_batch_cli.py
+++ b/tests/integration/test_agent_batch_cli.py
@@ -1,0 +1,337 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+from typer.testing import CliRunner
+
+from quanttradeai.cli import PROJECT_TEMPLATES, app
+
+
+runner = CliRunner()
+
+
+def _write_project_with_all_agent_kinds(config_path: Path) -> None:
+    project_config = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["hybrid"], sort_keys=False)
+    )
+    project_config["project"]["name"] = "multi_agent_lab"
+    project_config["research"]["enabled"] = False
+    project_config["agents"] = [
+        yaml.safe_load(yaml.safe_dump(PROJECT_TEMPLATES["rule-agent"]["agents"][0])),
+        yaml.safe_load(yaml.safe_dump(PROJECT_TEMPLATES["model-agent"]["agents"][0])),
+        yaml.safe_load(yaml.safe_dump(PROJECT_TEMPLATES["llm-agent"]["agents"][0])),
+        yaml.safe_load(yaml.safe_dump(PROJECT_TEMPLATES["hybrid"]["agents"][0])),
+    ]
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        yaml.safe_dump(project_config, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _seed_agent_assets(tmp_path: Path) -> Path:
+    config_path = tmp_path / "config" / "project.yaml"
+
+    llm_init = runner.invoke(
+        app,
+        ["init", "--template", "llm-agent", "--output", str(config_path)],
+    )
+    assert llm_init.exit_code == 0, llm_init.stdout
+
+    hybrid_init = runner.invoke(
+        app,
+        ["init", "--template", "hybrid", "--output", str(config_path), "--force"],
+    )
+    assert hybrid_init.exit_code == 0, hybrid_init.stdout
+
+    _write_project_with_all_agent_kinds(config_path)
+    return config_path
+
+
+def test_agent_run_requires_exactly_one_of_agent_or_all(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+
+    neither = runner.invoke(app, ["agent", "run", "--config", str(config_path)])
+    assert neither.exit_code == 2
+    neither_output = f"{neither.stdout}\n{neither.stderr}".lower()
+    assert "exactly one of --agent or --all" in neither_output
+
+    both = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--agent",
+            "rsi_reversion",
+            "--all",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert both.exit_code == 2
+    both_output = f"{both.stdout}\n{both.stderr}".lower()
+    assert "exactly one of --agent or --all" in both_output
+
+
+def test_agent_run_all_rejects_non_backtest_modes(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--all",
+            "--config",
+            str(config_path),
+            "--mode",
+            "paper",
+        ],
+    )
+
+    assert result.exit_code == 1
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert "--all currently supports only --mode backtest" in combined
+
+
+def test_agent_run_all_rejects_invalid_max_concurrency(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--all",
+            "--config",
+            str(config_path),
+            "--max-concurrency",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 2
+
+
+def test_agent_run_all_errors_when_project_has_no_agents(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config" / "project.yaml"
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "research", "--output", str(config_path)],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    result = runner.invoke(
+        app,
+        ["agent", "run", "--all", "--config", str(config_path)],
+    )
+
+    assert result.exit_code == 1
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert "defines no agents to run with --all" in combined
+
+
+def test_agent_run_all_writes_batch_artifacts_and_sorts_scoreboard(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+
+    def _fake_run_project_agent(
+        *,
+        project_config_path: str,
+        agent_name: str,
+        mode: str,
+        skip_validation: bool,
+        run_timestamp: str | None = None,
+    ):
+        assert mode == "backtest"
+        assert run_timestamp is not None
+        run_dir = (
+            Path("runs")
+            / "agent"
+            / "backtest"
+            / f"{run_timestamp}_{agent_name.lower()}"
+        )
+        run_dir.mkdir(parents=True, exist_ok=True)
+        sharpe_by_agent = {
+            "rsi_reversion": 0.8,
+            "paper_momentum": 1.1,
+            "breakout_gpt": 2.4,
+            "hybrid_swing_agent": 1.7,
+        }
+        metrics_path = run_dir / "metrics.json"
+        metrics_path.write_text(
+            json.dumps(
+                {
+                    "net_sharpe": sharpe_by_agent[agent_name],
+                    "net_pnl": sharpe_by_agent[agent_name] / 10.0,
+                    "net_mdd": -0.05,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        summary = {
+            "run_id": f"agent/backtest/{run_dir.name}",
+            "run_type": "agent",
+            "mode": "backtest",
+            "name": agent_name,
+            "status": "success",
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "symbols": ["AAPL"],
+            "warnings": [],
+            "artifacts": {"metrics": str(metrics_path)},
+            "run_dir": str(run_dir),
+        }
+        (run_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2),
+            encoding="utf-8",
+        )
+        return summary, []
+
+    with patch(
+        "quanttradeai.agents.batch.run_project_agent",
+        side_effect=_fake_run_project_agent,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--all",
+                "--config",
+                str(config_path),
+                "--mode",
+                "backtest",
+                "--max-concurrency",
+                "2",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    batch_dir = Path(payload["run_dir"])
+
+    assert payload["status"] == "success"
+    assert payload["agent_count"] == 4
+    assert (batch_dir / "batch_manifest.json").is_file()
+    assert (batch_dir / "results.json").is_file()
+    assert (batch_dir / "scoreboard.json").is_file()
+    assert (batch_dir / "scoreboard.txt").is_file()
+
+    results_payload = json.loads((batch_dir / "results.json").read_text("utf-8"))
+    assert [item["agent_name"] for item in results_payload["results"]] == [
+        "breakout_gpt",
+        "hybrid_swing_agent",
+        "paper_momentum",
+        "rsi_reversion",
+    ]
+
+    scoreboard_payload = json.loads((batch_dir / "scoreboard.json").read_text("utf-8"))
+    ordered_names = [record["name"] for record in scoreboard_payload["records"]]
+    assert ordered_names == [
+        "breakout_gpt",
+        "hybrid_swing_agent",
+        "paper_momentum",
+        "rsi_reversion",
+    ]
+    assert "NET_SHARPE" in (batch_dir / "scoreboard.txt").read_text("utf-8")
+
+
+def test_agent_run_all_returns_non_zero_after_partial_failure(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+
+    def _fake_run_project_agent(
+        *,
+        project_config_path: str,
+        agent_name: str,
+        mode: str,
+        skip_validation: bool,
+        run_timestamp: str | None = None,
+    ):
+        run_dir = (
+            Path("runs")
+            / "agent"
+            / "backtest"
+            / f"{run_timestamp}_{agent_name.lower()}"
+        )
+        run_dir.mkdir(parents=True, exist_ok=True)
+        if agent_name == "paper_momentum":
+            summary = {
+                "run_id": f"agent/backtest/{run_dir.name}",
+                "run_type": "agent",
+                "mode": "backtest",
+                "name": agent_name,
+                "status": "failed",
+                "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+                "symbols": [],
+                "warnings": [],
+                "artifacts": {},
+                "run_dir": str(run_dir),
+                "error": "model failure",
+            }
+            (run_dir / "summary.json").write_text(
+                json.dumps(summary, indent=2),
+                encoding="utf-8",
+            )
+            raise ValueError("model failure")
+
+        metrics_path = run_dir / "metrics.json"
+        metrics_path.write_text(
+            json.dumps({"net_sharpe": 1.0, "net_pnl": 0.1, "net_mdd": -0.02}, indent=2),
+            encoding="utf-8",
+        )
+        summary = {
+            "run_id": f"agent/backtest/{run_dir.name}",
+            "run_type": "agent",
+            "mode": "backtest",
+            "name": agent_name,
+            "status": "success",
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "symbols": ["AAPL"],
+            "warnings": [],
+            "artifacts": {"metrics": str(metrics_path)},
+            "run_dir": str(run_dir),
+        }
+        (run_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2),
+            encoding="utf-8",
+        )
+        return summary, []
+
+    with patch(
+        "quanttradeai.agents.batch.run_project_agent",
+        side_effect=_fake_run_project_agent,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--all",
+                "--config",
+                str(config_path),
+                "--mode",
+                "backtest",
+            ],
+        )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    assert payload["status"] == "failed"
+    assert payload["failure_count"] == 1
+    failed_result = next(
+        item for item in payload["results"] if item["agent_name"] == "paper_momentum"
+    )
+    assert failed_result["status"] == "failed"
+    assert failed_result["error"] == "model failure"

--- a/tests/integration/test_runs_cli.py
+++ b/tests/integration/test_runs_cli.py
@@ -539,3 +539,24 @@ def test_runs_list_scoreboard_json_includes_additive_scoreboard_payload(
     assert payload[0]["scoreboard"]["net_sharpe"] == 1.25
     assert "scoreboard" in payload[1]
     assert payload[1]["scoreboard"]["accuracy"] == 0.8
+
+
+def test_runs_list_ignores_batch_artifacts_without_child_run_summaries(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _seed_runs(runs_root)
+
+    batch_root = runs_root / "agent" / "batches" / "20260101_000000_multi_agent_backtest"
+    batch_root.mkdir(parents=True, exist_ok=True)
+    (batch_root / "batch_manifest.json").write_text("{}", encoding="utf-8")
+    (batch_root / "results.json").write_text("{}", encoding="utf-8")
+    (batch_root / "scoreboard.json").write_text("{}", encoding="utf-8")
+    (batch_root / "scoreboard.txt").write_text("placeholder", encoding="utf-8")
+
+    result = runner.invoke(app, ["runs", "list", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert all("batches" not in record["run_dir"] for record in payload)


### PR DESCRIPTION
## What changed

This PR adds a first-class multi-agent backtest workflow on top of the existing single-agent runners.

- extends `quanttradeai agent run` with `--all` and `--max-concurrency`
- adds a shared agent dispatcher to keep single-agent and batch execution on one code path
- adds a batch orchestrator that runs every configured agent in backtest mode and writes batch artifacts under `runs/agent/batches/...`
- preserves the existing child run layout under `runs/agent/backtest/...` so `runs list --scoreboard` continues to work
- updates docs, roadmap status, and package metadata to reflect the new QuantTradeAI workflow

## Why it changed

Stage 2 had scoreboard support but no first-class way to run many agents from one project config. The missing workflow was multi-agent orchestration for local backtests.

## Impact

Users can now run:

```bash
quanttradeai agent run --all -c config/project.yaml --mode backtest
quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
```

This produces:

- normal per-agent child backtest runs
- batch-level `batch_manifest.json`
- batch-level `results.json`
- batch-level `scoreboard.json`
- batch-level `scoreboard.txt`

## Root cause

The codebase already had strong single-agent backtest/paper/live flows, but Stage 2 orchestration was still missing. There was no reusable dispatcher or batch-level artifact model to build on.

## Validation

- `make lint.format.test`
- `poetry build`
- commit hooks: `format`, `lint`, `test`
