### PR TITLE
Add deterministic paper replay mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 | Run a hybrid agent | `init --template hybrid` -> `research run` -> `promote --run research/<run_id>` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Model signals plus LLM reasoning in one project, with research outputs promoted into a stable path before the agent is promoted through environments |
 | Backtest every project agent together | `agent run --all --mode backtest --max-concurrency 4` | A local multi-agent backtest batch with preserved child runs plus batch-level manifests and scoreboards |
 | Sweep one agent across parameter variants | `agent run --sweep rsi_threshold_grid --mode backtest --max-concurrency 4` | A local sweep batch that expands one agent into many backtest variants, preserves normal child runs, and ranks them with the same scoreboard flow |
-| Generate a Docker Compose deployment bundle | `deploy --agent <name> --target docker-compose` | A paper-agent bundle with compose, Dockerfile, env placeholders, and resolved config |
+| Generate a Docker Compose deployment bundle | `deploy --agent <name> --target docker-compose` | A real-time paper-agent bundle with compose, Dockerfile, env placeholders, and resolved config |
 | Keep using the older live loop | `live-trade` with runtime YAML files | Legacy compatibility for existing setups |
 
 ## How It Fits Together
@@ -99,6 +99,8 @@ poetry run quanttradeai --help
 If you prefer a package install, `pip install .` also works.
 
 ## Fastest Working Paths
+
+Local `agent run --mode paper` now defaults to deterministic historical replay through `data.streaming.replay`. If you do not set explicit replay dates, QuantTradeAI uses `data.test_start` and `data.test_end`, then falls back to `data.start_date` and `data.end_date`.
 
 ### Research In 4 Commands
 
@@ -268,6 +270,8 @@ This writes a deployment bundle under `reports/deployments/<agent>/<timestamp>/`
 - `resolved_project_config.yaml`
 - `deployment_manifest.json`
 
+Generated deployment bundles always disable replay in the emitted resolved project config and expect real-time streaming credentials. Local replay-backed paper runs stay unchanged in your source `config/project.yaml`.
+
 ## What A Project Looks Like
 
 The happy path is centered on `config/project.yaml`.
@@ -284,6 +288,16 @@ data:
   timeframe: "1d"
   test_start: "2024-09-01"
   test_end: "2024-12-31"
+  streaming:
+    enabled: true
+    provider: "alpaca"
+    websocket_url: "wss://stream.data.alpaca.markets/v2/iex"
+    auth_method: "api_key"
+    symbols: ["AAPL"]
+    channels: ["trades", "quotes"]
+    replay:
+      enabled: true
+      pace_delay_ms: 0
 
 features:
   definitions:
@@ -307,7 +321,7 @@ For the full shape, field reference, and supported agent modes, see [Project YAM
 | --- | --- | --- |
 | Research | `runs/research/<timestamp>_<project>/` | `resolved_project_config.yaml`, runtime YAML snapshots, `summary.json`, `metrics.json`, backtest artifacts |
 | Agent backtest | `runs/agent/backtest/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, backtest files |
-| Agent paper | `runs/agent/paper/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime YAML snapshots |
+| Agent paper | `runs/agent/paper/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime YAML snapshots, and `replay_manifest.json` when replay is enabled |
 | Agent live | `runs/agent/live/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime streaming/risk/position-manager YAML snapshots |
 
 Sweep batch artifacts:
@@ -365,8 +379,9 @@ poetry run quanttradeai validate-config
 
 Important boundary:
 
-- `agent run --mode paper` for project-defined `model` agents compiles runtime config from `config/project.yaml`
+- `agent run --mode paper` for project-defined agents uses replay from `config/project.yaml` when `data.streaming.replay.enabled: true`
 - `agent run --mode live` for project-defined `rule`, `model`, `llm`, and `hybrid` agents compiles runtime config from `config/project.yaml`
+- `deploy --target docker-compose` generates a real-time paper bundle and disables replay in the emitted deployment config
 - `live-trade` still uses the legacy runtime YAML files directly
 
 ## Development

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-QuantTradeAI has one **canonical project config** for research and agent backtests, plus a set of **runtime YAML files** that still power live trading and some compatibility workflows.
+QuantTradeAI has one **canonical project config** for research and project-defined agents, plus a set of **runtime YAML files** that still power `live-trade` and some compatibility workflows.
 
 > Start with `config/project.yaml` if you are building a new research or agent workflow.
 > Use the runtime YAMLs when you are running `live-trade`, saved-model backtests, or migrating older setups.
@@ -24,6 +24,20 @@ QuantTradeAI has one **canonical project config** for research and agent backtes
 - [Legacy Config Compatibility](configuration/legacy-configs.md)
 
 ## Typical Workflows
+
+### Local Paper Mode
+
+```bash
+poetry run quanttradeai init --template rule-agent -o config/project.yaml
+poetry run quanttradeai validate -c config/project.yaml
+poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode paper
+```
+
+By default, project-defined paper runs use `data.streaming.replay` for deterministic OHLCV replay. Replay dates resolve in this order:
+
+- `data.streaming.replay.start_date` / `data.streaming.replay.end_date`
+- `data.test_start` / `data.test_end`
+- `data.start_date` / `data.end_date`
 
 ### Research
 
@@ -49,6 +63,8 @@ poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
 ```
 
+Deployment bundles are still real-time paper bundles. QuantTradeAI disables replay in the emitted deployment config and expects provider/websocket settings to be valid.
+
 ### Live Trading
 
 ```bash
@@ -63,6 +79,8 @@ poetry run quanttradeai live-trade \
 ## Important Boundaries
 
 - `config/project.yaml` is the center of gravity for **research**, **agent runs**, **promotion**, and **deployment generation**
+- local `agent run --mode paper` defaults to replay from `config/project.yaml`
+- generated deployment bundles keep paper mode but switch the emitted config back to real-time streaming
 - `quanttradeai live-trade` does **not** read `config/project.yaml` today
 - `config/streaming.yaml`, `config/risk_config.yaml`, and `config/position_manager.yaml` are still first-class runtime files
 - `quanttradeai validate-config` is the fastest way to catch malformed runtime YAMLs before running live or backtest commands

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -14,6 +14,8 @@ It drives:
 
 `live-trade` still uses the legacy runtime YAML files documented in [Runtime and Live Trading Configs](live-runtime-files.md).
 
+For local project-defined agents, `agent run --mode paper` defaults to deterministic replay when `data.streaming.replay.enabled: true`.
+
 ## Supported Project Workflows
 
 ### Research
@@ -160,6 +162,9 @@ data:
     auth_method: "api_key"
     symbols: ["AAPL"]
     channels: ["trades", "quotes"]
+    replay:
+      enabled: true
+      pace_delay_ms: 0
     buffer_size: 1000
     reconnect_attempts: 5
     health_check_interval: 30
@@ -312,17 +317,27 @@ When you use mapping syntax, validation checks `asset_class` against the asset c
 
 Used by project-defined paper and live agents.
 
-Required when any agent is configured with `mode: paper` or `mode: live`:
+Realtime-required fields:
 
 - `enabled: true`
 - `provider`
 - `websocket_url`
-- `auth_method`
 - `symbols`
 - `channels`
+
+General runtime fields:
+
+- `auth_method`
 - `buffer_size`
 - `reconnect_attempts`
 - `health_check_interval`
+
+Replay fields:
+
+- `replay.enabled`
+- `replay.start_date`
+- `replay.end_date`
+- `replay.pace_delay_ms`
 
 Optional passthrough sections:
 
@@ -336,7 +351,14 @@ Optional passthrough sections:
 
 These values are compiled into the runtime streaming YAML consumed by the current gateway.
 
-Validation enforces the same rule for both paper and live agents: if any agent is configured with `mode: paper` or `mode: live`, then `data.streaming.enabled` must be `true`.
+Happy-path behavior:
+
+- if `data.streaming.replay.enabled: true`, then `quanttradeai agent run --mode paper` replays historical OHLCV bars instead of connecting to a real-time websocket
+- replay dates resolve from `replay.start_date` and `replay.end_date`, then `data.test_start` and `data.test_end`, then `data.start_date` and `data.end_date`
+- local replay-backed paper runs may omit `provider` and `websocket_url`
+- `quanttradeai agent run --mode live` and `quanttradeai deploy` still require real-time streaming fields
+
+The default agent templates keep both the replay block and the real-time streaming block so the same project can move from local paper runs into later live promotion or paper deployment without restructuring the config.
 
 ### `features`
 
@@ -415,8 +437,10 @@ Paper mode:
 
 - compiles `data.streaming` into a runtime streaming config
 - warm-starts with recent historical OHLCV before streaming begins
+- replays historical OHLCV deterministically when `data.streaming.replay.enabled` is true
 - evaluates the configured rule on each completed streaming bar
 - writes `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, and `runtime_streaming_config.yaml`
+- writes `replay_manifest.json` and records `paper_source: replay` in `summary.json` when replay is enabled
 - does not emit `prompt_samples.json`
 
 Live mode:
@@ -446,8 +470,10 @@ Backtest mode:
 Paper mode:
 
 - compiles `data.streaming` into a runtime streaming config
+- warm-starts the model with historical bars so the first replay/live bar can infer immediately on the happy path
 - runs the existing paper/live engine with the compiled feature config
 - writes `summary.json`, `metrics.json`, `executions.jsonl`, and `runtime_streaming_config.yaml`
+- writes `replay_manifest.json` and records `paper_source: replay` in `summary.json` when replay is enabled
 
 Live mode:
 
@@ -474,8 +500,10 @@ Paper mode:
 
 - compiles `data.streaming` into a runtime streaming config
 - warm-starts with recent historical OHLCV before streaming begins
+- replays historical OHLCV deterministically when `data.streaming.replay.enabled` is true
 - aggregates streaming messages into completed bars before invoking the agent
 - writes `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, `prompt_samples.json`, and `runtime_streaming_config.yaml`
+- writes `replay_manifest.json` and records `paper_source: replay` in `summary.json` when replay is enabled
 
 Live mode:
 
@@ -506,6 +534,8 @@ Behavior:
 - `quanttradeai promote --run research/<run_id> -c config/project.yaml` copies trained model artifacts into stable `models/...` destinations and writes `promotion_manifest.json`
 - `quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml` updates `deployment.mode` to `paper` when promoting a successful agent backtest run
 - `quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` generates a bundle under `reports/deployments/<agent>/<timestamp>/`
+- generated deployment bundles force `data.streaming.replay.enabled: false` in `resolved_project_config.yaml`
+- deployment generation fails if the project does not include the real-time `provider`, `websocket_url`, and `channels` required for paper deployment
 - generated bundles include `docker-compose.yml`, `Dockerfile`, `.env.example`, `README.md`, `resolved_project_config.yaml`, and `deployment_manifest.json`
 - generated compose services run `quanttradeai agent run --agent <name> -c config/project.yaml --mode paper`
 
@@ -614,6 +644,8 @@ Writes a batch directory under `runs/agent/batches/<timestamp>_<project>_<sweep>
 Writes under `runs/agent/paper/<timestamp>_<agent>/`.
 
 For `llm` and `hybrid` paper runs, the run directory includes both `decisions.jsonl` and `executions.jsonl` so prompt-driven decisions and actual paper executions can be audited separately.
+
+When replay is enabled, the run directory also includes `replay_manifest.json`, and `summary.json` records `paper_source: replay`.
 
 ### `quanttradeai agent run --mode live`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ The model-agent template creates:
 
 - a canonical `config/project.yaml`
 - a placeholder model artifact directory at `models/promoted/aapl_daily_classifier/`
-- a minimal `data.streaming` block
+- a replay-enabled `data.streaming` block for local paper runs
 - top-level `risk` and `position_manager` defaults for later live promotion
 
 Replace the placeholder model directory with a promoted research model artifact or another compatible saved model before running the agent.
@@ -61,6 +61,8 @@ poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode paper
 ```
 
+Local paper mode uses deterministic historical replay by default. If you leave `data.streaming.replay.start_date` and `end_date` unset, QuantTradeAI resolves the replay window from `data.test_start` and `data.test_end`, then falls back to `data.start_date` and `data.end_date`.
+
 ### Promote The Same Agent To Live
 
 ```bash
@@ -74,12 +76,16 @@ poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml 
 poetry run quanttradeai deploy --agent paper_momentum -c config/project.yaml --target docker-compose
 ```
 
+Generated deployment bundles are still real-time paper deployments. QuantTradeAI disables replay in the emitted `resolved_project_config.yaml` and requires the normal provider and websocket settings to be present in the source project config.
+
 Paper and live runs write standardized artifacts under `runs/agent/paper/...` and `runs/agent/live/...`, including:
 
 - `summary.json`
 - `metrics.json`
 - `executions.jsonl`
 - compiled runtime YAML snapshots
+
+Replay-backed paper runs also write `replay_manifest.json`.
 
 Live runs also write compiled `runtime_risk_config.yaml` and `runtime_position_manager_config.yaml`.
 
@@ -153,7 +159,8 @@ poetry run quanttradeai live-trade -m <model_dir> -c config/model_config.yaml -s
 
 Important boundary:
 
-- project-defined paper and live agents compile runtime config from `config/project.yaml`
+- project-defined paper agents default to replay from `config/project.yaml`
+- deployment bundles and live agents still use real-time streaming compiled from `config/project.yaml`
 - `live-trade` still uses the legacy runtime YAML files directly
 
 ## Where To Go Next

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -2,6 +2,8 @@
 
 Common commands, patterns, and examples for QuantTradeAI.
 
+Project-defined `agent run --mode paper` defaults to deterministic replay through `data.streaming.replay`. Generated deployment bundles stay on the real-time paper path.
+
 ## CLI Commands
 
 ```bash
@@ -24,6 +26,7 @@ poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 # Promote the successful backtest run before starting paper mode
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
+# Local paper mode replays historical OHLCV by default
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
 
 # Backtest every configured project agent together
@@ -35,6 +38,7 @@ poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.y
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest --max-concurrency 4
 
 # Generate a Docker Compose bundle for the paper agent
+# Generated bundles disable replay and expect real-time streaming settings
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
 
 # Import an existing legacy config/ directory into the canonical workflow
@@ -92,9 +96,10 @@ Canonical agent paper artifacts:
 - `runs/agent/paper/<timestamp>_<agent>/runtime_streaming_config.yaml`
 - `runs/agent/paper/<timestamp>_<agent>/summary.json`
 - `runs/agent/paper/<timestamp>_<agent>/metrics.json`
-- `runs/agent/paper/<timestamp>_<agent>/decisions.jsonl`
 - `runs/agent/paper/<timestamp>_<agent>/executions.jsonl`
-- `runs/agent/paper/<timestamp>_<agent>/prompt_samples.json`
+- `runs/agent/paper/<timestamp>_<agent>/decisions.jsonl` for `rule`, `llm`, and `hybrid`
+- `runs/agent/paper/<timestamp>_<agent>/prompt_samples.json` for `llm` and `hybrid`
+- `runs/agent/paper/<timestamp>_<agent>/replay_manifest.json` when replay is enabled
 
 Canonical deployment bundle artifacts:
 - `reports/deployments/<agent>/<timestamp>/docker-compose.yml`
@@ -291,6 +296,7 @@ Use these pages instead of copying large config blocks out of the quick referenc
 Quick decision rule:
 
 - Use `config/project.yaml` for `validate`, `research run`, `agent run`, and `agent run --sweep`
+- Use `data.streaming.replay` for deterministic local paper runs; keep provider/websocket fields in place for later deployment or live promotion
 - Use `quanttradeai runs list --scoreboard` to compare local research and agent runs by metrics
 - Use the runtime YAML files for `live-trade`, `backtest-model`, and operational streaming setup
 

--- a/quanttradeai/agents/model_agent.py
+++ b/quanttradeai/agents/model_agent.py
@@ -22,6 +22,12 @@ from quanttradeai.main import (
     time_aware_split,
 )
 from quanttradeai.models.classifier import MomentumClassifier
+from quanttradeai.streaming.replay import ReplayGateway
+from quanttradeai.streaming.history import (
+    ReplayWindow,
+    build_streaming_runtime_model_config,
+    split_replay_frames,
+)
 from quanttradeai.streaming.live_trading import LiveTradingEngine
 from quanttradeai.trading.portfolio import PortfolioManager
 from quanttradeai.utils.config_validator import validate_project_config
@@ -31,6 +37,7 @@ from quanttradeai.utils.project_config import (
     compile_live_streaming_runtime_config,
     compile_paper_streaming_runtime_config,
     compile_research_runtime_configs,
+    resolve_paper_replay_window,
 )
 from quanttradeai.utils.project_paths import resolve_project_path
 from quanttradeai.utils.run_records import apply_required_run_fields, create_run_dir
@@ -88,6 +95,7 @@ def _initialize_model_agent_run(
     dict[str, Any],
     dict[str, Any],
     dict[str, Any],
+    ReplayWindow | None,
     Path,
     Path,
     Path,
@@ -127,11 +135,26 @@ def _initialize_model_agent_run(
         project_config,
         require_research=False,
     )
+    replay_window = (
+        resolve_paper_replay_window(project_config) if mode == "paper" else None
+    )
+    runtime_model_cfg = (
+        build_streaming_runtime_model_config(
+            model_cfg,
+            bootstrap_bars=220,
+            end_date=replay_window.end_date if replay_window is not None else None,
+            replay_start_date=(
+                replay_window.start_date if replay_window is not None else None
+            ),
+        )
+        if mode in {"paper", "live"}
+        else model_cfg
+    )
     runtime_model_path = run_dir / "runtime_model_config.yaml"
     runtime_features_path = run_dir / "runtime_features_config.yaml"
     runtime_backtest_path = run_dir / "runtime_backtest_config.yaml"
     runtime_model_path.write_text(
-        yaml.safe_dump(model_cfg, sort_keys=False),
+        yaml.safe_dump(runtime_model_cfg, sort_keys=False),
         encoding="utf-8",
     )
     runtime_features_path.write_text(
@@ -185,6 +208,7 @@ def _initialize_model_agent_run(
         project_config,
         agent_config,
         model_cfg,
+        replay_window,
         runtime_model_path,
         runtime_features_path,
         runtime_backtest_path,
@@ -271,6 +295,7 @@ def run_model_agent_backtest(
             _project_config,
             agent_config,
             model_cfg,
+            _replay_window,
             runtime_model_path,
             runtime_features_path,
             runtime_backtest_path,
@@ -581,6 +606,7 @@ def _run_model_agent_streaming(
             _project_config,
             agent_config,
             model_cfg,
+            replay_window,
             runtime_model_path,
             runtime_features_path,
             _runtime_backtest_path,
@@ -610,6 +636,30 @@ def _run_model_agent_streaming(
             max_risk_per_trade,
             max_portfolio_risk,
         ) = _resolve_risk_settings(agent_config, model_cfg)
+        gateway: ReplayGateway | None = None
+        bootstrap_history_frames: dict[str, pd.DataFrame] | None = None
+        paper_source = "realtime"
+        artifacts = dict(summary["artifacts"])
+        if mode == "paper" and replay_window is not None:
+            loader = DataLoader(str(runtime_model_path))
+            bootstrap_frames, replay_frames, replay_manifest = split_replay_frames(
+                loader.fetch_data(),
+                replay_window=replay_window,
+                history_window=512,
+            )
+            if not replay_frames:
+                raise ValueError(
+                    "Replay-enabled paper mode did not produce any bars for the configured replay window."
+                )
+            gateway = ReplayGateway(
+                replay_frames,
+                pace_delay_ms=replay_window.pace_delay_ms,
+            )
+            bootstrap_history_frames = bootstrap_frames
+            replay_manifest_path = run_dir / "replay_manifest.json"
+            _write_json(replay_manifest_path, replay_manifest)
+            artifacts["replay_manifest"] = str(replay_manifest_path)
+            paper_source = "replay"
 
         engine = LiveTradingEngine(
             model_config=str(runtime_model_path),
@@ -626,6 +676,8 @@ def _run_model_agent_streaming(
             max_risk_per_trade=max_risk_per_trade,
             max_portfolio_risk=max_portfolio_risk,
             stop_loss_pct=stop_loss_pct,
+            gateway=gateway,
+            bootstrap_history_frames=bootstrap_history_frames,
         )
         asyncio.run(engine.start())
 
@@ -638,7 +690,7 @@ def _run_model_agent_streaming(
         _write_json(run_dir / "metrics.json", metrics_payload)
 
         artifacts = {
-            **summary["artifacts"],
+            **artifacts,
             "metrics": str(run_dir / "metrics.json"),
             "executions": str(run_dir / "executions.jsonl"),
         }
@@ -662,6 +714,8 @@ def _run_model_agent_streaming(
                 "metrics": metrics_payload,
             }
         )
+        if mode == "paper":
+            summary["paper_source"] = paper_source
         summary["timestamps"]["completed_at"] = datetime.now(timezone.utc).isoformat()
         apply_required_run_fields(
             summary,

--- a/quanttradeai/agents/paper.py
+++ b/quanttradeai/agents/paper.py
@@ -6,9 +6,8 @@ import asyncio
 import contextlib
 import json
 import logging
-import re
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +17,14 @@ import yaml
 from quanttradeai.data.loader import DataLoader
 from quanttradeai.data.processor import DataProcessor
 from quanttradeai.streaming.gateway import StreamingGateway
+from quanttradeai.streaming.replay import ReplayGateway
+from quanttradeai.streaming.history import (
+    ReplayWindow,
+    bucket_for_timestamp,
+    build_streaming_runtime_model_config,
+    ensure_utc_datetime_index,
+    split_replay_frames,
+)
 from quanttradeai.trading.portfolio import PortfolioManager
 from quanttradeai.trading.position_manager import (
     PositionManager as RealtimePositionManager,
@@ -35,6 +42,7 @@ from quanttradeai.utils.project_config import (
     compile_live_streaming_runtime_config,
     compile_paper_streaming_runtime_config,
     compile_research_runtime_configs,
+    resolve_paper_replay_window,
 )
 from quanttradeai.utils.run_records import apply_required_run_fields, create_run_dir
 
@@ -119,70 +127,6 @@ def _copy_artifact(source: str | Path, destination: Path) -> str:
     return str(destination)
 
 
-def _parse_timeframe(timeframe: str) -> tuple[int, str] | None:
-    normalized = str(timeframe or "").strip().lower()
-    match = re.match(r"^(\d+)(mo|wk|m|h|d)$", normalized)
-    if not match:
-        return None
-    return int(match.group(1)), match.group(2)
-
-
-def _timeframe_to_pandas_freq(timeframe: str) -> str:
-    parsed = _parse_timeframe(timeframe)
-    if parsed is None:
-        return "1D"
-    amount, unit = parsed
-    unit_map = {
-        "m": "min",
-        "h": "h",
-        "d": "D",
-        "wk": "W",
-        "mo": "ME",
-    }
-    return f"{amount}{unit_map[unit]}"
-
-
-def _bootstrap_window_delta(timeframe: str, bars: int) -> timedelta:
-    parsed = _parse_timeframe(timeframe)
-    multiplier = max(1, bars) * 3
-    if parsed is None:
-        return timedelta(days=multiplier)
-
-    amount, unit = parsed
-    steps = amount * multiplier
-    if unit == "m":
-        return timedelta(minutes=steps)
-    if unit == "h":
-        return timedelta(hours=steps)
-    if unit == "d":
-        return timedelta(days=steps)
-    if unit == "wk":
-        return timedelta(weeks=steps)
-    return timedelta(days=steps * 30)
-
-
-def _bucket_for_timestamp(timestamp: pd.Timestamp, timeframe: str) -> pd.Timestamp:
-    freq = _timeframe_to_pandas_freq(timeframe)
-    if freq.endswith("W") or freq.endswith("ME"):
-        bucket = timestamp.tz_convert(None) if timestamp.tzinfo else timestamp
-        bucket = bucket.to_period(freq).to_timestamp()
-        if timestamp.tzinfo:
-            return bucket.tz_localize(timestamp.tzinfo)
-        return bucket
-    return timestamp.floor(freq)
-
-
-def _ensure_datetime_index(df: pd.DataFrame) -> pd.DataFrame:
-    out = df if isinstance(df.index, pd.DatetimeIndex) else df.copy()
-    if not isinstance(out.index, pd.DatetimeIndex):
-        out.index = pd.to_datetime(out.index)
-    if out.index.tz is None:
-        out.index = out.index.tz_localize(timezone.utc)
-    else:
-        out.index = out.index.tz_convert(timezone.utc)
-    return out
-
-
 def _required_bootstrap_bars(agent_config: dict[str, Any]) -> int:
     market_data_cfg = dict((agent_config.get("context") or {}).get("market_data") or {})
     lookback_bars = int(market_data_cfg.get("lookback_bars", 20))
@@ -192,27 +136,17 @@ def _required_bootstrap_bars(agent_config: dict[str, Any]) -> int:
 def _build_paper_runtime_model_config(
     model_cfg: dict[str, Any],
     agent_config: dict[str, Any],
+    *,
+    replay_window: ReplayWindow | None = None,
 ) -> dict[str, Any]:
-    runtime_model_cfg = json.loads(json.dumps(model_cfg))
-    data_cfg = dict(runtime_model_cfg.get("data") or {})
-    now = datetime.now(timezone.utc)
-    timeframe = str(data_cfg.get("timeframe") or "1d")
-    recent_start = (
-        now - _bootstrap_window_delta(timeframe, _required_bootstrap_bars(agent_config))
-    ).date()
-
-    start_raw = data_cfg.get("start_date")
-    try:
-        start_dt = datetime.fromisoformat(str(start_raw)).date()
-    except (TypeError, ValueError):
-        start_dt = recent_start
-
-    data_cfg["start_date"] = min(start_dt, recent_start).isoformat()
-    data_cfg["end_date"] = now.date().isoformat()
-    data_cfg["test_start"] = None
-    data_cfg["test_end"] = None
-    runtime_model_cfg["data"] = data_cfg
-    return runtime_model_cfg
+    return build_streaming_runtime_model_config(
+        model_cfg,
+        bootstrap_bars=_required_bootstrap_bars(agent_config),
+        end_date=replay_window.end_date if replay_window is not None else None,
+        replay_start_date=(
+            replay_window.start_date if replay_window is not None else None
+        ),
+    )
 
 
 def _streaming_metrics(
@@ -334,9 +268,10 @@ class PaperAgentEngine:
     runtime_risk_config: str | None = None
     runtime_position_manager_config: str | None = None
     model_signal_runtimes: list[ModelSignalRuntime] = field(default_factory=list)
-    gateway: StreamingGateway | None = None
+    gateway: StreamingGateway | ReplayGateway | None = None
     data_loader: DataLoader | None = None
     data_processor: DataProcessor | None = None
+    bootstrap_history_frames: dict[str, pd.DataFrame] | None = None
     initial_capital: float = 100_000.0
     max_risk_per_trade: float = 0.02
     max_portfolio_risk: float = 0.10
@@ -525,13 +460,17 @@ class PaperAgentEngine:
         self._history[symbol] = history.tail(self.history_window)
 
     def bootstrap_history(self) -> None:
-        bootstrap_frames = self.data_loader.fetch_data()
-        now_bucket = _bucket_for_timestamp(
+        bootstrap_frames = (
+            self.bootstrap_history_frames
+            if self.bootstrap_history_frames is not None
+            else self.data_loader.fetch_data()
+        )
+        now_bucket = bucket_for_timestamp(
             pd.Timestamp(datetime.now(timezone.utc)),
             self.timeframe,
         )
         for symbol, frame in bootstrap_frames.items():
-            history = _ensure_datetime_index(frame).sort_index()
+            history = ensure_utc_datetime_index(frame)
             history = history[
                 [
                     column
@@ -542,7 +481,11 @@ class PaperAgentEngine:
             if history.empty:
                 continue
 
-            latest_bucket = _bucket_for_timestamp(
+            if self.bootstrap_history_frames is not None:
+                self._history[symbol] = history.tail(self.history_window)
+                continue
+
+            latest_bucket = bucket_for_timestamp(
                 pd.Timestamp(history.index.max()),
                 self.timeframe,
             )
@@ -563,6 +506,31 @@ class PaperAgentEngine:
                 continue
             self._history[symbol] = history.tail(self.history_window)
 
+    def _finalize_open_bars(self) -> None:
+        for symbol, current_bar in list(self._open_bars.items()):
+            latest_history = self._history.get(symbol)
+            if latest_history is not None and not latest_history.empty:
+                latest_bucket = bucket_for_timestamp(
+                    pd.Timestamp(latest_history.index.max()),
+                    self.timeframe,
+                )
+                if current_bar.bucket <= latest_bucket:
+                    continue
+
+            frame = current_bar.to_frame()
+            completed_timestamp = current_bar.bucket
+            self._append_history(symbol, frame)
+            self._mark_to_market(
+                symbol,
+                _safe_float(frame["Close"].iloc[-1], 0.0),
+                timestamp=completed_timestamp,
+            )
+            self._process_completed_bar(
+                symbol=symbol,
+                completed_timestamp=completed_timestamp,
+            )
+            del self._open_bars[symbol]
+
     def _update_open_bar(
         self,
         *,
@@ -574,13 +542,13 @@ class PaperAgentEngine:
         close: float,
         volume: float,
     ) -> tuple[pd.Timestamp, pd.DataFrame] | None:
-        bucket = _bucket_for_timestamp(timestamp, self.timeframe)
+        bucket = bucket_for_timestamp(timestamp, self.timeframe)
         current_bar = self._open_bars.get(symbol)
 
         if current_bar is None:
             latest_history = self._history.get(symbol)
             if latest_history is not None and not latest_history.empty:
-                latest_bucket = _bucket_for_timestamp(
+                latest_bucket = bucket_for_timestamp(
                     pd.Timestamp(latest_history.index.max()),
                     self.timeframe,
                 )
@@ -846,6 +814,9 @@ class PaperAgentEngine:
                         and asyncio.get_running_loop().time() < deadline
                     ):
                         await asyncio.sleep(0.01)
+                if getattr(self.gateway, "flush_on_stop", False):
+                    await asyncio.sleep(0)
+                    self._finalize_open_bars()
                 self._consumer.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await self._consumer
@@ -933,6 +904,9 @@ def _run_agent_streaming(
         project_config = (
             yaml.safe_load(root_resolved_path.read_text(encoding="utf-8")) or {}
         )
+        replay_window = (
+            resolve_paper_replay_window(project_config) if mode == "paper" else None
+        )
 
         agent_config = next(
             (
@@ -960,7 +934,11 @@ def _run_agent_streaming(
             project_config,
             require_research=False,
         )
-        runtime_model_cfg = _build_paper_runtime_model_config(model_cfg, agent_config)
+        runtime_model_cfg = _build_paper_runtime_model_config(
+            model_cfg,
+            agent_config,
+            replay_window=replay_window,
+        )
         runtime_model_path = run_dir / "runtime_model_config.yaml"
         runtime_features_path = run_dir / "runtime_features_config.yaml"
         runtime_streaming_path = run_dir / "runtime_streaming_config.yaml"
@@ -1042,6 +1020,35 @@ def _run_agent_streaming(
             )
             + 32,
         )
+        gateway: StreamingGateway | ReplayGateway | None = None
+        data_loader: DataLoader | None = None
+        bootstrap_history_frames: dict[str, pd.DataFrame] | None = None
+        paper_source = "realtime"
+        artifacts = dict(summary["artifacts"])
+        if replay_window is not None:
+            data_loader = DataLoader(str(runtime_model_path))
+            bootstrap_frames, replay_frames, replay_manifest = split_replay_frames(
+                data_loader.fetch_data(),
+                replay_window=replay_window,
+                history_window=history_window,
+            )
+            if not replay_frames:
+                raise ValueError(
+                    "Replay-enabled paper mode did not produce any bars for the configured replay window."
+                )
+            gateway = ReplayGateway(
+                replay_frames,
+                pace_delay_ms=replay_window.pace_delay_ms,
+                buffer_size=int(
+                    ((runtime_streaming_cfg.get("streaming") or {}).get("buffer_size"))
+                    or 1000
+                ),
+            )
+            bootstrap_history_frames = bootstrap_frames
+            replay_manifest_path = run_dir / "replay_manifest.json"
+            _write_json(replay_manifest_path, replay_manifest)
+            artifacts["replay_manifest"] = str(replay_manifest_path)
+            paper_source = "replay"
 
         engine = PaperAgentEngine(
             project_config_path=project_config_path,
@@ -1060,6 +1067,9 @@ def _run_agent_streaming(
                 else None
             ),
             model_signal_runtimes=model_signal_runtimes,
+            gateway=gateway,
+            data_loader=data_loader,
+            bootstrap_history_frames=bootstrap_history_frames,
             initial_capital=initial_capital,
             max_risk_per_trade=max_risk_per_trade,
             max_portfolio_risk=max_portfolio_risk,
@@ -1079,7 +1089,7 @@ def _run_agent_streaming(
         _write_json(run_dir / "metrics.json", metrics_payload)
 
         artifacts = {
-            **summary["artifacts"],
+            **artifacts,
             "metrics": str(run_dir / "metrics.json"),
             "decisions": str(run_dir / "decisions.jsonl"),
             "executions": str(run_dir / "executions.jsonl"),
@@ -1102,6 +1112,8 @@ def _run_agent_streaming(
                 "metrics": metrics_payload,
             }
         )
+        if mode == "paper":
+            summary["paper_source"] = paper_source
         summary["timestamps"]["completed_at"] = datetime.now(timezone.utc).isoformat()
         apply_required_run_fields(
             summary,

--- a/quanttradeai/agents/paper.py
+++ b/quanttradeai/agents/paper.py
@@ -759,6 +759,11 @@ class PaperAgentEngine:
     async def _consume_buffer(self) -> None:
         while True:
             message = await self.gateway.buffer.get()
+            completion_type = getattr(self.gateway, "completion_type", None)
+            if completion_type and message.get("type") == completion_type:
+                if getattr(self.gateway, "flush_on_stop", False):
+                    self._finalize_open_bars()
+                return
             try:
                 normalized = self._normalize_message(message)
                 symbol = normalized.get("symbol")
@@ -801,10 +806,16 @@ class PaperAgentEngine:
     async def start(self) -> None:
         self.bootstrap_history()
         self._consumer = asyncio.create_task(self._consume_buffer())
+        completed_via_signal = False
         try:
             await self.gateway._start()
+            if self._consumer is not None and getattr(
+                self.gateway, "signals_completion", False
+            ):
+                await self._consumer
+                completed_via_signal = True
         finally:
-            if self._consumer is not None:
+            if self._consumer is not None and not completed_via_signal:
                 if self.shutdown_drain_timeout > 0:
                     deadline = (
                         asyncio.get_running_loop().time() + self.shutdown_drain_timeout

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -162,6 +162,7 @@ PROJECT_TEMPLATES = {
                 "channels": ["trades", "quotes"],
                 "buffer_size": 1000,
                 "reconnect_attempts": 5,
+                "replay": {"enabled": True, "pace_delay_ms": 0},
                 "monitoring": {"enabled": True, "check_interval": 5},
                 "metrics": {"enabled": False, "host": "0.0.0.0", "port": 9000},
                 "api": {"enabled": False, "host": "0.0.0.0", "port": 8000},
@@ -249,6 +250,7 @@ PROJECT_TEMPLATES = {
                 "channels": ["trades", "quotes"],
                 "buffer_size": 1000,
                 "reconnect_attempts": 5,
+                "replay": {"enabled": True, "pace_delay_ms": 0},
                 "monitoring": {"enabled": True, "check_interval": 5},
                 "metrics": {"enabled": False, "host": "0.0.0.0", "port": 9000},
                 "api": {"enabled": False, "host": "0.0.0.0", "port": 8000},
@@ -361,6 +363,7 @@ PROJECT_TEMPLATES = {
                 "channels": ["trades", "quotes"],
                 "buffer_size": 1000,
                 "reconnect_attempts": 5,
+                "replay": {"enabled": True, "pace_delay_ms": 0},
                 "monitoring": {"enabled": True, "check_interval": 5},
                 "metrics": {"enabled": False, "host": "0.0.0.0", "port": 9000},
                 "api": {"enabled": False, "host": "0.0.0.0", "port": 8000},
@@ -453,6 +456,7 @@ PROJECT_TEMPLATES = {
                 "channels": ["trades", "quotes"],
                 "buffer_size": 1000,
                 "reconnect_attempts": 5,
+                "replay": {"enabled": True, "pace_delay_ms": 0},
                 "monitoring": {"enabled": True, "check_interval": 5},
                 "metrics": {"enabled": False, "host": "0.0.0.0", "port": 9000},
                 "api": {"enabled": False, "host": "0.0.0.0", "port": 8000},
@@ -1548,6 +1552,16 @@ def cmd_validate(
         f"research_enabled={summary['research_enabled']}, agents={len(summary['agents'])}, "
         f"sweeps={summary['sweeps']}"
     )
+    if summary.get("paper_source"):
+        replay_window = summary.get("paper_replay_window") or {}
+        if summary["paper_source"] == "replay":
+            typer.echo(
+                "- paper: source=replay, "
+                f"window={replay_window.get('start')}..{replay_window.get('end')}, "
+                f"pace_delay_ms={replay_window.get('pace_delay_ms', 0)}"
+            )
+        else:
+            typer.echo(f"- paper: source={summary['paper_source']}")
 
     if result.get("warnings"):
         for warning in result["warnings"]:

--- a/quanttradeai/deployment.py
+++ b/quanttradeai/deployment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import re
@@ -207,6 +208,19 @@ def _copy_resolved_project_config(
     return resolved_project, warnings
 
 
+def _disable_replay_for_deployment(project_config: dict[str, Any]) -> dict[str, Any]:
+    deployment_project = copy.deepcopy(project_config)
+    streaming_cfg = dict((deployment_project.get("data") or {}).get("streaming") or {})
+    if not streaming_cfg:
+        return deployment_project
+    replay_cfg = dict(streaming_cfg.get("replay") or {})
+    if replay_cfg:
+        replay_cfg["enabled"] = False
+        streaming_cfg["replay"] = replay_cfg
+        deployment_project.setdefault("data", {})["streaming"] = streaming_cfg
+    return deployment_project
+
+
 def _resolve_agent_config(
     *,
     project_config: dict[str, Any],
@@ -360,8 +374,16 @@ def deploy_project_agent(
             config_path=config_path,
             destination=temp_resolved_project_path,
         )
+    deployment_project = _disable_replay_for_deployment(resolved_project)
+    if (
+        ((resolved_project.get("data") or {}).get("streaming") or {}).get("replay")
+        or {}
+    ).get("enabled") is True:
+        warnings.append(
+            "Paper deployment bundles always use real-time streaming; replay was disabled in the generated bundle."
+        )
 
-    deployment_cfg = dict(resolved_project.get("deployment") or {})
+    deployment_cfg = dict(deployment_project.get("deployment") or {})
     resolved_target = str(target or deployment_cfg.get("target") or "docker-compose")
     resolved_target = resolved_target.strip().lower()
     if resolved_target not in SUPPORTED_DEPLOY_TARGETS:
@@ -377,10 +399,13 @@ def deploy_project_agent(
             "Only deploy --mode paper is supported in this release. "
             "Live deployment and promotion remain future work."
         )
-    compile_paper_streaming_runtime_config(resolved_project)
+    compile_paper_streaming_runtime_config(
+        deployment_project,
+        require_realtime=True,
+    )
 
     agent_config = _resolve_agent_config(
-        project_config=resolved_project,
+        project_config=deployment_project,
         agent_name=agent_name,
     )
     configured_mode = str(agent_config.get("mode") or "").strip().lower()
@@ -392,7 +417,7 @@ def deploy_project_agent(
     service_name = _slugify(f"{agent_name}-{resolved_mode}")
     env_vars = _required_env_vars(
         agent_config=agent_config,
-        project_config=resolved_project,
+        project_config=deployment_project,
     )
     mounts = _required_mounts(
         project_root=project_root,
@@ -442,7 +467,7 @@ def deploy_project_agent(
 
     resolved_project_path = output_path / "resolved_project_config.yaml"
     resolved_project_path.write_text(
-        yaml.safe_dump(resolved_project, sort_keys=False),
+        yaml.safe_dump(deployment_project, sort_keys=False),
         encoding="utf-8",
     )
 

--- a/quanttradeai/streaming/__init__.py
+++ b/quanttradeai/streaming/__init__.py
@@ -12,6 +12,7 @@ from typing import Any
 
 _EXPORTS = {
     "StreamingGateway": (".gateway", "StreamingGateway"),
+    "ReplayGateway": (".replay", "ReplayGateway"),
     "AuthManager": (".auth_manager", "AuthManager"),
     "AdaptiveRateLimiter": (".rate_limiter", "AdaptiveRateLimiter"),
     "ConnectionPool": (".connection_pool", "ConnectionPool"),

--- a/quanttradeai/streaming/history.py
+++ b/quanttradeai/streaming/history.py
@@ -1,0 +1,198 @@
+"""Shared helpers for streaming bootstrap and deterministic replay."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+import re
+from typing import Any
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class ReplayWindow:
+    start_date: str
+    end_date: str
+    pace_delay_ms: int = 0
+
+
+def parse_iso_date(value: str, *, field_name: str) -> date:
+    try:
+        return datetime.fromisoformat(str(value)).date()
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must be in ISO format YYYY-MM-DD. Received: {value!r}."
+        ) from exc
+
+
+def parse_timeframe(timeframe: str) -> tuple[int, str] | None:
+    normalized = str(timeframe or "").strip().lower()
+    match = re.match(r"^(\d+)(mo|wk|m|h|d)$", normalized)
+    if not match:
+        return None
+    return int(match.group(1)), match.group(2)
+
+
+def timeframe_to_pandas_freq(timeframe: str) -> str:
+    parsed = parse_timeframe(timeframe)
+    if parsed is None:
+        return "1D"
+    amount, unit = parsed
+    unit_map = {
+        "m": "min",
+        "h": "h",
+        "d": "D",
+        "wk": "W",
+        "mo": "ME",
+    }
+    return f"{amount}{unit_map[unit]}"
+
+
+def bootstrap_window_delta(timeframe: str, bars: int) -> timedelta:
+    parsed = parse_timeframe(timeframe)
+    multiplier = max(1, bars) * 3
+    if parsed is None:
+        return timedelta(days=multiplier)
+
+    amount, unit = parsed
+    steps = amount * multiplier
+    if unit == "m":
+        return timedelta(minutes=steps)
+    if unit == "h":
+        return timedelta(hours=steps)
+    if unit == "d":
+        return timedelta(days=steps)
+    if unit == "wk":
+        return timedelta(weeks=steps)
+    return timedelta(days=steps * 30)
+
+
+def bucket_for_timestamp(timestamp: pd.Timestamp, timeframe: str) -> pd.Timestamp:
+    freq = timeframe_to_pandas_freq(timeframe)
+    if freq.endswith("W") or freq.endswith("ME"):
+        bucket = timestamp.tz_convert(None) if timestamp.tzinfo else timestamp
+        bucket = bucket.to_period(freq).to_timestamp()
+        if timestamp.tzinfo:
+            return bucket.tz_localize(timestamp.tzinfo)
+        return bucket
+    return timestamp.floor(freq)
+
+
+def ensure_utc_datetime_index(df: pd.DataFrame) -> pd.DataFrame:
+    out = df if isinstance(df.index, pd.DatetimeIndex) else df.copy()
+    if not isinstance(out.index, pd.DatetimeIndex):
+        out.index = pd.to_datetime(out.index)
+    if out.index.tz is None:
+        out.index = out.index.tz_localize(timezone.utc)
+    else:
+        out.index = out.index.tz_convert(timezone.utc)
+    return out.sort_index()
+
+
+def build_streaming_runtime_model_config(
+    model_cfg: dict[str, Any],
+    *,
+    bootstrap_bars: int,
+    end_date: str | None = None,
+    replay_start_date: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    runtime_model_cfg = deepcopy(model_cfg)
+    data_cfg = dict(runtime_model_cfg.get("data") or {})
+    clock = now or datetime.now(timezone.utc)
+    timeframe = str(data_cfg.get("timeframe") or "1d")
+
+    effective_end = end_date or clock.date().isoformat()
+    anchor_start = replay_start_date or effective_end
+    recent_start = parse_iso_date(
+        anchor_start,
+        field_name=(
+            "data.streaming.replay.start_date" if replay_start_date else "data.end_date"
+        ),
+    ) - bootstrap_window_delta(timeframe, bootstrap_bars)
+
+    start_raw = data_cfg.get("start_date")
+    try:
+        configured_start = parse_iso_date(str(start_raw), field_name="data.start_date")
+    except (TypeError, ValueError):
+        configured_start = recent_start
+
+    data_cfg["start_date"] = min(configured_start, recent_start).isoformat()
+    data_cfg["end_date"] = effective_end
+    data_cfg["test_start"] = None
+    data_cfg["test_end"] = None
+    runtime_model_cfg["data"] = data_cfg
+    return runtime_model_cfg
+
+
+def seed_history_frames(
+    frames: dict[str, pd.DataFrame],
+    *,
+    history_window: int,
+) -> dict[str, pd.DataFrame]:
+    seeded: dict[str, pd.DataFrame] = {}
+    for symbol, frame in frames.items():
+        history = ensure_utc_datetime_index(frame)
+        history = history[
+            [
+                column
+                for column in ("Open", "High", "Low", "Close", "Volume")
+                if column in history.columns
+            ]
+        ].copy()
+        if history.empty:
+            continue
+        seeded[symbol] = history.tail(history_window)
+    return seeded
+
+
+def split_replay_frames(
+    frames: dict[str, pd.DataFrame],
+    *,
+    replay_window: ReplayWindow,
+    history_window: int,
+) -> tuple[dict[str, pd.DataFrame], dict[str, pd.DataFrame], dict[str, Any]]:
+    replay_start = pd.Timestamp(replay_window.start_date).tz_localize(timezone.utc)
+    replay_end = pd.Timestamp(replay_window.end_date).tz_localize(timezone.utc)
+    bootstrap_frames: dict[str, pd.DataFrame] = {}
+    replay_frames: dict[str, pd.DataFrame] = {}
+    symbols_manifest: list[dict[str, Any]] = []
+
+    for symbol, frame in frames.items():
+        history = ensure_utc_datetime_index(frame)
+        replay_slice = history[
+            (history.index >= replay_start) & (history.index <= replay_end)
+        ]
+        bootstrap_slice = history[history.index < replay_start].tail(history_window)
+        if not bootstrap_slice.empty:
+            bootstrap_frames[symbol] = bootstrap_slice
+        if not replay_slice.empty:
+            replay_frames[symbol] = replay_slice
+        symbols_manifest.append(
+            {
+                "symbol": symbol,
+                "bootstrap_bars": int(len(bootstrap_slice)),
+                "replay_bars": int(len(replay_slice)),
+                "replay_start": (
+                    replay_slice.index.min().isoformat()
+                    if not replay_slice.empty
+                    else None
+                ),
+                "replay_end": (
+                    replay_slice.index.max().isoformat()
+                    if not replay_slice.empty
+                    else None
+                ),
+            }
+        )
+
+    manifest = {
+        "source": "replay",
+        "start_date": replay_window.start_date,
+        "end_date": replay_window.end_date,
+        "pace_delay_ms": replay_window.pace_delay_ms,
+        "symbols": symbols_manifest,
+    }
+    return bootstrap_frames, replay_frames, manifest

--- a/quanttradeai/streaming/history.py
+++ b/quanttradeai/streaming/history.py
@@ -155,7 +155,9 @@ def split_replay_frames(
     history_window: int,
 ) -> tuple[dict[str, pd.DataFrame], dict[str, pd.DataFrame], dict[str, Any]]:
     replay_start = pd.Timestamp(replay_window.start_date).tz_localize(timezone.utc)
-    replay_end = pd.Timestamp(replay_window.end_date).tz_localize(timezone.utc)
+    replay_end_exclusive = pd.Timestamp(replay_window.end_date).tz_localize(
+        timezone.utc
+    ) + timedelta(days=1)
     bootstrap_frames: dict[str, pd.DataFrame] = {}
     replay_frames: dict[str, pd.DataFrame] = {}
     symbols_manifest: list[dict[str, Any]] = []
@@ -163,7 +165,7 @@ def split_replay_frames(
     for symbol, frame in frames.items():
         history = ensure_utc_datetime_index(frame)
         replay_slice = history[
-            (history.index >= replay_start) & (history.index <= replay_end)
+            (history.index >= replay_start) & (history.index < replay_end_exclusive)
         ]
         bootstrap_slice = history[history.index < replay_start].tail(history_window)
         if not bootstrap_slice.empty:

--- a/quanttradeai/streaming/live_trading.py
+++ b/quanttradeai/streaming/live_trading.py
@@ -19,9 +19,12 @@ from typing import Callable, Dict, Optional
 import pandas as pd
 import yaml
 
+from quanttradeai.data.loader import DataLoader
 from quanttradeai.data.processor import DataProcessor
 from quanttradeai.models.classifier import MomentumClassifier
 from quanttradeai.streaming.gateway import StreamingGateway
+from quanttradeai.streaming.replay import ReplayGateway
+from quanttradeai.streaming.history import ensure_utc_datetime_index
 from quanttradeai.streaming.logging import logger
 from quanttradeai.trading.drawdown_guard import DrawdownGuard
 from quanttradeai.trading.portfolio import PortfolioManager
@@ -104,9 +107,10 @@ class LiveTradingEngine:
     stop_loss_pct: float = 0.01
     shutdown_drain_timeout: float = 0.5
     execution_hook: ExecutionHook | None = None
-    gateway: StreamingGateway | None = None
+    gateway: StreamingGateway | ReplayGateway | None = None
     data_processor: DataProcessor | None = None
     model: MomentumClassifier | None = None
+    bootstrap_history_frames: Dict[str, pd.DataFrame] | None = None
     _history: Dict[str, pd.DataFrame] = field(default_factory=dict, init=False)
     _consumer: asyncio.Task | None = field(default=None, init=False)
     execution_log: list[dict] = field(default_factory=list, init=False)
@@ -115,7 +119,7 @@ class LiveTradingEngine:
 
     def __post_init__(self) -> None:
         self.gateway = self.gateway or StreamingGateway(self.streaming_config)
-        if self.enable_health_api is not None:
+        if self.enable_health_api is not None and hasattr(self.gateway, "_api_enabled"):
             self.gateway._api_enabled = self.enable_health_api  # type: ignore[attr-defined]
         self.data_processor = self.data_processor or DataProcessor(self.features_config)
         self.model = self.model or MomentumClassifier(self.model_config)
@@ -134,7 +138,7 @@ class LiveTradingEngine:
         self.position_manager = _load_position_manager(
             self.position_manager_config, cash=self.initial_capital
         )
-        if self.position_manager:
+        if self.position_manager and isinstance(self.gateway, StreamingGateway):
             try:
                 symbols = _load_streaming_symbols(self.streaming_config)
                 if symbols:
@@ -144,7 +148,7 @@ class LiveTradingEngine:
 
     @property
     def health_monitor(self):
-        return self.gateway.health_monitor
+        return getattr(self.gateway, "health_monitor", None)
 
     def _extract_timestamp(self, message: dict) -> pd.Timestamp:
         ts = (
@@ -286,6 +290,28 @@ class LiveTradingEngine:
         history = history.sort_index()
         history = history[~history.index.duplicated(keep="last")]
         self._history[symbol] = history.tail(self.history_window)
+
+    def _seed_history(self, frames: Dict[str, pd.DataFrame]) -> None:
+        for symbol, frame in frames.items():
+            history = ensure_utc_datetime_index(frame)
+            history = history[
+                [
+                    column
+                    for column in ("Open", "High", "Low", "Close", "Volume")
+                    if column in history.columns
+                ]
+            ].copy()
+            if history.empty:
+                continue
+            self._history[symbol] = history.tail(self.history_window)
+
+    def bootstrap_history(self) -> None:
+        frames = (
+            self.bootstrap_history_frames
+            if self.bootstrap_history_frames is not None
+            else DataLoader(self.model_config).fetch_data()
+        )
+        self._seed_history(frames)
 
     def _prepare_features(self, symbol: str) -> Optional[pd.DataFrame]:
         history = self._history.get(symbol)
@@ -444,25 +470,28 @@ class LiveTradingEngine:
                 self._mark_to_market(symbol, price, timestamp)
             except Exception as exc:  # pragma: no cover - runtime guard
                 logger.error("live_pipeline_error", error=str(exc))
-                self.health_monitor.trigger_alerts(
-                    "error", f"live_pipeline_error: {exc}"
-                )
+                if self.health_monitor is not None:
+                    self.health_monitor.trigger_alerts(
+                        "error", f"live_pipeline_error: {exc}"
+                    )
             finally:
                 elapsed_ms = (time.perf_counter() - start) * 1000.0
-                try:
-                    self.health_monitor.metrics_collector.record_latency(
-                        "inference", elapsed_ms
-                    )
-                    depth = self.gateway.buffer.queue.qsize()
-                    self.health_monitor.metrics_collector.record_queue_depth(
-                        "stream", depth
-                    )
-                except Exception:  # pragma: no cover - metrics best effort
-                    pass
+                if self.health_monitor is not None:
+                    try:
+                        self.health_monitor.metrics_collector.record_latency(
+                            "inference", elapsed_ms
+                        )
+                        depth = self.gateway.buffer.queue.qsize()
+                        self.health_monitor.metrics_collector.record_queue_depth(
+                            "stream", depth
+                        )
+                    except Exception:  # pragma: no cover - metrics best effort
+                        pass
 
     async def start(self) -> None:
         """Start streaming and inference concurrently."""
 
+        self.bootstrap_history()
         self._consumer = asyncio.create_task(self._consume_buffer())
         try:
             await self.gateway._start()

--- a/quanttradeai/streaming/live_trading.py
+++ b/quanttradeai/streaming/live_trading.py
@@ -427,6 +427,9 @@ class LiveTradingEngine:
     async def _consume_buffer(self) -> None:
         while True:
             message = await self.gateway.buffer.get()
+            completion_type = getattr(self.gateway, "completion_type", None)
+            if completion_type and message.get("type") == completion_type:
+                return
             start = time.perf_counter()
             try:
                 message = self._normalize_message(message)
@@ -493,10 +496,16 @@ class LiveTradingEngine:
 
         self.bootstrap_history()
         self._consumer = asyncio.create_task(self._consume_buffer())
+        completed_via_signal = False
         try:
             await self.gateway._start()
+            if self._consumer is not None and getattr(
+                self.gateway, "signals_completion", False
+            ):
+                await self._consumer
+                completed_via_signal = True
         finally:
-            if self._consumer:
+            if self._consumer and not completed_via_signal:
                 if self.shutdown_drain_timeout > 0:
                     deadline = (
                         asyncio.get_running_loop().time() + self.shutdown_drain_timeout

--- a/quanttradeai/streaming/replay.py
+++ b/quanttradeai/streaming/replay.py
@@ -1,0 +1,61 @@
+"""Deterministic historical replay gateway for paper trading."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pandas as pd
+
+from .stream_buffer import StreamBuffer
+from .history import ensure_utc_datetime_index
+
+
+@dataclass
+class ReplayGateway:
+    """Replay historical OHLCV bars into the standard stream buffer."""
+
+    frames: dict[str, pd.DataFrame]
+    pace_delay_ms: int = 0
+    buffer_size: int = 1000
+    buffer: StreamBuffer = field(init=False)
+    flush_on_stop: bool = field(default=True, init=False)
+
+    def __post_init__(self) -> None:
+        self.buffer = StreamBuffer(self.buffer_size)
+
+    def _iter_messages(self) -> list[tuple[pd.Timestamp, int, dict[str, Any]]]:
+        events: list[tuple[pd.Timestamp, int, dict[str, Any]]] = []
+        order = 0
+        for symbol, frame in sorted(self.frames.items()):
+            history = ensure_utc_datetime_index(frame)
+            for timestamp, row in history.iterrows():
+                close = float(row.get("Close", row.get("close", 0.0)))
+                events.append(
+                    (
+                        timestamp,
+                        order,
+                        {
+                            "type": "replay_bar",
+                            "symbol": symbol,
+                            "timestamp": timestamp.isoformat(),
+                            "open": float(row.get("Open", row.get("open", close))),
+                            "high": float(row.get("High", row.get("high", close))),
+                            "low": float(row.get("Low", row.get("low", close))),
+                            "close": close,
+                            "price": close,
+                            "volume": float(row.get("Volume", row.get("volume", 0.0))),
+                        },
+                    )
+                )
+                order += 1
+        events.sort(key=lambda item: (item[0], item[1]))
+        return events
+
+    async def _start(self) -> None:
+        delay_seconds = max(self.pace_delay_ms, 0) / 1000.0
+        for _timestamp, _order, message in self._iter_messages():
+            await self.buffer.put(message)
+            if delay_seconds > 0:
+                await asyncio.sleep(delay_seconds)

--- a/quanttradeai/streaming/replay.py
+++ b/quanttradeai/streaming/replay.py
@@ -21,6 +21,8 @@ class ReplayGateway:
     buffer_size: int = 1000
     buffer: StreamBuffer = field(init=False)
     flush_on_stop: bool = field(default=True, init=False)
+    signals_completion: bool = field(default=True, init=False)
+    completion_type: str = field(default="replay_complete", init=False)
 
     def __post_init__(self) -> None:
         self.buffer = StreamBuffer(self.buffer_size)
@@ -59,3 +61,4 @@ class ReplayGateway:
             await self.buffer.put(message)
             if delay_seconds > 0:
                 await asyncio.sleep(delay_seconds)
+        await self.buffer.put({"type": self.completion_type})

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -70,6 +70,35 @@ class ProjectStreamingAPIConfig(BaseModel):
     port: int = Field(8000, ge=1, le=65535)
 
 
+class ProjectStreamingReplayConfig(BaseModel):
+    enabled: bool = False
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    pace_delay_ms: int = Field(0, ge=0)
+
+    @staticmethod
+    def _parse_date(value: str, field_name: str) -> datetime:
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(
+                f"data.streaming.replay.{field_name} must be in ISO format YYYY-MM-DD. Received: {value!r}."
+            ) from exc
+
+    @model_validator(mode="after")
+    def validate_date_window(self) -> "ProjectStreamingReplayConfig":
+        start_dt = None
+        if self.start_date is not None:
+            start_dt = self._parse_date(self.start_date, "start_date")
+        if self.end_date is not None:
+            end_dt = self._parse_date(self.end_date, "end_date")
+            if start_dt is not None and start_dt > end_dt:
+                raise ValueError(
+                    "data.streaming.replay.start_date must be on or before data.streaming.replay.end_date."
+                )
+        return self
+
+
 class ProjectDataStreamingConfig(BaseModel):
     enabled: bool = False
     provider: Optional[str] = None
@@ -87,18 +116,30 @@ class ProjectDataStreamingConfig(BaseModel):
     alerts: Optional[ProjectStreamingAlertsConfig] = None
     metrics: Optional[ProjectStreamingMetricsConfig] = None
     api: Optional[ProjectStreamingAPIConfig] = None
+    replay: ProjectStreamingReplayConfig = Field(
+        default_factory=ProjectStreamingReplayConfig
+    )
 
     @model_validator(mode="after")
     def validate_enabled_requirements(self) -> "ProjectDataStreamingConfig":
         if not self.enabled:
+            return self
+        if self.replay.enabled:
+            missing = []
+            if not self.channels:
+                missing.append("channels")
+            if missing:
+                raise ValueError(
+                    "data.streaming requires "
+                    + ", ".join(missing)
+                    + " when replay is enabled."
+                )
             return self
         missing = []
         if not self.provider:
             missing.append("provider")
         if not self.websocket_url:
             missing.append("websocket_url")
-        if not self.symbols:
-            missing.append("symbols")
         if not self.channels:
             missing.append("channels")
         if missing:
@@ -808,6 +849,18 @@ class ProjectConfigSchema(BaseModel):
 
         requires_live = any(agent.mode == "live" for agent in self.agents)
         if requires_live:
+            if not self.data.streaming.provider:
+                raise ValueError(
+                    "data.streaming.provider is required when an agent is configured with mode=live."
+                )
+            if not self.data.streaming.websocket_url:
+                raise ValueError(
+                    "data.streaming.websocket_url is required when an agent is configured with mode=live."
+                )
+            if not self.data.streaming.channels:
+                raise ValueError(
+                    "data.streaming.channels is required when an agent is configured with mode=live."
+                )
             if self.risk is None:
                 raise ValueError(
                     "risk is required when an agent is configured with mode=live."

--- a/quanttradeai/utils/config_validator.py
+++ b/quanttradeai/utils/config_validator.py
@@ -33,6 +33,7 @@ from quanttradeai.utils.project_paths import infer_project_root, resolve_project
 from quanttradeai.utils.project_config import (
     load_project_config,
     normalize_live_risk_compatibility,
+    resolve_paper_replay_window,
 )
 from quanttradeai.utils.sweeps import expand_agent_backtest_sweep
 
@@ -347,6 +348,12 @@ def _render_project_summary(resolved: dict, warnings: list[str]) -> dict:
     data = resolved.get("data") or {}
     project = resolved.get("project") or {}
     deployment = resolved.get("deployment") or {}
+    replay_window = resolve_paper_replay_window(resolved)
+    paper_source = (
+        "replay"
+        if replay_window is not None
+        else "realtime" if (data.get("streaming") or {}).get("enabled") else None
+    )
     return {
         "project": {
             "name": project.get("name"),
@@ -371,6 +378,16 @@ def _render_project_summary(resolved: dict, warnings: list[str]) -> dict:
         "sweeps": len(resolved.get("sweeps") or []),
         "research_enabled": bool(
             (resolved.get("research") or {}).get("enabled", False)
+        ),
+        "paper_source": paper_source,
+        "paper_replay_window": (
+            {
+                "start": replay_window.start_date,
+                "end": replay_window.end_date,
+                "pace_delay_ms": replay_window.pace_delay_ms,
+            }
+            if replay_window is not None
+            else None
         ),
         "agents": [
             {

--- a/quanttradeai/utils/project_config.py
+++ b/quanttradeai/utils/project_config.py
@@ -12,6 +12,7 @@ from quanttradeai.utils.config_schemas import (
     PositionManagerConfig,
     RiskManagementConfig,
 )
+from quanttradeai.streaming.history import ReplayWindow, parse_iso_date
 
 
 LEGACY_CONFIG_FILES = {
@@ -29,6 +30,61 @@ DEFAULT_PROFILES = {
     "paper": {"mode": "paper"},
     "live": {"mode": "live"},
 }
+
+
+def paper_replay_enabled(project_config: dict[str, Any]) -> bool:
+    streaming_cfg = dict((project_config.get("data") or {}).get("streaming") or {})
+    replay_cfg = dict(streaming_cfg.get("replay") or {})
+    return bool(replay_cfg.get("enabled", False))
+
+
+def resolve_paper_replay_window(project_config: dict[str, Any]) -> ReplayWindow | None:
+    if not paper_replay_enabled(project_config):
+        return None
+
+    data_cfg = dict(project_config.get("data") or {})
+    streaming_cfg = dict(data_cfg.get("streaming") or {})
+    replay_cfg = dict(streaming_cfg.get("replay") or {})
+
+    start_date = (
+        replay_cfg.get("start_date")
+        or data_cfg.get("test_start")
+        or data_cfg.get("start_date")
+    )
+    end_date = (
+        replay_cfg.get("end_date")
+        or data_cfg.get("test_end")
+        or data_cfg.get("end_date")
+    )
+    if not start_date or not end_date:
+        raise ValueError(
+            "Replay-enabled paper mode requires replay dates or a data/test window in config/project.yaml."
+        )
+
+    replay_start = parse_iso_date(
+        str(start_date), field_name="data.streaming.replay.start_date"
+    )
+    replay_end = parse_iso_date(
+        str(end_date), field_name="data.streaming.replay.end_date"
+    )
+    data_start = parse_iso_date(
+        str(data_cfg.get("start_date")), field_name="data.start_date"
+    )
+    data_end = parse_iso_date(str(data_cfg.get("end_date")), field_name="data.end_date")
+    if replay_start < data_start or replay_end > data_end:
+        raise ValueError(
+            "data.streaming.replay window must stay within data.start_date and data.end_date."
+        )
+    if replay_start > replay_end:
+        raise ValueError(
+            "data.streaming.replay.start_date must be on or before data.streaming.replay.end_date."
+        )
+
+    return ReplayWindow(
+        start_date=replay_start.isoformat(),
+        end_date=replay_end.isoformat(),
+        pace_delay_ms=int(replay_cfg.get("pace_delay_ms", 0) or 0),
+    )
 
 
 @dataclass
@@ -625,6 +681,7 @@ def compile_streaming_runtime_config(
     project_config: dict[str, Any],
     *,
     mode: str = "paper",
+    require_realtime: bool = False,
 ) -> dict[str, Any]:
     """Compile canonical project streaming settings into gateway runtime YAML."""
 
@@ -637,28 +694,54 @@ def compile_streaming_runtime_config(
 
     symbols = list(streaming_cfg.get("symbols") or data_cfg.get("symbols") or [])
     channels = list(streaming_cfg.get("channels") or [])
-    provider_cfg: dict[str, Any] = {
-        "name": streaming_cfg.get("provider"),
-        "websocket_url": streaming_cfg.get("websocket_url"),
-        "auth_method": streaming_cfg.get("auth_method", "api_key"),
-        "subscriptions": channels,
-        "symbols": symbols,
-    }
-    if streaming_cfg.get("rate_limit"):
-        provider_cfg["rate_limit"] = dict(streaming_cfg.get("rate_limit") or {})
-    if streaming_cfg.get("circuit_breaker"):
-        provider_cfg["circuit_breaker"] = dict(
-            streaming_cfg.get("circuit_breaker") or {}
-        )
-
     runtime_cfg: dict[str, Any] = {
         "streaming": {
             "symbols": symbols,
-            "providers": [provider_cfg],
             "buffer_size": int(streaming_cfg.get("buffer_size", 1000)),
             "reconnect_attempts": int(streaming_cfg.get("reconnect_attempts", 5)),
         }
     }
+    replay_window = (
+        resolve_paper_replay_window(project_config) if mode == "paper" else None
+    )
+    realtime_required = require_realtime or mode == "live" or replay_window is None
+    if realtime_required:
+        provider = str(streaming_cfg.get("provider") or "").strip()
+        websocket_url = str(streaming_cfg.get("websocket_url") or "").strip()
+        if not provider:
+            raise ValueError(
+                f"data.streaming.provider must be configured for `quanttradeai agent run --mode {mode}`."
+            )
+        if not websocket_url:
+            raise ValueError(
+                f"data.streaming.websocket_url must be configured for `quanttradeai agent run --mode {mode}`."
+            )
+        if not channels:
+            raise ValueError(
+                f"data.streaming.channels must be configured for `quanttradeai agent run --mode {mode}`."
+            )
+
+        provider_cfg: dict[str, Any] = {
+            "name": provider,
+            "websocket_url": websocket_url,
+            "auth_method": streaming_cfg.get("auth_method", "api_key"),
+            "subscriptions": channels,
+            "symbols": symbols,
+        }
+        if streaming_cfg.get("rate_limit"):
+            provider_cfg["rate_limit"] = dict(streaming_cfg.get("rate_limit") or {})
+        if streaming_cfg.get("circuit_breaker"):
+            provider_cfg["circuit_breaker"] = dict(
+                streaming_cfg.get("circuit_breaker") or {}
+            )
+        runtime_cfg["streaming"]["providers"] = [provider_cfg]
+    if replay_window is not None and mode == "paper":
+        runtime_cfg["streaming"]["replay"] = {
+            "enabled": True,
+            "start_date": replay_window.start_date,
+            "end_date": replay_window.end_date,
+            "pace_delay_ms": replay_window.pace_delay_ms,
+        }
     health_check_interval = streaming_cfg.get("health_check_interval")
     if health_check_interval is not None:
         runtime_cfg["streaming"]["health_check_interval"] = int(health_check_interval)
@@ -676,14 +759,24 @@ def compile_streaming_runtime_config(
 
 def compile_paper_streaming_runtime_config(
     project_config: dict[str, Any],
+    *,
+    require_realtime: bool = False,
 ) -> dict[str, Any]:
-    return compile_streaming_runtime_config(project_config, mode="paper")
+    return compile_streaming_runtime_config(
+        project_config,
+        mode="paper",
+        require_realtime=require_realtime,
+    )
 
 
 def compile_live_streaming_runtime_config(
     project_config: dict[str, Any],
 ) -> dict[str, Any]:
-    return compile_streaming_runtime_config(project_config, mode="live")
+    return compile_streaming_runtime_config(
+        project_config,
+        mode="live",
+        require_realtime=True,
+    )
 
 
 def compile_live_risk_runtime_config(

--- a/roadmap.md
+++ b/roadmap.md
@@ -113,8 +113,12 @@ data:
   streaming:
     enabled: true
     provider: "alpaca"
+    websocket_url: "wss://stream.data.alpaca.markets/v2/iex"
     symbols: ["AAPL"]
     channels: ["trades", "quotes"]
+    replay:
+      enabled: true
+      pace_delay_ms: 0
 
 features:
   definitions:
@@ -331,9 +335,10 @@ Status on 2026-04-10:
 - `quanttradeai agent run --agent <name> -c config/project.yaml --mode live` is implemented for `rule`, `model`, `llm`, and `hybrid` agents.
 - Agent templates now write the referenced prompt markdown assets.
 - Agent backtest runs now persist resolved config, runtime YAML snapshots, metrics, equity curve, ledger, decisions, sampled prompt/response payloads where applicable, and standardized run metadata under `runs/agent/backtest/...`.
-- Model-agent paper runs now persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, and `executions.jsonl` under `runs/agent/paper/...`.
-- LLM and hybrid paper runs now persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, and sampled prompt payloads under `runs/agent/paper/...`.
-- Rule-agent paper runs now persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, `decisions.jsonl`, and `executions.jsonl` under `runs/agent/paper/...`.
+- Project-defined paper runs now support deterministic OHLCV replay through `data.streaming.replay`, resolving the replay window from replay dates, then test dates, then data dates.
+- Model-agent paper runs now warm-start from historical bars, persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, `executions.jsonl`, and write `replay_manifest.json` when replay is enabled under `runs/agent/paper/...`.
+- LLM and hybrid paper runs now warm-start from historical bars, persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, sampled prompt payloads, and write `replay_manifest.json` when replay is enabled under `runs/agent/paper/...`.
+- Rule-agent paper runs now warm-start from historical bars, persist resolved config, runtime YAML snapshots, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, and write `replay_manifest.json` when replay is enabled under `runs/agent/paper/...`.
 - Live agent runs now persist resolved config, runtime streaming/risk/position-manager YAML snapshots, `summary.json`, `metrics.json`, `executions.jsonl`, and `decisions.jsonl` under `runs/agent/live/...`, with `prompt_samples.json` for `llm` and `hybrid`.
 - `quanttradeai runs list` is implemented for local research and agent run discovery.
 - `quanttradeai promote --run research/<run_id> -c config/project.yaml` is implemented for successful research-model promotion into stable `models/...` paths, with `promotion_manifest.json` written in each promoted destination.
@@ -341,7 +346,7 @@ Status on 2026-04-10:
 - `quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml` is implemented for successful agent backtest-to-paper promotion.
 - `quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live <agent_name>` is implemented for successful paper-to-live promotion with an explicit safety acknowledgement.
 - Top-level `risk` and `position_manager` are now the canonical live safety/runtime sections in `config/project.yaml`.
-- `quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` now generates a paper-agent deployment bundle with compose, Dockerfile, env placeholders, resolved config, and a deployment manifest.
+- `quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` now generates a real-time paper-agent deployment bundle with compose, Dockerfile, env placeholders, resolved config, and a deployment manifest. Replay is disabled in the emitted bundle config.
 - `live-trade`, `config/risk_config.yaml`, `config/position_manager.yaml`, and `config/streaming.yaml` remain supported as legacy compatibility paths, but they are no longer the primary live workflow for project-defined agents.
 
 ### Stage 2: Multi-Agent Lab
@@ -452,7 +457,7 @@ quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode 
 ```
 
 Current implementation note:
-`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`. `deploy --target docker-compose` still generates paper-agent bundles only.
+`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`. `deploy --target docker-compose` still generates real-time paper bundles only.
 
 ### Hybrid track
 

--- a/tests/agents/test_paper.py
+++ b/tests/agents/test_paper.py
@@ -11,6 +11,7 @@ from quanttradeai.agents.paper import (
     _build_paper_runtime_model_config,
     _required_bootstrap_bars,
 )
+from quanttradeai.streaming.replay import ReplayGateway
 from quanttradeai.streaming.stream_buffer import StreamBuffer
 
 
@@ -306,3 +307,30 @@ def test_paper_engine_records_prompt_context_and_hybrid_model_signals(
     assert len(context["market_data"]["bars"]) == 2
     assert engine.prompt_samples
     assert "messages" in engine.prompt_samples[0]["prompt_payload"]
+
+
+def test_paper_engine_replay_bootstrap_does_not_double_count_history(
+    tmp_path: Path, monkeypatch
+):
+    engine = _build_engine(
+        tmp_path,
+        monkeypatch,
+        gateway_messages=[],
+        completion=_completion_from_actions(["buy", "hold"]),
+    )
+    bootstrap_history = {"AAPL": _mock_history(periods=2)}
+    replay_frames = {"AAPL": _mock_history(periods=4).iloc[2:4]}
+
+    engine.bootstrap_history_frames = bootstrap_history
+    engine.gateway = ReplayGateway(replay_frames, pace_delay_ms=0, buffer_size=16)
+
+    asyncio.run(engine.start())
+
+    assert len(engine.decision_log) == 2
+    assert [entry["timestamp"] for entry in engine.decision_log] == [
+        pd.Timestamp("2024-01-03T00:00:00Z"),
+        pd.Timestamp("2024-01-04T00:00:00Z"),
+    ]
+    assert len(engine.execution_log) == 1
+    assert engine.execution_log[0]["action"] == "buy"
+    assert len(engine._history["AAPL"]) == 4

--- a/tests/agents/test_paper.py
+++ b/tests/agents/test_paper.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from pathlib import Path
+import time
 
 import numpy as np
 import pandas as pd
@@ -334,3 +335,38 @@ def test_paper_engine_replay_bootstrap_does_not_double_count_history(
     assert len(engine.execution_log) == 1
     assert engine.execution_log[0]["action"] == "buy"
     assert len(engine._history["AAPL"]) == 4
+
+
+def test_paper_engine_replay_waits_for_completion_signal(
+    tmp_path: Path, monkeypatch
+):
+    def _slow_completion(**kwargs):
+        time.sleep(0.12)
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {"action": "hold", "reason": "slow replay test"}
+                        )
+                    }
+                }
+            ]
+        }
+
+    engine = _build_engine(
+        tmp_path,
+        monkeypatch,
+        gateway_messages=[],
+        completion=_slow_completion,
+    )
+    bootstrap_history = {"AAPL": _mock_history(periods=2)}
+    replay_frames = {"AAPL": _mock_history(periods=8).iloc[2:8]}
+
+    engine.bootstrap_history_frames = bootstrap_history
+    engine.gateway = ReplayGateway(replay_frames, pace_delay_ms=0, buffer_size=32)
+
+    asyncio.run(engine.start())
+
+    assert len(engine.decision_log) == 6
+    assert len(engine.execution_log) == 0

--- a/tests/integration/test_agent_cli.py
+++ b/tests/integration/test_agent_cli.py
@@ -656,6 +656,13 @@ def test_model_agent_paper_run_writes_metrics_and_execution_log(
     assert init_result.exit_code == 0, init_result.stdout
 
     observed: dict[str, str] = {}
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["data"]["streaming"]["replay"]["enabled"] = False
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
 
     def _engine_factory(**kwargs):
         observed.update({key: str(value) for key, value in kwargs.items()})
@@ -695,6 +702,71 @@ def test_model_agent_paper_run_writes_metrics_and_execution_log(
     assert metrics_payload["execution_count"] == 2
     assert metrics_payload["realized_pnl"] == 120.0
     assert metrics_payload["open_positions"]["AAPL"]["unrealized_pnl"] == 50.0
+
+
+def test_model_agent_paper_run_uses_replay_manifest(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    _stub_prometheus_client(monkeypatch)
+    _stub_live_trading_module(monkeypatch)
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "model-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["data"]["start_date"] = "2024-01-01"
+    config_payload["data"]["end_date"] = "2024-02-09"
+    config_payload["data"]["test_start"] = "2024-02-01"
+    config_payload["data"]["test_end"] = "2024-02-03"
+    config_payload["data"]["streaming"].pop("websocket_url")
+    config_payload["data"]["streaming"].pop("provider")
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    observed: dict[str, object] = {}
+
+    def _engine_factory(**kwargs):
+        observed.update(kwargs)
+        return FakePaperEngine(**kwargs)
+
+    with (
+        patch(
+            "quanttradeai.agents.model_agent.DataLoader.fetch_data",
+            return_value={"AAPL": _mock_history()},
+        ),
+        patch(
+            "quanttradeai.agents.model_agent.LiveTradingEngine",
+            side_effect=_engine_factory,
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--agent",
+                "paper_momentum",
+                "--config",
+                "config/project.yaml",
+                "--mode",
+                "paper",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    run_dir = Path(payload["run_dir"])
+    assert payload["paper_source"] == "replay"
+    assert (run_dir / "replay_manifest.json").is_file()
+    assert observed["gateway"].__class__.__name__ == "ReplayGateway"
+    assert observed["bootstrap_history_frames"]
 
 
 def test_model_agent_live_run_writes_live_artifacts_and_risk_metrics(
@@ -782,6 +854,7 @@ def test_llm_agent_paper_run_writes_standardized_artifacts(tmp_path: Path, monke
     config_payload["data"]["test_start"] = "2024-02-01"
     config_payload["data"]["test_end"] = "2024-02-09"
     config_payload["agents"][0]["mode"] = "paper"
+    config_payload["data"]["streaming"]["replay"]["enabled"] = False
     config_path.write_text(
         yaml.safe_dump(config_payload, sort_keys=False),
         encoding="utf-8",
@@ -871,6 +944,67 @@ def test_llm_agent_paper_run_writes_standardized_artifacts(tmp_path: Path, monke
     assert metrics_payload["execution_count"] == 1
 
 
+def test_llm_agent_paper_run_uses_replay_without_realtime_streaming(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "llm-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["data"]["start_date"] = "2024-01-01"
+    config_payload["data"]["end_date"] = "2024-02-09"
+    config_payload["data"]["test_start"] = "2024-02-01"
+    config_payload["data"]["test_end"] = "2024-02-03"
+    config_payload["data"]["streaming"].pop("websocket_url")
+    config_payload["data"]["streaming"].pop("provider")
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    with (
+        patch(
+            "quanttradeai.agents.paper.DataLoader.fetch_data",
+            return_value={"AAPL": _mock_history()},
+        ),
+        patch(
+            "quanttradeai.agents.paper.DataProcessor.generate_features",
+            _fake_generate_features,
+        ),
+        patch(
+            "quanttradeai.agents.llm.completion",
+            side_effect=_completion_from_actions(["buy", "hold", "sell", "hold"]),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--agent",
+                "breakout_gpt",
+                "--config",
+                str(config_path),
+                "--mode",
+                "paper",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    run_dir = Path(payload["run_dir"])
+    assert payload["paper_source"] == "replay"
+    assert (run_dir / "replay_manifest.json").is_file()
+    assert (run_dir / "prompt_samples.json").is_file()
+
+
 def test_rule_agent_paper_run_writes_metrics_and_execution_log(
     tmp_path: Path, monkeypatch
 ):
@@ -891,6 +1025,7 @@ def test_rule_agent_paper_run_writes_metrics_and_execution_log(
     config_payload["data"]["test_end"] = "2024-02-09"
     config_payload["agents"][0]["rule"]["buy_below"] = 50.0
     config_payload["agents"][0]["rule"]["sell_above"] = 60.0
+    config_payload["data"]["streaming"]["replay"]["enabled"] = False
     config_path.write_text(
         yaml.safe_dump(config_payload, sort_keys=False),
         encoding="utf-8",
@@ -978,6 +1113,63 @@ def test_rule_agent_paper_run_writes_metrics_and_execution_log(
     metrics_payload = json.loads((run_dir / "metrics.json").read_text("utf-8"))
     assert metrics_payload["decision_count"] == 2
     assert metrics_payload["execution_count"] == 2
+
+
+def test_rule_agent_paper_run_uses_replay_without_realtime_streaming(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["data"]["start_date"] = "2024-01-01"
+    config_payload["data"]["end_date"] = "2024-02-09"
+    config_payload["data"]["test_start"] = "2024-02-01"
+    config_payload["data"]["test_end"] = "2024-02-03"
+    config_payload["data"]["streaming"].pop("websocket_url")
+    config_payload["data"]["streaming"].pop("provider")
+    config_payload["agents"][0]["rule"]["buy_below"] = 50.0
+    config_payload["agents"][0]["rule"]["sell_above"] = 60.0
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    with (
+        patch(
+            "quanttradeai.agents.paper.DataLoader.fetch_data",
+            return_value={"AAPL": _mock_history()},
+        ),
+        patch(
+            "quanttradeai.agents.paper.DataProcessor.generate_features",
+            _rule_paper_features,
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--agent",
+                "rsi_reversion",
+                "--config",
+                str(config_path),
+                "--mode",
+                "paper",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    run_dir = Path(payload["run_dir"])
+    assert payload["paper_source"] == "replay"
+    assert (run_dir / "replay_manifest.json").is_file()
 
 
 def test_rule_agent_live_run_writes_live_artifacts_and_risk_metrics(
@@ -1111,6 +1303,7 @@ def test_hybrid_agent_paper_run_includes_model_signals_in_decisions(
     config_payload["data"]["test_start"] = "2024-02-01"
     config_payload["data"]["test_end"] = "2024-02-09"
     config_payload["agents"][0]["mode"] = "paper"
+    config_payload["data"]["streaming"]["replay"]["enabled"] = False
     config_path.write_text(
         yaml.safe_dump(config_payload, sort_keys=False),
         encoding="utf-8",
@@ -1198,6 +1391,92 @@ def test_hybrid_agent_paper_run_includes_model_signals_in_decisions(
     first_decision = json.loads(decision_lines[0])
     assert first_decision["model_signals"]["aapl_daily_classifier"]["signal"] == 1
     assert first_decision["action"] == "buy"
+
+
+def test_hybrid_agent_paper_run_uses_replay_without_realtime_streaming(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "hybrid", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    model_dir = Path("models/promoted/aapl_daily_classifier")
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["data"]["start_date"] = "2024-01-01"
+    config_payload["data"]["end_date"] = "2024-02-09"
+    config_payload["data"]["test_start"] = "2024-02-01"
+    config_payload["data"]["test_end"] = "2024-02-03"
+    config_payload["data"]["streaming"].pop("websocket_url")
+    config_payload["data"]["streaming"].pop("provider")
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    def _hybrid_completion(**kwargs):
+        content = kwargs["messages"][-1]["content"]
+        action = "buy" if '"signal": 1' in content else "hold"
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {"action": action, "reason": "Model signal driven"}
+                        )
+                    }
+                }
+            ]
+        }
+
+    with (
+        patch(
+            "quanttradeai.agents.paper.DataLoader.fetch_data",
+            return_value={"AAPL": _mock_history()},
+        ),
+        patch(
+            "quanttradeai.agents.paper.DataProcessor.generate_features",
+            _fake_generate_features,
+        ),
+        patch(
+            "quanttradeai.agents.backtest.MomentumClassifier",
+            FakeSignalClassifier,
+        ),
+        patch(
+            "quanttradeai.agents.backtest._load_feature_preprocessor",
+            return_value=None,
+        ),
+        patch(
+            "quanttradeai.agents.llm.completion",
+            side_effect=_hybrid_completion,
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--agent",
+                "hybrid_swing_agent",
+                "--config",
+                str(config_path),
+                "--mode",
+                "paper",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    run_dir = Path(payload["run_dir"])
+    assert payload["paper_source"] == "replay"
+    assert (run_dir / "replay_manifest.json").is_file()
 
 
 def test_agent_run_warns_when_cli_mode_differs_from_configured_mode(

--- a/tests/integration/test_deploy_cli.py
+++ b/tests/integration/test_deploy_cli.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import yaml
 from typer.testing import CliRunner
 
 from quanttradeai.cli import app
@@ -166,6 +167,55 @@ def test_model_agent_deploy_writes_manifest_and_models_mount(
     )
     assert payload["artifacts"]["manifest"].endswith("deployment_manifest.json")
     assert manifest["agent_kind"] == "model"
+
+
+def test_deploy_disables_replay_in_generated_bundle_and_warns(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "rule-agent")
+
+    result = _deploy_agent(
+        agent_name="rsi_reversion",
+        config_path=config_path,
+        output_dir="deployments/rule-replay",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    output_dir = Path(payload["output_dir"])
+    resolved_project = yaml.safe_load(
+        (output_dir / "resolved_project_config.yaml").read_text(encoding="utf-8")
+    )
+
+    assert config_path.read_text(encoding="utf-8") != ""
+    assert resolved_project["data"]["streaming"]["replay"]["enabled"] is False
+    assert any(
+        "replay was disabled in the generated bundle" in warning.lower()
+        for warning in payload["warnings"]
+    )
+
+
+def test_deploy_rejects_replay_only_project_without_realtime_streaming_fields(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "rule-agent")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["data"]["streaming"].pop("provider")
+    config_payload["data"]["streaming"].pop("websocket_url")
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = _deploy_agent(
+        agent_name="rsi_reversion",
+        config_path=config_path,
+        output_dir="deployments/rule-missing-realtime",
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert "data.streaming.provider must be configured" in combined_output
 
 
 def test_deploy_failure_cases(

--- a/tests/streaming/test_live_trading.py
+++ b/tests/streaming/test_live_trading.py
@@ -1,9 +1,11 @@
 import asyncio
+import time
 from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 
+from quanttradeai.streaming.replay import ReplayGateway
 from quanttradeai.streaming.live_trading import LiveTradingEngine
 from quanttradeai.streaming.monitoring.health_monitor import StreamingHealthMonitor
 from quanttradeai.streaming.stream_buffer import StreamBuffer
@@ -51,6 +53,16 @@ class DummyModel:
     def predict(self, X):
         value = self.outputs.pop(0) if self.outputs else 0
         return [value for _ in range(len(X))]
+
+
+class SlowDummyModel(DummyModel):
+    def __init__(self, outputs=None, delay_seconds: float = 0.12) -> None:
+        super().__init__(outputs=outputs)
+        self.delay_seconds = delay_seconds
+
+    def predict(self, X):
+        time.sleep(self.delay_seconds)
+        return super().predict(X)
 
 
 class DummyPreprocessor:
@@ -525,3 +537,58 @@ async def test_live_trading_engine_bootstrap_history_allows_first_bar_inference(
     assert len(engine.execution_log) == 1
     assert engine.execution_log[0]["action"] == "buy"
     assert len(engine._history["AAPL"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_live_trading_engine_replay_waits_for_completion_signal():
+    bootstrap_history = {
+        "AAPL": pd.DataFrame(
+            [
+                {
+                    "Open": 10.0,
+                    "High": 10.0,
+                    "Low": 10.0,
+                    "Close": 10.0,
+                    "Volume": 100,
+                }
+            ],
+            index=pd.to_datetime(["2024-01-01T00:00:00Z"], utc=True),
+        )
+    }
+    replay_history = pd.DataFrame(
+        {
+            "Open": [11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+            "High": [11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+            "Low": [11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+            "Close": [11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+            "Volume": [100, 100, 100, 100, 100, 100],
+        },
+        index=pd.to_datetime(
+            [
+                "2024-01-01T00:01:00Z",
+                "2024-01-01T00:02:00Z",
+                "2024-01-01T00:03:00Z",
+                "2024-01-01T00:04:00Z",
+                "2024-01-01T00:05:00Z",
+                "2024-01-01T00:06:00Z",
+            ],
+            utc=True,
+        ),
+    )
+    engine = LiveTradingEngine(
+        model_config="config/model_config.yaml",
+        model_path="unused",
+        gateway=ReplayGateway({"AAPL": replay_history}, pace_delay_ms=0, buffer_size=32),
+        data_processor=DummyProcessor(),
+        model=SlowDummyModel(outputs=[1, 1, 1, 1, 1, 1], delay_seconds=0.12),
+        min_history_for_features=2,
+        history_window=16,
+        risk_config=None,
+        position_manager_config=None,
+        bootstrap_history_frames=bootstrap_history,
+    )
+
+    await engine.start()
+
+    assert len(engine.decision_log) == 6
+    assert len(engine.execution_log) == 1

--- a/tests/streaming/test_live_trading.py
+++ b/tests/streaming/test_live_trading.py
@@ -1,6 +1,7 @@
 import asyncio
 from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 
 from quanttradeai.streaming.live_trading import LiveTradingEngine
@@ -16,6 +17,16 @@ class FakeGateway:
 
     async def _start(self) -> None:
         return None
+
+
+class ScriptedGateway(FakeGateway):
+    def __init__(self, messages: list[dict]) -> None:
+        super().__init__()
+        self.messages = messages
+
+    async def _start(self) -> None:
+        for message in self.messages:
+            await self.buffer.put(message)
 
 
 class DummyProcessor:
@@ -462,3 +473,55 @@ async def test_live_trading_engine_skips_when_saved_preprocessor_columns_missing
 
     assert engine.execution_log == []
     alert_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_trading_engine_bootstrap_history_allows_first_bar_inference():
+    gateway = ScriptedGateway(
+        [
+            {
+                "symbol": "AAPL",
+                "price": 11.0,
+                "Open": 11.0,
+                "High": 11.0,
+                "Low": 11.0,
+                "Close": 11.0,
+                "Volume": 100,
+                "timestamp": "2024-01-01T00:01:00Z",
+            }
+        ]
+    )
+    bootstrap_history = {
+        "AAPL": pd.DataFrame(
+            [
+                {
+                    "Open": 10.0,
+                    "High": 10.0,
+                    "Low": 10.0,
+                    "Close": 10.0,
+                    "Volume": 100,
+                }
+            ],
+            index=pd.to_datetime(["2024-01-01T00:00:00Z"], utc=True),
+        )
+    }
+    engine = LiveTradingEngine(
+        model_config="config/model_config.yaml",
+        model_path="unused",
+        gateway=gateway,
+        data_processor=DummyProcessor(),
+        model=DummyModel(outputs=[1]),
+        min_history_for_features=2,
+        history_window=8,
+        risk_config=None,
+        position_manager_config=None,
+        bootstrap_history_frames=bootstrap_history,
+    )
+
+    await engine.start()
+
+    assert len(engine.decision_log) == 1
+    assert engine.decision_log[0]["action"] == "buy"
+    assert len(engine.execution_log) == 1
+    assert engine.execution_log[0]["action"] == "buy"
+    assert len(engine._history["AAPL"]) == 2

--- a/tests/streaming/test_replay.py
+++ b/tests/streaming/test_replay.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+from quanttradeai.streaming.history import ReplayWindow, split_replay_frames
 from quanttradeai.streaming.replay import ReplayGateway
 
 
@@ -46,20 +47,66 @@ async def test_replay_gateway_emits_one_bar_per_row_in_time_order():
     while not gateway.buffer.queue.empty():
         messages.append(await gateway.buffer.get())
 
-    assert len(messages) == 4
-    assert [message["type"] for message in messages] == ["replay_bar"] * 4
-    assert [message["symbol"] for message in messages] == [
+    assert len(messages) == 5
+    assert [message["type"] for message in messages] == [
+        "replay_bar",
+        "replay_bar",
+        "replay_bar",
+        "replay_bar",
+        "replay_complete",
+    ]
+    assert [message["symbol"] for message in messages[:-1]] == [
         "AAPL",
         "MSFT",
         "AAPL",
         "MSFT",
     ]
-    assert [message["timestamp"] for message in messages] == [
+    assert [message["timestamp"] for message in messages[:-1]] == [
         "2024-01-01T00:00:00+00:00",
         "2024-01-02T00:00:00+00:00",
         "2024-01-03T00:00:00+00:00",
         "2024-01-03T00:00:00+00:00",
     ]
     assert messages[0]["open"] == pytest.approx(100.0)
-    assert messages[-1]["close"] == pytest.approx(211.0)
-    assert messages[-1]["volume"] == pytest.approx(101.0)
+    assert messages[-2]["close"] == pytest.approx(211.0)
+    assert messages[-2]["volume"] == pytest.approx(101.0)
+
+
+def test_split_replay_frames_includes_intraday_rows_on_end_date():
+    frame = pd.DataFrame(
+        {
+            "Open": [100.0, 101.0, 102.0, 103.0],
+            "High": [101.0, 102.0, 103.0, 104.0],
+            "Low": [99.0, 100.0, 101.0, 102.0],
+            "Close": [100.5, 101.5, 102.5, 103.5],
+            "Volume": [100.0, 110.0, 120.0, 130.0],
+        },
+        index=pd.to_datetime(
+            [
+                "2024-02-01T15:30:00Z",
+                "2024-02-02T09:30:00Z",
+                "2024-02-02T15:30:00Z",
+                "2024-02-03T09:30:00Z",
+            ],
+            utc=True,
+        ),
+    )
+
+    bootstrap_frames, replay_frames, manifest = split_replay_frames(
+        {"AAPL": frame},
+        replay_window=ReplayWindow(
+            start_date="2024-02-02",
+            end_date="2024-02-02",
+            pace_delay_ms=0,
+        ),
+        history_window=10,
+    )
+
+    assert list(bootstrap_frames["AAPL"].index) == [
+        pd.Timestamp("2024-02-01T15:30:00Z")
+    ]
+    assert list(replay_frames["AAPL"].index) == [
+        pd.Timestamp("2024-02-02T09:30:00Z"),
+        pd.Timestamp("2024-02-02T15:30:00Z"),
+    ]
+    assert manifest["symbols"][0]["replay_end"] == "2024-02-02T15:30:00+00:00"

--- a/tests/streaming/test_replay.py
+++ b/tests/streaming/test_replay.py
@@ -1,0 +1,65 @@
+import pandas as pd
+import pytest
+
+from quanttradeai.streaming.replay import ReplayGateway
+
+
+def _frame(rows: list[tuple[str, float]]) -> pd.DataFrame:
+    index = pd.to_datetime([timestamp for timestamp, _price in rows], utc=True)
+    prices = [price for _timestamp, price in rows]
+    return pd.DataFrame(
+        {
+            "Open": prices,
+            "High": [price + 1.0 for price in prices],
+            "Low": [price - 1.0 for price in prices],
+            "Close": prices,
+            "Volume": [100.0 + offset for offset, _ in enumerate(prices)],
+        },
+        index=index,
+    )
+
+
+@pytest.mark.asyncio
+async def test_replay_gateway_emits_one_bar_per_row_in_time_order():
+    gateway = ReplayGateway(
+        frames={
+            "MSFT": _frame(
+                [
+                    ("2024-01-02T00:00:00Z", 210.0),
+                    ("2024-01-03T00:00:00Z", 211.0),
+                ]
+            ),
+            "AAPL": _frame(
+                [
+                    ("2024-01-01T00:00:00Z", 100.0),
+                    ("2024-01-03T00:00:00Z", 101.0),
+                ]
+            ),
+        },
+        pace_delay_ms=0,
+        buffer_size=16,
+    )
+
+    await gateway._start()
+
+    messages = []
+    while not gateway.buffer.queue.empty():
+        messages.append(await gateway.buffer.get())
+
+    assert len(messages) == 4
+    assert [message["type"] for message in messages] == ["replay_bar"] * 4
+    assert [message["symbol"] for message in messages] == [
+        "AAPL",
+        "MSFT",
+        "AAPL",
+        "MSFT",
+    ]
+    assert [message["timestamp"] for message in messages] == [
+        "2024-01-01T00:00:00+00:00",
+        "2024-01-02T00:00:00+00:00",
+        "2024-01-03T00:00:00+00:00",
+        "2024-01-03T00:00:00+00:00",
+    ]
+    assert messages[0]["open"] == pytest.approx(100.0)
+    assert messages[-1]["close"] == pytest.approx(211.0)
+    assert messages[-1]["volume"] == pytest.approx(101.0)

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -460,6 +460,8 @@ def test_model_agent_template_includes_canonical_streaming_block(
     assert payload["data"]["streaming"]["enabled"] is True
     assert payload["data"]["streaming"]["provider"] == "alpaca"
     assert payload["data"]["streaming"]["channels"] == ["trades", "quotes"]
+    assert payload["data"]["streaming"]["replay"]["enabled"] is True
+    assert payload["data"]["streaming"]["replay"]["pace_delay_ms"] == 0
 
 
 def test_rule_agent_template_includes_canonical_streaming_block(
@@ -481,6 +483,7 @@ def test_rule_agent_template_includes_canonical_streaming_block(
     assert payload["agents"][0]["rule"]["feature"] == "rsi_14"
     assert payload["data"]["streaming"]["enabled"] is True
     assert payload["data"]["streaming"]["provider"] == "alpaca"
+    assert payload["data"]["streaming"]["replay"]["enabled"] is True
     assert payload["research"]["enabled"] is False
 
 
@@ -505,6 +508,7 @@ def test_llm_and_hybrid_templates_include_canonical_streaming_block(
         assert payload["data"]["streaming"]["enabled"] is True
         assert payload["data"]["streaming"]["provider"] == "alpaca"
         assert payload["data"]["streaming"]["symbols"] == expected_symbols
+        assert payload["data"]["streaming"]["replay"]["enabled"] is True
         cfg_path.unlink()
 
 
@@ -760,6 +764,7 @@ def test_validate_fails_when_model_agent_paper_streaming_is_incomplete(
     config_payload = yaml.safe_load(
         yaml.safe_dump(PROJECT_TEMPLATES["model-agent"], sort_keys=False)
     )
+    config_payload["data"]["streaming"]["replay"]["enabled"] = False
     config_payload["data"]["streaming"].pop("websocket_url")
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
     cfg_path.write_text(
@@ -773,6 +778,53 @@ def test_validate_fails_when_model_agent_paper_streaming_is_incomplete(
 
     assert result.exit_code == 1
     assert "data.streaming requires websocket_url" in result.stderr.lower()
+
+
+def test_validate_passes_when_model_agent_replay_omits_realtime_websocket(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["model-agent"], sort_keys=False)
+    )
+    config_payload["data"]["streaming"].pop("websocket_url")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+    model_dir = Path("models/promoted/aapl_daily_classifier")
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "- paper: source=replay" in result.stdout
+
+
+def test_validate_fails_when_live_agent_is_missing_realtime_websocket(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["rule-agent"], sort_keys=False)
+    )
+    config_payload["agents"][0]["mode"] = "live"
+    config_payload["data"]["streaming"].pop("websocket_url")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert "data.streaming.websocket_url is required" in result.stderr.lower()
 
 
 def test_validate_fails_when_llm_agent_paper_streaming_is_missing(

--- a/tests/utils/test_project_runtime.py
+++ b/tests/utils/test_project_runtime.py
@@ -2,7 +2,9 @@ from quanttradeai.utils.project_config import (
     compile_live_position_manager_runtime_config,
     compile_live_risk_runtime_config,
     compile_live_streaming_runtime_config,
+    compile_paper_streaming_runtime_config,
     compile_research_runtime_configs,
+    resolve_paper_replay_window,
 )
 from quanttradeai.utils.project_runtime import project_to_runtime_configs
 
@@ -160,3 +162,76 @@ def test_compile_live_runtime_accepts_legacy_nested_position_manager_risk():
         ]["max_drawdown_pct"]
         == 0.15
     )
+
+
+def test_compile_paper_runtime_config_allows_replay_without_realtime_provider():
+    project_cfg = {
+        "data": {
+            "symbols": ["AAPL"],
+            "start_date": "2024-01-01",
+            "end_date": "2024-03-31",
+            "test_start": "2024-02-01",
+            "test_end": "2024-02-29",
+            "streaming": {
+                "enabled": True,
+                "symbols": ["AAPL"],
+                "channels": ["trades"],
+                "replay": {
+                    "enabled": True,
+                    "pace_delay_ms": 0,
+                },
+            },
+        }
+    }
+
+    streaming_cfg = compile_paper_streaming_runtime_config(project_cfg)
+
+    assert "providers" not in streaming_cfg["streaming"]
+    assert streaming_cfg["streaming"]["replay"] == {
+        "enabled": True,
+        "start_date": "2024-02-01",
+        "end_date": "2024-02-29",
+        "pace_delay_ms": 0,
+    }
+
+
+def test_resolve_paper_replay_window_prefers_explicit_dates_then_test_then_data():
+    project_cfg = {
+        "data": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-03-31",
+            "test_start": "2024-02-01",
+            "test_end": "2024-02-29",
+            "streaming": {
+                "enabled": True,
+                "symbols": ["AAPL"],
+                "channels": ["trades"],
+                "replay": {
+                    "enabled": True,
+                    "start_date": "2024-02-10",
+                    "end_date": "2024-02-12",
+                    "pace_delay_ms": 25,
+                },
+            },
+        }
+    }
+
+    explicit_window = resolve_paper_replay_window(project_cfg)
+    assert explicit_window is not None
+    assert explicit_window.start_date == "2024-02-10"
+    assert explicit_window.end_date == "2024-02-12"
+    assert explicit_window.pace_delay_ms == 25
+
+    project_cfg["data"]["streaming"]["replay"].pop("start_date")
+    project_cfg["data"]["streaming"]["replay"].pop("end_date")
+    test_window = resolve_paper_replay_window(project_cfg)
+    assert test_window is not None
+    assert test_window.start_date == "2024-02-01"
+    assert test_window.end_date == "2024-02-29"
+
+    project_cfg["data"].pop("test_start")
+    project_cfg["data"].pop("test_end")
+    data_window = resolve_paper_replay_window(project_cfg)
+    assert data_window is not None
+    assert data_window.start_date == "2024-01-01"
+    assert data_window.end_date == "2024-03-31"


### PR DESCRIPTION
## What changed

This adds deterministic replay-backed paper mode for project-defined agents while keeping the existing real-time paper and live paths intact.

Key changes:
- add `data.streaming.replay` to the canonical project config schema
- resolve replay windows from explicit replay dates, then test dates, then data dates
- add a replay gateway that emits normalized OHLCV bars into the existing streaming buffer contract
- warm-start paper and live engines with bootstrap history so model agents can infer on the first replay/live bar on the happy path
- write `paper_source` plus `replay_manifest.json` for replay-backed paper runs
- keep deployment bundles on the real-time paper path by disabling replay in emitted bundle configs and validating required real-time streaming fields
- update templates, roadmap, README, and config docs to make local replay-backed paper mode the recommended workflow

## Why

`agent run --mode paper` was previously tied to real-time streaming for every agent kind. That made paper mode non-deterministic, awkward without provider credentials, and a poor promotion step between backtest and live. This change makes local paper runs deterministic and easier to validate while preserving the current real-time runtime and deployment behavior.

## Impact

- local paper runs for `rule`, `model`, `llm`, and `hybrid` agents can now work without real-time provider credentials when replay is enabled
- model agents now bootstrap enough history to make decisions immediately on the first replay/live bar in the happy path
- deployment generation remains compatible with the current real-time paper deployment flow
- docs and templates now reflect the intended project-first workflow

## Validation

- `make lint.format.test`
- `poetry build`
- `poetry run quanttradeai validate -c config/project.yaml`

The aggregated test target passed with 303 tests.