### PR TITLE
Add replay-backed multi-agent paper batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 | Run a trained model as an agent | `init --template model-agent` -> `validate` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | One YAML-defined model agent wired to a stable `models/promoted/...` path that can be backtested, promoted, paper-run, and live-run |
 | Run an LLM agent | `init --template llm-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Prompt-driven agent logic using project config across all three modes |
 | Run a hybrid agent | `init --template hybrid` -> `research run` -> `promote --run research/<run_id>` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Model signals plus LLM reasoning in one project, with research outputs promoted into a stable path before the agent is promoted through environments |
-| Backtest every project agent together | `agent run --all --mode backtest --max-concurrency 4` | A local multi-agent backtest batch with preserved child runs plus batch-level manifests and scoreboards |
+| Run every project agent together | `agent run --all --mode backtest|paper --max-concurrency 4` | A local multi-agent batch that preserves normal child runs plus batch-level manifests and scoreboards |
 | Sweep one agent across parameter variants | `agent run --sweep rsi_threshold_grid --mode backtest --max-concurrency 4` | A local sweep batch that expands one agent into many backtest variants, preserves normal child runs, and ranks them with the same scoreboard flow |
 | Generate a Docker Compose deployment bundle | `deploy --agent <name> --target docker-compose` | A real-time paper-agent bundle with compose, Dockerfile, env placeholders, and resolved config |
 | Keep using the older live loop | `live-trade` with runtime YAML files | Legacy compatibility for existing setups |
@@ -78,6 +78,8 @@ QuantTradeAI is one framework with two connected tracks:
 | Research-run promotion to stable model paths | Supported |
 | Agent backtest-to-paper promotion | Supported |
 | Agent paper-to-live promotion with acknowledgement | Supported |
+| `agent run --all --mode backtest` from `project.yaml` | Supported |
+| `agent run --all --mode paper` from `project.yaml` | Supported |
 | `agent run --sweep <name> --mode backtest` from `project.yaml` | Supported |
 | `deploy --target docker-compose` for paper agents | Supported |
 | `live-trade` legacy runtime YAML workflow | Supported for compatibility |
@@ -208,23 +210,25 @@ poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.y
 
 The default hybrid template is prewired to `models/promoted/aapl_daily_classifier`, so you do not need to hand-edit timestamped experiment paths after the research run.
 
-### Backtest Every Project Agent
+### Run Every Project Agent
 
-Use this when one `config/project.yaml` defines several agents and you want one local batch run that keeps the normal child backtest runs intact.
+Use this when one `config/project.yaml` defines several agents and you want one local batch run that keeps the normal child runs intact.
 
 ```bash
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
+poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
+poetry run quanttradeai agent run --all -c config/project.yaml --mode paper --max-concurrency 4
 ```
 
-This writes batch artifacts under `runs/agent/batches/<timestamp>_<project>_backtest/`:
+This writes batch artifacts under `runs/agent/batches/<timestamp>_<project>_backtest/` or `runs/agent/batches/<timestamp>_<project>_paper/`:
 
 - `batch_manifest.json`
 - `results.json`
 - `scoreboard.json`
 - `scoreboard.txt`
 
-Each child agent still writes its normal run under `runs/agent/backtest/...`, so `quanttradeai runs list --scoreboard` continues to work without a separate comparison path.
+Each child agent still writes its normal run under `runs/agent/backtest/...` or `runs/agent/paper/...`, so `quanttradeai runs list --scoreboard` continues to work without a separate comparison path. Backtest batches rank by `net_sharpe`; paper batches rank by `total_pnl`.
 
 ### Sweep One Agent
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,16 +28,17 @@ poetry install
 
 ### Basic Usage
 ```bash
-# Canonical Stage 1 workflow (project config)
+# Canonical project workflow
 poetry run quanttradeai init --template research -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai runs list
 
-# Runnable agent backtest workflow
+# Runnable agent workflow
 poetry run quanttradeai init --template llm-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
+poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
 
 # Import an existing legacy config/ directory into the canonical workflow
 poetry run quanttradeai validate --legacy-config-dir config

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -8,6 +8,7 @@ It drives:
 - `quanttradeai validate`
 - `quanttradeai research run`
 - `quanttradeai agent run` for project-defined agents in `backtest`, `paper`, and `live`
+- `quanttradeai agent run --all` for multi-agent batches in `backtest` and `paper`
 - `quanttradeai agent run --sweep <name>` for backtest-only parameter sweeps
 - `quanttradeai promote` for research-model promotion plus agent backtest-to-paper and paper-to-live promotion
 - `quanttradeai deploy` for docker-compose paper-agent bundles
@@ -82,6 +83,17 @@ poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.y
 ```
 
 The default hybrid template already points `model_signal_sources` at `models/promoted/aapl_daily_classifier`, so the happy path does not require editing timestamped experiment directories.
+
+### Multi-Agent Paper Batches
+
+```bash
+poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
+poetry run quanttradeai agent run --all -c config/project.yaml --mode paper --max-concurrency 4
+```
+
+Multi-agent paper batches preserve the normal child runs under `runs/agent/paper/...` and write batch artifacts under `runs/agent/batches/<timestamp>_<project>_paper/`.
+
+Paper batches rank the batch scoreboard by `total_pnl`.
 
 ### Backtest Sweeps
 
@@ -646,6 +658,12 @@ Writes under `runs/agent/paper/<timestamp>_<agent>/`.
 For `llm` and `hybrid` paper runs, the run directory includes both `decisions.jsonl` and `executions.jsonl` so prompt-driven decisions and actual paper executions can be audited separately.
 
 When replay is enabled, the run directory also includes `replay_manifest.json`, and `summary.json` records `paper_source: replay`.
+
+### `quanttradeai agent run --all --mode paper`
+
+Writes a batch directory under `runs/agent/batches/<timestamp>_<project>_paper/` and one normal child paper run under `runs/agent/paper/...` for each enumerated agent.
+
+Batch scoreboards for paper mode sort by `total_pnl`.
 
 ### `quanttradeai agent run --mode live`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,21 +121,23 @@ The hybrid template already points `model_signal_sources` at `models/promoted/aa
 
 Deployment bundles for project-defined paper agents are written under `reports/deployments/<agent>/<timestamp>/`.
 
-## Workflow 4: Multi-Agent Backtest Batch
+## Workflow 4: Multi-Agent Batches
 
 Use this when one `config/project.yaml` already defines several agents and you want one local batch run across all of them.
 
 ```bash
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
+poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
+poetry run quanttradeai agent run --all -c config/project.yaml --mode paper --max-concurrency 4
 ```
 
 This workflow:
 
 - validates the project before enumeration
-- runs every configured agent through the existing backtest path
-- preserves the normal child runs under `runs/agent/backtest/...`
-- adds batch-level artifacts under `runs/agent/batches/<timestamp>_<project>_backtest/`
+- runs every configured agent through the existing backtest or paper path
+- preserves the normal child runs under `runs/agent/backtest/...` or `runs/agent/paper/...`
+- adds batch-level artifacts under `runs/agent/batches/<timestamp>_<project>_backtest/` or `runs/agent/batches/<timestamp>_<project>_paper/`
 
 Batch artifacts include:
 
@@ -144,7 +146,7 @@ Batch artifacts include:
 - `scoreboard.json`
 - `scoreboard.txt`
 
-The batch workflow is backtest-only in this release. Paper and live still run one agent at a time.
+Backtest batches rank by `net_sharpe`. Paper batches rank by `total_pnl`. Live still runs one agent at a time.
 
 ## Legacy Runtime Workflows
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -32,6 +32,9 @@ poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --
 # Backtest every configured project agent together
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
+# Replay-backed paper batch across every configured project agent
+poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
+poetry run quanttradeai agent run --all -c config/project.yaml --mode paper --max-concurrency 4
 
 # Backtest one sweep of agent parameter variants
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest
@@ -114,6 +117,10 @@ Canonical multi-agent batch artifacts:
 - `runs/agent/batches/<timestamp>_<project>_backtest/results.json`
 - `runs/agent/batches/<timestamp>_<project>_backtest/scoreboard.json`
 - `runs/agent/batches/<timestamp>_<project>_backtest/scoreboard.txt`
+- `runs/agent/batches/<timestamp>_<project>_paper/batch_manifest.json`
+- `runs/agent/batches/<timestamp>_<project>_paper/results.json`
+- `runs/agent/batches/<timestamp>_<project>_paper/scoreboard.json`
+- `runs/agent/batches/<timestamp>_<project>_paper/scoreboard.txt`
 
 Canonical sweep batch artifacts:
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/batch_manifest.json`

--- a/quanttradeai/agents/batch.py
+++ b/quanttradeai/agents/batch.py
@@ -13,7 +13,10 @@ from typing import Any
 import yaml
 
 from quanttradeai.utils.config_validator import validate_project_config
-from quanttradeai.utils.project_config import load_project_config
+from quanttradeai.utils.project_config import (
+    compile_paper_streaming_runtime_config,
+    load_project_config,
+)
 from quanttradeai.utils.run_scoreboard import (
     attach_scoreboard,
     render_scoreboard_table,
@@ -22,6 +25,13 @@ from quanttradeai.utils.run_scoreboard import (
 from quanttradeai.utils.sweeps import expand_agent_backtest_sweep, sweep_summary_payload
 
 from .runner import run_project_agent
+
+
+SUPPORTED_BATCH_MODES = {"backtest", "paper"}
+BATCH_SCOREBOARD_SORT_FIELDS = {
+    "backtest": "net_sharpe",
+    "paper": "total_pnl",
+}
 
 
 def _slugify(value: str | None) -> str:
@@ -67,10 +77,8 @@ def _load_summary(path: Path) -> dict[str, Any] | None:
     return payload
 
 
-def _predict_child_run_dir(*, agent_name: str, run_timestamp: str) -> Path:
-    return (
-        Path("runs") / "agent" / "backtest" / f"{run_timestamp}_{_slugify(agent_name)}"
-    )
+def _predict_child_run_dir(*, agent_name: str, run_timestamp: str, mode: str) -> Path:
+    return Path("runs") / "agent" / mode / f"{run_timestamp}_{_slugify(agent_name)}"
 
 
 def _child_run_timestamp(batch_timestamp: str, index: int) -> str:
@@ -100,12 +108,13 @@ def _default_failed_summary(
     *,
     agent_name: str,
     child_run_dir: Path,
+    mode: str,
     error: str,
 ) -> dict[str, Any]:
     return {
-        "run_id": f"agent/backtest/{child_run_dir.name}",
+        "run_id": f"agent/{mode}/{child_run_dir.name}",
         "run_type": "agent",
-        "mode": "backtest",
+        "mode": mode,
         "name": agent_name,
         "status": "failed",
         "timestamps": {},
@@ -147,6 +156,32 @@ def _build_all_agent_specs(
         for index, agent in enumerate(agents, start=1)
     ]
     return None, specs
+
+
+def _scoreboard_sort_field(mode: str) -> str:
+    try:
+        return BATCH_SCOREBOARD_SORT_FIELDS[mode]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"Unsupported batch mode: {mode}") from exc
+
+
+def _sort_result_entries(
+    entries: list[dict[str, Any]],
+    *,
+    scoreboard_order: list[str],
+    mode: str,
+) -> list[dict[str, Any]]:
+    if mode != "paper":
+        return entries
+
+    order_index = {run_id: index for index, run_id in enumerate(scoreboard_order)}
+    return sorted(
+        entries,
+        key=lambda entry: (
+            order_index.get(str(entry.get("run_id") or ""), len(scoreboard_order)),
+            int(entry.get("display_order") or 0),
+        ),
+    )
 
 
 def _build_sweep_specs(
@@ -214,17 +249,25 @@ def _build_sweep_specs(
     return sweep_payload, specs
 
 
-def run_agent_backtest_batch(
+def run_agent_batch(
     *,
     project_config_path: str = "config/project.yaml",
+    mode: str = "backtest",
     skip_validation: bool = False,
     max_concurrency: int = 1,
     sweep_name: str | None = None,
 ) -> dict[str, Any]:
-    """Run every configured agent or sweep variant through the backtest path."""
+    """Run every configured agent or sweep variant through a supported batch path."""
 
     if max_concurrency < 1:
         raise ValueError("--max-concurrency must be at least 1.")
+    if mode not in SUPPORTED_BATCH_MODES:
+        supported = ", ".join(sorted(SUPPORTED_BATCH_MODES))
+        raise ValueError(
+            f"Unsupported batch mode '{mode}'. Supported modes: {supported}."
+        )
+    if sweep_name is not None and mode != "backtest":
+        raise ValueError("--sweep currently supports only --mode backtest.")
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     original_project_path = Path(project_config_path).resolve()
@@ -233,9 +276,9 @@ def run_agent_backtest_batch(
         original_project_path
     ).stem
     batch_name = (
-        f"{timestamp}_{_slugify(project_name)}_{_slugify(sweep_name)}_backtest"
+        f"{timestamp}_{_slugify(project_name)}_{_slugify(sweep_name)}_{mode}"
         if sweep_name
-        else f"{timestamp}_{_slugify(project_name)}_backtest"
+        else f"{timestamp}_{_slugify(project_name)}_{mode}"
     )
     batch_dir = Path("runs") / "agent" / "batches" / batch_name
     batch_dir.mkdir(parents=True, exist_ok=True)
@@ -251,6 +294,9 @@ def run_agent_backtest_batch(
     resolved_project = (
         yaml.safe_load(resolved_project_path.read_text(encoding="utf-8")) or {}
     )
+    if mode == "paper":
+        # Fail fast for project-wide paper prerequisites before launching child runs.
+        compile_paper_streaming_runtime_config(resolved_project)
 
     if sweep_name:
         sweep_payload, agent_specs = _build_sweep_specs(
@@ -278,7 +324,7 @@ def run_agent_backtest_batch(
             summary, warnings = run_project_agent(
                 project_config_path=str(spec["project_config_path"]),
                 agent_name=agent_name,
-                mode="backtest",
+                mode=mode,
                 skip_validation=skip_validation,
                 project_config_override=spec.get("project_config_override"),
                 run_timestamp=str(spec["run_timestamp"]),
@@ -303,12 +349,14 @@ def run_agent_backtest_batch(
             child_run_dir = _predict_child_run_dir(
                 agent_name=agent_name,
                 run_timestamp=str(spec["run_timestamp"]),
+                mode=mode,
             )
             child_summary = _load_summary(
                 child_run_dir / "summary.json"
             ) or _default_failed_summary(
                 agent_name=agent_name,
                 child_run_dir=child_run_dir,
+                mode=mode,
                 error=str(exc),
             )
             child_summary = _attach_sweep_metadata(
@@ -334,46 +382,59 @@ def run_agent_backtest_batch(
     results.sort(key=lambda item: int(item["display_order"]))
 
     scoreboard_records = attach_scoreboard([item["summary"] for item in results])
+    scoreboard_sort_by = _scoreboard_sort_field(mode)
     scoreboard_records = sort_run_records(
         scoreboard_records,
-        sort_by="net_sharpe",
+        sort_by=scoreboard_sort_by,
         ascending=False,
     )
     scoreboard_order = [
         str(record.get("run_id") or "") for record in scoreboard_records
     ]
 
+    result_entries = [
+        {
+            "agent_name": item["agent_name"],
+            "base_agent_name": item.get("base_agent_name"),
+            "agent_kind": item["agent_kind"],
+            "configured_mode": item["configured_mode"],
+            "status": item["status"],
+            "warnings": item["warnings"],
+            "error": item.get("error"),
+            "parameters": item.get("parameters"),
+            "paper_source": item["summary"].get("paper_source"),
+            "run_timestamp": item["run_timestamp"],
+            "run_id": item["summary"].get("run_id"),
+            "run_dir": item["summary"].get("run_dir"),
+            "variant_project_config": item.get("variant_project_config"),
+            "stdout_log": item["stdout_log"],
+            "stderr_log": item["stderr_log"],
+            "display_order": item["display_order"],
+            "scoreboard": next(
+                (
+                    record.get("scoreboard")
+                    for record in scoreboard_records
+                    if record.get("run_id") == item["summary"].get("run_id")
+                ),
+                None,
+            ),
+        }
+        for item in results
+    ]
+    result_entries = _sort_result_entries(
+        result_entries,
+        scoreboard_order=scoreboard_order,
+        mode=mode,
+    )
+    for entry in result_entries:
+        entry.pop("display_order", None)
+
     results_payload = {
         "batch_type": batch_type,
-        "mode": "backtest",
+        "mode": mode,
+        "scoreboard_sort_by": scoreboard_sort_by,
         "scoreboard_order": scoreboard_order,
-        "results": [
-            {
-                "agent_name": item["agent_name"],
-                "base_agent_name": item.get("base_agent_name"),
-                "agent_kind": item["agent_kind"],
-                "configured_mode": item["configured_mode"],
-                "status": item["status"],
-                "warnings": item["warnings"],
-                "error": item.get("error"),
-                "parameters": item.get("parameters"),
-                "run_timestamp": item["run_timestamp"],
-                "run_id": item["summary"].get("run_id"),
-                "run_dir": item["summary"].get("run_dir"),
-                "variant_project_config": item.get("variant_project_config"),
-                "stdout_log": item["stdout_log"],
-                "stderr_log": item["stderr_log"],
-                "scoreboard": next(
-                    (
-                        record.get("scoreboard")
-                        for record in scoreboard_records
-                        if record.get("run_id") == item["summary"].get("run_id")
-                    ),
-                    None,
-                ),
-            }
-            for item in results
-        ],
+        "results": result_entries,
     }
     if sweep_payload is not None:
         results_payload["sweep"] = dict(sweep_payload)
@@ -382,7 +443,7 @@ def run_agent_backtest_batch(
         )
 
     scoreboard_payload = {
-        "sort_by": "net_sharpe",
+        "sort_by": scoreboard_sort_by,
         "records": scoreboard_records,
     }
 
@@ -407,12 +468,13 @@ def run_agent_backtest_batch(
         "project_name": project_name,
         "project_config_path": str(original_project_path),
         "resolved_project_config": str(resolved_project_path),
-        "mode": "backtest",
+        "mode": mode,
         "max_concurrency": max_concurrency,
         "run_dir": str(batch_dir),
         "agent_count": len(results),
         "success_count": success_count,
         "failure_count": failure_count,
+        "scoreboard_sort_by": scoreboard_sort_by,
         "scoreboard_order": scoreboard_order,
         "artifacts": {
             "results": str(results_path),
@@ -421,20 +483,24 @@ def run_agent_backtest_batch(
         },
         "agents": [
             {
-                "agent_name": item["agent_name"],
-                "base_agent_name": item.get("base_agent_name"),
-                "parameters": item.get("parameters"),
-                "agent_kind": item["agent_kind"],
-                "configured_mode": item["configured_mode"],
-                "status": item["status"],
-                "run_timestamp": item["run_timestamp"],
-                "run_id": item["summary"].get("run_id"),
-                "run_dir": item["summary"].get("run_dir"),
-                "variant_project_config": item.get("variant_project_config"),
-                "stdout_log": item["stdout_log"],
-                "stderr_log": item["stderr_log"],
+                key: entry.get(key)
+                for key in (
+                    "agent_name",
+                    "base_agent_name",
+                    "parameters",
+                    "agent_kind",
+                    "configured_mode",
+                    "status",
+                    "paper_source",
+                    "run_timestamp",
+                    "run_id",
+                    "run_dir",
+                    "variant_project_config",
+                    "stdout_log",
+                    "stderr_log",
+                )
             }
-            for item in results
+            for entry in result_entries
         ],
         "warnings": list(dict.fromkeys(validation.get("warnings", []))),
     }
@@ -451,7 +517,7 @@ def run_agent_backtest_batch(
         "status": batch_status,
         "batch_type": batch_type,
         "project_name": project_name,
-        "mode": "backtest",
+        "mode": mode,
         "run_dir": str(batch_dir),
         "agent_count": len(results),
         "success_count": success_count,
@@ -464,3 +530,21 @@ def run_agent_backtest_batch(
         "warnings": manifest["warnings"],
         **({"sweep": dict(sweep_payload)} if sweep_payload is not None else {}),
     }
+
+
+def run_agent_backtest_batch(
+    *,
+    project_config_path: str = "config/project.yaml",
+    skip_validation: bool = False,
+    max_concurrency: int = 1,
+    sweep_name: str | None = None,
+) -> dict[str, Any]:
+    """Backward-compatible wrapper for backtest batch orchestration."""
+
+    return run_agent_batch(
+        project_config_path=project_config_path,
+        mode="backtest",
+        skip_validation=skip_validation,
+        max_concurrency=max_concurrency,
+        sweep_name=sweep_name,
+    )

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -1396,7 +1396,7 @@ def cmd_agent_run(
     run_all: bool = typer.Option(
         False,
         "--all",
-        help="Run every project-defined agent. Backtest mode only in this release.",
+        help="Run every project-defined agent. Supports backtest and paper modes in this release.",
     ),
     sweep: Optional[str] = typer.Option(
         None,
@@ -1414,18 +1414,18 @@ def cmd_agent_run(
     skip_validation: bool = typer.Option(
         False,
         "--skip-validation",
-        help="Skip data-quality validation before backtesting",
+        help="Skip data-quality validation before backtesting. Ignored for paper/live runs.",
     ),
     max_concurrency: int = typer.Option(
         1,
         "--max-concurrency",
         min=1,
-        help="Maximum concurrent child runs when using --all.",
+        help="Maximum concurrent child runs when using --all or --sweep.",
     ),
 ):
     """Run a first-class project agent in backtest, paper, or live mode."""
 
-    from .agents.batch import run_agent_backtest_batch
+    from .agents.batch import run_agent_batch
     from .agents.runner import run_project_agent
 
     chosen = sum((1 if agent else 0, 1 if run_all else 0, 1 if sweep else 0))
@@ -1434,10 +1434,13 @@ def cmd_agent_run(
 
     try:
         if run_all:
-            if mode != "backtest":
-                raise ValueError("--all currently supports only --mode backtest.")
-            batch_result = run_agent_backtest_batch(
+            if mode == "live":
+                raise ValueError(
+                    "--all currently supports only --mode backtest or --mode paper."
+                )
+            batch_result = run_agent_batch(
                 project_config_path=config,
+                mode=mode,
                 skip_validation=skip_validation,
                 max_concurrency=max_concurrency,
             )
@@ -1450,8 +1453,9 @@ def cmd_agent_run(
         if sweep:
             if mode != "backtest":
                 raise ValueError("--sweep currently supports only --mode backtest.")
-            batch_result = run_agent_backtest_batch(
+            batch_result = run_agent_batch(
                 project_config_path=config,
+                mode=mode,
                 skip_validation=skip_validation,
                 max_concurrency=max_concurrency,
                 sweep_name=sweep,

--- a/roadmap.md
+++ b/roadmap.md
@@ -354,12 +354,13 @@ Status on 2026-04-10:
 Goal:
 Make running many agents and many experiments on one machine easy and trustworthy.
 
-Status on 2026-04-12:
+Status on 2026-04-14:
 
 - `quanttradeai runs list --scoreboard` is implemented for local research and agent runs, with metric-aware sorting via `--sort-by` and additive JSON scoreboard payloads.
 - `quanttradeai agent run --all -c config/project.yaml --mode backtest` is implemented for local multi-agent backtest batches, with bounded concurrency, preserved child runs, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
+- `quanttradeai agent run --all -c config/project.yaml --mode paper` is implemented for local multi-agent paper batches, reusing the existing replay-backed paper path, preserving child runs under `runs/agent/paper/...`, and writing batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 - `quanttradeai agent run --sweep <name> -c config/project.yaml --mode backtest` is implemented for backtest-only parameter sweeps defined under `sweeps:` in `config/project.yaml`, with deterministic variant expansion, preserved child runs, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
-- Paper/live multi-agent orchestration and richer comparison workflows remain future Stage 2 work.
+- Live multi-agent orchestration and richer comparison workflows remain future Stage 2 work.
 
 Deliverables:
 
@@ -457,7 +458,7 @@ quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode 
 ```
 
 Current implementation note:
-`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`. `deploy --target docker-compose` still generates real-time paper bundles only.
+`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`, including `agent run --all --mode paper`. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`. `deploy --target docker-compose` still generates real-time paper bundles only.
 
 ### Hybrid track
 

--- a/tests/integration/test_agent_batch_cli.py
+++ b/tests/integration/test_agent_batch_cli.py
@@ -137,7 +137,7 @@ def test_agent_run_rejects_mixing_agent_and_sweep(tmp_path: Path, monkeypatch):
     assert "--sweep" in combined
 
 
-def test_agent_run_all_rejects_non_backtest_modes(tmp_path: Path, monkeypatch):
+def test_agent_run_all_rejects_live_mode(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     config_path = _seed_agent_assets(tmp_path)
 
@@ -150,13 +150,13 @@ def test_agent_run_all_rejects_non_backtest_modes(tmp_path: Path, monkeypatch):
             "--config",
             str(config_path),
             "--mode",
-            "paper",
+            "live",
         ],
     )
 
     assert result.exit_code == 1
     combined = f"{result.stdout}\n{result.stderr}"
-    assert "--all currently supports only --mode backtest" in combined
+    assert "--all currently supports only --mode backtest or --mode paper" in combined
 
 
 def test_agent_run_sweep_rejects_non_backtest_modes(tmp_path: Path, monkeypatch):
@@ -331,6 +331,250 @@ def test_agent_run_all_writes_batch_artifacts_and_sorts_scoreboard(
         "rsi_reversion",
     ]
     assert "NET_SHARPE" in (batch_dir / "scoreboard.txt").read_text("utf-8")
+
+
+def test_agent_run_all_paper_writes_batch_artifacts_and_sorts_by_total_pnl(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+
+    def _fake_run_project_agent(
+        *,
+        project_config_path: str,
+        agent_name: str,
+        mode: str,
+        skip_validation: bool,
+        project_config_override: dict | None = None,
+        run_timestamp: str | None = None,
+    ):
+        assert mode == "paper"
+        assert run_timestamp is not None
+        assert Path(project_config_path).resolve() == config_path.resolve()
+        assert project_config_override is None
+        run_dir = (
+            Path("runs") / "agent" / "paper" / f"{run_timestamp}_{agent_name.lower()}"
+        )
+        run_dir.mkdir(parents=True, exist_ok=True)
+        pnl_by_agent = {
+            "rsi_reversion": 80.0,
+            "paper_momentum": 120.0,
+            "breakout_gpt": 240.0,
+            "hybrid_swing_agent": 170.0,
+        }
+        metrics_path = run_dir / "metrics.json"
+        metrics_path.write_text(
+            json.dumps(
+                {
+                    "total_pnl": pnl_by_agent[agent_name],
+                    "portfolio_value": 100000.0 + pnl_by_agent[agent_name],
+                    "execution_count": int(pnl_by_agent[agent_name] / 10.0),
+                    "decision_count": int(pnl_by_agent[agent_name] / 5.0),
+                    "risk_status": "ok",
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        summary = {
+            "run_id": f"agent/paper/{run_dir.name}",
+            "run_type": "agent",
+            "mode": "paper",
+            "name": agent_name,
+            "status": "success",
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "symbols": ["AAPL"],
+            "warnings": [],
+            "artifacts": {"metrics": str(metrics_path)},
+            "paper_source": "replay",
+            "run_dir": str(run_dir),
+        }
+        (run_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2),
+            encoding="utf-8",
+        )
+        return summary, []
+
+    with patch(
+        "quanttradeai.agents.batch.run_project_agent",
+        side_effect=_fake_run_project_agent,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--all",
+                "--config",
+                str(config_path),
+                "--mode",
+                "paper",
+                "--max-concurrency",
+                "2",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    batch_dir = Path(payload["run_dir"])
+
+    assert payload["status"] == "success"
+    assert payload["mode"] == "paper"
+    assert batch_dir.name.endswith("_paper")
+    assert (batch_dir / "results.json").is_file()
+    assert (batch_dir / "scoreboard.json").is_file()
+
+    results_payload = json.loads((batch_dir / "results.json").read_text("utf-8"))
+    assert results_payload["mode"] == "paper"
+    assert results_payload["scoreboard_sort_by"] == "total_pnl"
+    assert [item["agent_name"] for item in results_payload["results"]] == [
+        "breakout_gpt",
+        "hybrid_swing_agent",
+        "paper_momentum",
+        "rsi_reversion",
+    ]
+    assert all(
+        item["run_id"].startswith("agent/paper/") for item in results_payload["results"]
+    )
+    assert all(
+        Path(item["run_dir"]).parts[:3] == ("runs", "agent", "paper")
+        for item in results_payload["results"]
+    )
+    assert all(item["paper_source"] == "replay" for item in results_payload["results"])
+
+    scoreboard_payload = json.loads((batch_dir / "scoreboard.json").read_text("utf-8"))
+    assert scoreboard_payload["sort_by"] == "total_pnl"
+    assert [record["name"] for record in scoreboard_payload["records"]] == [
+        "breakout_gpt",
+        "hybrid_swing_agent",
+        "paper_momentum",
+        "rsi_reversion",
+    ]
+    scoreboard_text = (batch_dir / "scoreboard.txt").read_text("utf-8")
+    assert "TOTAL_PNL" in scoreboard_text
+    assert "RISK" in scoreboard_text
+
+
+def test_agent_run_all_paper_preserves_child_failures_and_logs(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+
+    def _fake_run_project_agent(
+        *,
+        project_config_path: str,
+        agent_name: str,
+        mode: str,
+        skip_validation: bool,
+        project_config_override: dict | None = None,
+        run_timestamp: str | None = None,
+    ):
+        assert mode == "paper"
+        assert run_timestamp is not None
+        assert Path(project_config_path).resolve() == config_path.resolve()
+        assert project_config_override is None
+        run_dir = (
+            Path("runs") / "agent" / "paper" / f"{run_timestamp}_{agent_name.lower()}"
+        )
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        if agent_name == "hybrid_swing_agent":
+            child_summary = {
+                "run_id": f"agent/paper/{run_dir.name}",
+                "run_type": "agent",
+                "mode": "paper",
+                "name": agent_name,
+                "status": "failed",
+                "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+                "symbols": ["AAPL"],
+                "warnings": ["child warning"],
+                "artifacts": {},
+                "run_dir": str(run_dir),
+                "error": "paper child failed",
+            }
+            (run_dir / "summary.json").write_text(
+                json.dumps(child_summary, indent=2),
+                encoding="utf-8",
+            )
+            raise RuntimeError("simulated paper failure")
+
+        pnl_by_agent = {
+            "rsi_reversion": 80.0,
+            "paper_momentum": 120.0,
+            "breakout_gpt": 240.0,
+        }
+        metrics_path = run_dir / "metrics.json"
+        metrics_path.write_text(
+            json.dumps(
+                {
+                    "total_pnl": pnl_by_agent[agent_name],
+                    "portfolio_value": 100000.0 + pnl_by_agent[agent_name],
+                    "execution_count": int(pnl_by_agent[agent_name] / 10.0),
+                    "decision_count": int(pnl_by_agent[agent_name] / 5.0),
+                    "risk_status": "ok",
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        summary = {
+            "run_id": f"agent/paper/{run_dir.name}",
+            "run_type": "agent",
+            "mode": "paper",
+            "name": agent_name,
+            "status": "success",
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "symbols": ["AAPL"],
+            "warnings": [],
+            "artifacts": {"metrics": str(metrics_path)},
+            "paper_source": "replay",
+            "run_dir": str(run_dir),
+        }
+        (run_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2),
+            encoding="utf-8",
+        )
+        return summary, []
+
+    with patch(
+        "quanttradeai.agents.batch.run_project_agent",
+        side_effect=_fake_run_project_agent,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--all",
+                "--config",
+                str(config_path),
+                "--mode",
+                "paper",
+                "--max-concurrency",
+                "2",
+            ],
+        )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    assert payload["status"] == "failed"
+    assert payload["failure_count"] == 1
+    assert payload["success_count"] == 3
+
+    failed_entry = next(
+        item
+        for item in payload["results"]
+        if item["agent_name"] == "hybrid_swing_agent"
+    )
+    assert failed_entry["status"] == "failed"
+    assert failed_entry["warnings"] == ["child warning"]
+    assert failed_entry["run_id"].startswith("agent/paper/")
+    assert Path(failed_entry["stderr_log"]).read_text("utf-8")
+    successful_names = {
+        item["agent_name"] for item in payload["results"] if item["status"] == "success"
+    }
+    assert successful_names == {"breakout_gpt", "paper_momentum", "rsi_reversion"}
 
 
 def test_agent_run_sweep_writes_variant_artifacts_and_preserves_source_config(


### PR DESCRIPTION
## Summary
Add replay-backed multi-agent paper batches for project-defined agents.

## What Changed
- generalized batch orchestration to support `agent run --all --mode paper` while preserving the existing backtest batch and sweep behavior
- ranked paper batch scoreboards by `total_pnl` and surfaced paper child metadata such as `paper_source`
- updated CLI help text and mode validation so `--all` supports `backtest` and `paper`, while `--all --mode live` still fails clearly
- added integration coverage for successful and partially failing paper batches
- updated roadmap and user docs to describe the new QuantTradeAI paper-batch workflow and removed the internal Stage 1 wording from touched docs

## Why
Stage 2 already supported multi-agent backtest batches, but paper/live orchestration was still incomplete. This closes the happy-path paper gap without adding new config concepts or changing promotion behavior.

## Impact
Users can now run all project-defined agents through the existing replay-backed paper workflow from one command while keeping normal child runs under `runs/agent/paper/...` for comparison and promotion.

## Validation
- `make lint.format.test`
- `poetry run pytest tests/integration/test_agent_batch_cli.py -q`
- `poetry run pytest tests/integration/test_agent_cli.py -q`
- `poetry run pytest tests/integration/test_runs_cli.py -q`
- `poetry run pytest tests/integration/test_promote_cli.py -q`
- `poetry run pytest tests/integration/test_deploy_cli.py -q`
- `poetry run pytest tests/test_project_config_cli.py -q`
- `poetry build`