### PR TITLE
feat: complete first-class agent context blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,32 @@ poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.y
 
 The default hybrid template is prewired to `models/promoted/aapl_daily_classifier`, so you do not need to hand-edit timestamped experiment paths after the research run.
 
+LLM and hybrid agents can now pull first-class prompt context from recent orders, recent decisions, optional news headlines, and a project-relative notes file in addition to market data, features, model signals, positions, and risk state.
+
+```yaml
+news:
+  enabled: true
+  provider: "yfinance"
+
+agents:
+  - name: "breakout_gpt"
+    kind: "llm"
+    mode: "paper"
+    llm:
+      provider: "openai"
+      model: "gpt-5.3"
+      prompt_file: "prompts/breakout.md"
+    context:
+      market_data: {enabled: true, lookback_bars: 20}
+      features: ["rsi_14"]
+      positions: true
+      orders: {enabled: true, max_entries: 5}
+      memory: true
+      news: {enabled: true, max_items: 5}
+      notes: {enabled: true, file: "notes/breakout_gpt.md"}
+      risk_state: true
+```
+
 ### Run Every Project Agent
 
 Use this when one `config/project.yaml` defines several agents and you want one local batch run that keeps the normal child runs intact.

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -508,6 +508,77 @@ Hybrid agents may also define `model_signal_sources`.
 
 `model_signal_sources` must be written as objects with `name` and `path` for runnable agent configs. Legacy string entries can still pass `quanttradeai validate` with a deprecation warning, but `quanttradeai agent run --mode backtest` raises a runtime `ValueError` when loading them.
 
+Prompt context for `llm` and `hybrid` agents supports these blocks:
+
+- `market_data`
+- `features`
+- `model_signals`
+- `positions`
+- `risk_state`
+- `orders`
+- `memory`
+- `news`
+- `notes`
+
+`orders`, `memory`, and `news` accept either boolean shorthand or an object with `enabled` plus a cap:
+
+- `orders: true` means `max_entries: 5`
+- `memory: true` means `max_entries: 5`
+- `news: true` means `max_items: 5`
+
+`notes` accepts either boolean shorthand or an object with `enabled` and `file`:
+
+- `notes: true` resolves to `notes/<agent_name>.md`
+- the resolved notes file must exist and contain non-empty text
+
+Validation rules:
+
+- `context.news` requires top-level `news.enabled: true`
+- `context.notes` fails validation when the resolved file is missing or empty
+
+Runtime behavior:
+
+- `orders.recent_orders` includes recent executions for the current symbol with `timestamp`, `action`, `qty`, `price`, and `status`
+- `memory.recent_decisions` includes recent decisions for the current symbol with `timestamp`, `action`, `reason`, `execution_status`, and `target_position_after`
+- `news.headlines` uses recent non-empty `text` rows already attached to the symbol history, newest first, deduped, capped
+- `notes` is loaded once per run as `{path, content}`
+
+Example:
+
+```yaml
+news:
+  enabled: true
+  provider: "yfinance"
+  lookback_days: 7
+
+agents:
+  - name: "breakout_gpt"
+    kind: "llm"
+    mode: "paper"
+    llm:
+      provider: "openai"
+      model: "gpt-5.3"
+      prompt_file: "prompts/breakout.md"
+    context:
+      market_data:
+        enabled: true
+        timeframe: "1d"
+        lookback_bars: 20
+      features: ["rsi_14"]
+      positions: true
+      orders:
+        enabled: true
+        max_entries: 5
+      memory: true
+      news:
+        enabled: true
+        max_items: 5
+      notes:
+        enabled: true
+        file: "notes/breakout_gpt.md"
+      risk_state: true
+```
+
 Paper mode:
 
 - compiles `data.streaming` into a runtime streaming config

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -4,6 +4,25 @@ Common commands, patterns, and examples for QuantTradeAI.
 
 Project-defined `agent run --mode paper` defaults to deterministic replay through `data.streaming.replay`. Generated deployment bundles stay on the real-time paper path.
 
+LLM and hybrid agents can include prompt context from recent orders, recent decisions, news headlines, and a notes file:
+
+```yaml
+news:
+  enabled: true
+
+agents:
+  - name: "breakout_gpt"
+    kind: "llm"
+    mode: "paper"
+    context:
+      orders: {enabled: true, max_entries: 5}
+      memory: true
+      news: {enabled: true, max_items: 5}
+      notes: {enabled: true, file: "notes/breakout_gpt.md"}
+```
+
+`context.news` requires top-level `news.enabled: true`. `context.notes` requires a non-empty file.
+
 ## CLI Commands
 
 ```bash

--- a/quanttradeai/agents/backtest.py
+++ b/quanttradeai/agents/backtest.py
@@ -28,7 +28,12 @@ from quanttradeai.utils.project_paths import resolve_project_path
 from quanttradeai.utils.run_records import apply_required_run_fields, create_run_dir
 
 from .base import AgentSimulationState, action_to_target, signal_to_action
-from .context import build_context_payload, load_agent_notes_payload
+from .context import (
+    attach_prompt_context_history_columns,
+    build_context_payload,
+    load_agent_notes_payload,
+    strip_prompt_context_history_columns,
+)
 from .factory import build_strategy
 
 logger = logging.getLogger(__name__)
@@ -229,9 +234,13 @@ def run_agent_backtest(
             project_config_path=project_config_path,
         )
         include_prompt_artifacts = agent_config.get("kind") in {"llm", "hybrid"}
-        notes_payload = load_agent_notes_payload(
-            agent_config=agent_config,
-            project_config_path=project_config_path,
+        notes_payload = (
+            load_agent_notes_payload(
+                agent_config=agent_config,
+                project_config_path=project_config_path,
+            )
+            if include_prompt_artifacts
+            else None
         )
 
         model_cfg, features_cfg, backtest_cfg = compile_research_runtime_configs(
@@ -296,7 +305,13 @@ def run_agent_backtest(
         prompt_samples: list[dict[str, Any]] = []
 
         for symbol, df in data_dict.items():
-            features_df = processor.generate_features(df)
+            features_df = processor.generate_features(
+                strip_prompt_context_history_columns(df)
+            )
+            features_df = attach_prompt_context_history_columns(
+                features_df,
+                source_history=df,
+            )
             _, test_df, coverage = time_aware_split(features_df, model_cfg)
             symbol_dir = run_dir / "symbols" / symbol
             symbol_dir.mkdir(parents=True, exist_ok=True)

--- a/quanttradeai/agents/backtest.py
+++ b/quanttradeai/agents/backtest.py
@@ -28,7 +28,7 @@ from quanttradeai.utils.project_paths import resolve_project_path
 from quanttradeai.utils.run_records import apply_required_run_fields, create_run_dir
 
 from .base import AgentSimulationState, action_to_target, signal_to_action
-from .context import build_context_payload
+from .context import build_context_payload, load_agent_notes_payload
 from .factory import build_strategy
 
 logger = logging.getLogger(__name__)
@@ -229,6 +229,10 @@ def run_agent_backtest(
             project_config_path=project_config_path,
         )
         include_prompt_artifacts = agent_config.get("kind") in {"llm", "hybrid"}
+        notes_payload = load_agent_notes_payload(
+            agent_config=agent_config,
+            project_config_path=project_config_path,
+        )
 
         model_cfg, features_cfg, backtest_cfg = compile_research_runtime_configs(
             project_config,
@@ -288,6 +292,7 @@ def run_agent_backtest(
 
         prepared_data: dict[str, pd.DataFrame] = {}
         decision_records: list[dict[str, Any]] = []
+        execution_records: list[dict[str, Any]] = []
         prompt_samples: list[dict[str, Any]] = []
 
         for symbol, df in data_dict.items():
@@ -316,6 +321,9 @@ def run_agent_backtest(
                     current_row=current_row,
                     model_signals=model_signals,
                     state=state,
+                    decision_history=decision_records,
+                    execution_history=execution_records,
+                    notes_payload=notes_payload,
                 )
                 decision = strategy.decide(
                     agent_name=agent_name,
@@ -324,20 +332,38 @@ def run_agent_backtest(
                     context=context,
                     tools=list(agent_config.get("tools") or []),
                 )
+                target_before = state.target_position
                 target_position = action_to_target(
                     state.target_position, decision.action
                 )
+                target_delta = target_position - target_before
+                execution_status = "simulated" if target_delta != 0 else "no_change"
                 state.target_position = target_position
                 state.last_action = decision.action
                 state.last_reason = decision.reason
                 state.decision_count += 1
                 target_labels.append(target_position)
 
+                if target_delta != 0:
+                    execution_records.append(
+                        {
+                            "symbol": symbol,
+                            "timestamp": bar_timestamp,
+                            "action": decision.action,
+                            "qty": abs(target_delta),
+                            "price": _safe_float(current_row.get("Close"), 0.0),
+                            "status": "simulated",
+                        }
+                    )
+
                 decision_record = {
                     "symbol": symbol,
                     "timestamp": bar_timestamp,
                     "action": decision.action,
+                    "target_position_before": target_before,
                     "target_position": target_position,
+                    "target_position_after": target_position,
+                    "execution_status": execution_status,
                     "reason": decision.reason,
                     "context": context,
                     "model_signals": {

--- a/quanttradeai/agents/context.py
+++ b/quanttradeai/agents/context.py
@@ -11,6 +11,8 @@ from quanttradeai.utils.project_paths import infer_project_root, resolve_project
 
 from .base import AgentSimulationState, target_position_label
 
+PROMPT_CONTEXT_HISTORY_COLUMNS = ("text",)
+
 
 def _serialize_scalar(value: Any) -> Any:
     if isinstance(value, pd.Timestamp):
@@ -221,6 +223,30 @@ def _recent_news_items(
         if len(items) >= max_items:
             break
     return items
+
+
+def strip_prompt_context_history_columns(history: pd.DataFrame) -> pd.DataFrame:
+    return history.drop(
+        columns=[
+            column
+            for column in PROMPT_CONTEXT_HISTORY_COLUMNS
+            if column in history.columns
+        ],
+        errors="ignore",
+    )
+
+
+def attach_prompt_context_history_columns(
+    featured_history: pd.DataFrame,
+    *,
+    source_history: pd.DataFrame,
+) -> pd.DataFrame:
+    restored = featured_history.copy()
+    for column in PROMPT_CONTEXT_HISTORY_COLUMNS:
+        if column not in source_history.columns:
+            continue
+        restored[column] = source_history.reindex(restored.index)[column]
+    return restored
 
 
 def build_context_payload(

--- a/quanttradeai/agents/context.py
+++ b/quanttradeai/agents/context.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
+
+from quanttradeai.utils.project_paths import infer_project_root, resolve_project_path
 
 from .base import AgentSimulationState, target_position_label
 
@@ -83,6 +86,143 @@ def _infer_feature_columns(
     return []
 
 
+def resolve_context_block(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        resolved = dict(value)
+        resolved.setdefault("enabled", True)
+        return resolved
+    if value is True:
+        return {"enabled": True}
+    return {"enabled": False}
+
+
+def context_block_enabled(value: Any) -> bool:
+    return bool(resolve_context_block(value).get("enabled", False))
+
+
+def resolve_agent_notes_path(
+    *,
+    agent_config: dict[str, Any],
+    project_config_path: str | Path,
+) -> Path | None:
+    context_cfg = dict(agent_config.get("context") or {})
+    notes_cfg = resolve_context_block(context_cfg.get("notes"))
+    if not notes_cfg.get("enabled", False):
+        return None
+
+    agent_name = str(agent_config.get("name") or "agent").strip() or "agent"
+    notes_file = str(notes_cfg.get("file") or f"notes/{agent_name}.md").strip()
+    return resolve_project_path(project_config_path, notes_file)
+
+
+def load_agent_notes_payload(
+    *,
+    agent_config: dict[str, Any],
+    project_config_path: str | Path,
+) -> dict[str, Any] | None:
+    notes_path = resolve_agent_notes_path(
+        agent_config=agent_config,
+        project_config_path=project_config_path,
+    )
+    if notes_path is None:
+        return None
+    if not notes_path.is_file():
+        raise ValueError(f"Agent notes file does not exist: {notes_path}")
+
+    content = notes_path.read_text(encoding="utf-8").strip()
+    if not content:
+        raise ValueError(f"Agent notes file is empty: {notes_path}")
+
+    project_root = infer_project_root(project_config_path).resolve()
+    try:
+        display_path = notes_path.resolve().relative_to(project_root).as_posix()
+    except ValueError:
+        display_path = str(notes_path)
+
+    return {"path": display_path, "content": content}
+
+
+def _recent_execution_records(
+    *,
+    symbol: str | None,
+    execution_history: list[dict[str, Any]] | None,
+    max_entries: int,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for record in reversed(execution_history or []):
+        if symbol and record.get("symbol") != symbol:
+            continue
+        items.append(
+            {
+                "timestamp": _serialize_scalar(record.get("timestamp")),
+                "action": record.get("action"),
+                "qty": _serialize_scalar(record.get("qty")),
+                "price": _serialize_scalar(record.get("price")),
+                "status": record.get("status") or record.get("execution_status"),
+            }
+        )
+        if len(items) >= max_entries:
+            break
+    return items
+
+
+def _recent_decision_records(
+    *,
+    symbol: str | None,
+    decision_history: list[dict[str, Any]] | None,
+    max_entries: int,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for record in reversed(decision_history or []):
+        if symbol and record.get("symbol") != symbol:
+            continue
+        items.append(
+            {
+                "timestamp": _serialize_scalar(record.get("timestamp")),
+                "action": record.get("action"),
+                "reason": record.get("reason"),
+                "execution_status": record.get("execution_status"),
+                "target_position_after": _serialize_scalar(
+                    record.get(
+                        "target_position_after",
+                        record.get("position_after", record.get("target_position")),
+                    )
+                ),
+            }
+        )
+        if len(items) >= max_entries:
+            break
+    return items
+
+
+def _recent_news_items(
+    *,
+    history: pd.DataFrame,
+    max_items: int,
+) -> list[dict[str, Any]]:
+    if "text" not in history.columns:
+        return []
+
+    items: list[dict[str, Any]] = []
+    seen_text: set[str] = set()
+    for timestamp, value in reversed(list(history["text"].items())):
+        if pd.isna(value):
+            continue
+        text = str(value or "").strip()
+        if not text or text in seen_text:
+            continue
+        seen_text.add(text)
+        items.append(
+            {
+                "timestamp": _serialize_scalar(timestamp),
+                "text": text,
+            }
+        )
+        if len(items) >= max_items:
+            break
+    return items
+
+
 def build_context_payload(
     *,
     feature_definitions: list[dict[str, Any]],
@@ -91,6 +231,9 @@ def build_context_payload(
     current_row: pd.Series,
     model_signals: dict[str, int],
     state: AgentSimulationState,
+    decision_history: list[dict[str, Any]] | None = None,
+    execution_history: list[dict[str, Any]] | None = None,
+    notes_payload: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Assemble deterministic prompt context for the current bar."""
 
@@ -176,5 +319,43 @@ def build_context_payload(
             "current_direction": target_position_label(state.target_position),
             "risk_limits": dict(agent_config.get("risk") or {}),
         }
+
+    if agent_config.get("kind") not in {"llm", "hybrid"}:
+        return payload
+
+    current_symbol = agent_config.get("_current_symbol")
+
+    orders_cfg = resolve_context_block(context_cfg.get("orders"))
+    if orders_cfg.get("enabled", False):
+        payload["orders"] = {
+            "recent_orders": _recent_execution_records(
+                symbol=current_symbol,
+                execution_history=execution_history,
+                max_entries=int(orders_cfg.get("max_entries", 5)),
+            )
+        }
+
+    memory_cfg = resolve_context_block(context_cfg.get("memory"))
+    if memory_cfg.get("enabled", False):
+        payload["memory"] = {
+            "recent_decisions": _recent_decision_records(
+                symbol=current_symbol,
+                decision_history=decision_history,
+                max_entries=int(memory_cfg.get("max_entries", 5)),
+            )
+        }
+
+    news_cfg = resolve_context_block(context_cfg.get("news"))
+    if news_cfg.get("enabled", False):
+        payload["news"] = {
+            "headlines": _recent_news_items(
+                history=history,
+                max_items=int(news_cfg.get("max_items", 5)),
+            )
+        }
+
+    notes_cfg = resolve_context_block(context_cfg.get("notes"))
+    if notes_cfg.get("enabled", False) and notes_payload is not None:
+        payload["notes"] = dict(notes_payload)
 
     return payload

--- a/quanttradeai/agents/paper.py
+++ b/quanttradeai/agents/paper.py
@@ -54,7 +54,12 @@ from .backtest import (
     _load_model_signal_sources,
 )
 from .base import AgentDecision, AgentSimulationState
-from .context import build_context_payload, load_agent_notes_payload
+from .context import (
+    attach_prompt_context_history_columns,
+    build_context_payload,
+    load_agent_notes_payload,
+    strip_prompt_context_history_columns,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -302,9 +307,13 @@ class PaperAgentEngine:
             "llm",
             "hybrid",
         }
-        self.notes_payload = load_agent_notes_payload(
-            agent_config=self.agent_config,
-            project_config_path=self.project_config_path,
+        self.notes_payload = (
+            load_agent_notes_payload(
+                agent_config=self.agent_config,
+                project_config_path=self.project_config_path,
+            )
+            if self.include_prompt_artifacts
+            else None
         )
         risk_manager = None
         if self.mode == "live":
@@ -700,7 +709,13 @@ class PaperAgentEngine:
         if history is None or history.empty:
             return
 
-        featured_history = self.data_processor.generate_features(history.copy())
+        featured_history = self.data_processor.generate_features(
+            strip_prompt_context_history_columns(history).copy()
+        )
+        featured_history = attach_prompt_context_history_columns(
+            featured_history,
+            source_history=history,
+        )
         if (
             featured_history.empty
             or featured_history.index.max() != completed_timestamp

--- a/quanttradeai/agents/paper.py
+++ b/quanttradeai/agents/paper.py
@@ -54,7 +54,7 @@ from .backtest import (
     _load_model_signal_sources,
 )
 from .base import AgentDecision, AgentSimulationState
-from .context import build_context_payload
+from .context import build_context_payload, load_agent_notes_payload
 
 logger = logging.getLogger(__name__)
 
@@ -286,6 +286,7 @@ class PaperAgentEngine:
     decision_log: list[dict[str, Any]] = field(default_factory=list, init=False)
     execution_log: list[dict[str, Any]] = field(default_factory=list, init=False)
     prompt_samples: list[dict[str, Any]] = field(default_factory=list, init=False)
+    notes_payload: dict[str, Any] | None = field(default=None, init=False)
 
     def __post_init__(self) -> None:
         self.gateway = self.gateway or StreamingGateway(self.runtime_streaming_config)
@@ -301,6 +302,10 @@ class PaperAgentEngine:
             "llm",
             "hybrid",
         }
+        self.notes_payload = load_agent_notes_payload(
+            agent_config=self.agent_config,
+            project_config_path=self.project_config_path,
+        )
         risk_manager = None
         if self.mode == "live":
             drawdown_guard = _load_risk_guard(self.runtime_risk_config)
@@ -474,7 +479,7 @@ class PaperAgentEngine:
             history = history[
                 [
                     column
-                    for column in ("Open", "High", "Low", "Close", "Volume")
+                    for column in ("Open", "High", "Low", "Close", "Volume", "text")
                     if column in history.columns
                 ]
             ].copy()
@@ -635,6 +640,7 @@ class PaperAgentEngine:
                         "qty": qty,
                         "price": price,
                         "timestamp": timestamp,
+                        "status": "executed",
                         "decision_action": decision.action,
                     }
                     self.execution_log.append(execution_payload)
@@ -660,6 +666,7 @@ class PaperAgentEngine:
                         "qty": qty,
                         "price": price,
                         "timestamp": timestamp,
+                        "status": "executed",
                         "decision_action": decision.action,
                     }
                     self.execution_log.append(execution_payload)
@@ -715,6 +722,9 @@ class PaperAgentEngine:
             current_row=current_row,
             model_signals=model_signals,
             state=state,
+            decision_history=self.decision_log,
+            execution_history=self.execution_log,
+            notes_payload=self.notes_payload,
         )
         decision = self.strategy.decide(
             agent_name=str(self.agent_config.get("name") or ""),
@@ -735,6 +745,7 @@ class PaperAgentEngine:
             "timestamp": completed_timestamp,
             "action": decision.action,
             "reason": decision.reason,
+            "target_position_after": execution_result["position_after"],
             "context": context,
             "model_signals": {
                 name: {"signal": signal} for name, signal in model_signals.items()

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -699,6 +699,62 @@ class ProjectAgentMarketDataContext(BaseModel):
         return value
 
 
+class ProjectAgentOrdersContext(BaseModel):
+    enabled: bool = True
+    max_entries: int = Field(5, gt=0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_bool(cls, value: Any) -> Dict[str, Any]:
+        if value in (None, False):
+            return {"enabled": False}
+        if value is True:
+            return {"enabled": True}
+        return value
+
+
+class ProjectAgentMemoryContext(BaseModel):
+    enabled: bool = True
+    max_entries: int = Field(5, gt=0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_bool(cls, value: Any) -> Dict[str, Any]:
+        if value in (None, False):
+            return {"enabled": False}
+        if value is True:
+            return {"enabled": True}
+        return value
+
+
+class ProjectAgentNewsContext(BaseModel):
+    enabled: bool = True
+    max_items: int = Field(5, gt=0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_bool(cls, value: Any) -> Dict[str, Any]:
+        if value in (None, False):
+            return {"enabled": False}
+        if value is True:
+            return {"enabled": True}
+        return value
+
+
+class ProjectAgentNotesContext(BaseModel):
+    enabled: bool = True
+    file: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_bool(cls, value: Any) -> Dict[str, Any]:
+        if value in (None, False):
+            return {"enabled": False}
+        if value is True:
+            return {"enabled": True}
+        return value
+
+
 class ProjectModelSignalSourceConfig(BaseModel):
     name: str
     path: str
@@ -709,11 +765,11 @@ class ProjectAgentContextConfig(BaseModel):
     features: List[str] = Field(default_factory=list)
     model_signals: List[str] = Field(default_factory=list)
     positions: bool = False
-    orders: bool = False
+    orders: bool | ProjectAgentOrdersContext = False
     risk_state: bool = False
-    news: bool = False
-    memory: bool = False
-    notes: bool = False
+    news: bool | ProjectAgentNewsContext = False
+    memory: bool | ProjectAgentMemoryContext = False
+    notes: bool | ProjectAgentNotesContext = False
 
 
 class ProjectAgentConfig(BaseModel):

--- a/quanttradeai/utils/config_validator.py
+++ b/quanttradeai/utils/config_validator.py
@@ -19,7 +19,11 @@ from typing import Any, Callable, Dict, Iterable, Mapping
 import yaml
 from pydantic import ValidationError
 
-from quanttradeai.agents.context import _infer_feature_columns
+from quanttradeai.agents.context import (
+    _infer_feature_columns,
+    context_block_enabled,
+    resolve_agent_notes_path,
+)
 from quanttradeai.utils.config_schemas import (
     BacktestConfigSchema,
     FeaturesConfigSchema,
@@ -189,6 +193,7 @@ def _validate_agent_project_sections(
     feature_names = set(feature_definitions)
     data_streaming_cfg = dict((resolved.get("data") or {}).get("streaming") or {})
     position_manager_cfg = dict(resolved.get("position_manager") or {})
+    top_level_news_cfg = dict(resolved.get("news") or {})
 
     if "risk_management" in position_manager_cfg:
         warnings.append(
@@ -289,6 +294,32 @@ def _validate_agent_project_sections(
                 f"Agent '{agent_name}' references unknown model signals: "
                 + ", ".join(missing_signal_refs)
             )
+
+        if agent_kind in {"llm", "hybrid"} and context_block_enabled(
+            context_cfg.get("news")
+        ):
+            if not top_level_news_cfg.get("enabled", False):
+                errors.append(
+                    f"Agent '{agent_name}' enables context.news but top-level news.enabled is not true."
+                )
+
+        if agent_kind in {"llm", "hybrid"} and context_block_enabled(
+            context_cfg.get("notes")
+        ):
+            notes_path = resolve_agent_notes_path(
+                agent_config=agent,
+                project_config_path=config_path,
+            )
+            if notes_path is None or not notes_path.is_file():
+                errors.append(
+                    f"Agent '{agent_name}' enables context.notes but the notes file does not exist: {notes_path}"
+                )
+            else:
+                notes_content = notes_path.read_text(encoding="utf-8").strip()
+                if not notes_content:
+                    errors.append(
+                        f"Agent '{agent_name}' enables context.notes but the notes file is empty: {notes_path}"
+                    )
 
     if errors:
         raise ValueError("\n".join(errors))

--- a/tests/agents/test_context.py
+++ b/tests/agents/test_context.py
@@ -1,0 +1,185 @@
+import pandas as pd
+
+from quanttradeai.agents.base import AgentSimulationState
+from quanttradeai.agents.context import build_context_payload
+
+
+def _history_with_news() -> pd.DataFrame:
+    index = pd.date_range("2024-01-01", periods=4, freq="D", tz="UTC")
+    return pd.DataFrame(
+        {
+            "Open": [100.0, 101.0, 102.0, 103.0],
+            "High": [101.0, 102.0, 103.0, 104.0],
+            "Low": [99.0, 100.0, 101.0, 102.0],
+            "Close": [100.5, 101.5, 102.5, 103.5],
+            "Volume": [1000.0, 1100.0, 1200.0, 1300.0],
+            "rsi": [45.0, 50.0, 55.0, 60.0],
+            "text": [
+                "",
+                "Federal Reserve commentary eases rate fears",
+                "Federal Reserve commentary eases rate fears",
+                "Apple launches new buyback program",
+            ],
+        },
+        index=index,
+    )
+
+
+def test_build_context_payload_adds_prompt_only_blocks_for_llm_agents():
+    history = _history_with_news()
+    current_row = history.iloc[-1]
+    agent_config = {
+        "name": "breakout_gpt",
+        "kind": "llm",
+        "_current_symbol": "AAPL",
+        "context": {
+            "features": ["rsi_14"],
+            "orders": {"enabled": True, "max_entries": 2},
+            "memory": {"enabled": True, "max_entries": 2},
+            "news": {"enabled": True, "max_items": 2},
+            "notes": True,
+        },
+    }
+    decision_history = [
+        {
+            "symbol": "MSFT",
+            "timestamp": pd.Timestamp("2024-01-01T00:00:00Z"),
+            "action": "buy",
+            "reason": "ignore other symbols",
+            "execution_status": "executed",
+            "target_position_after": 1,
+        },
+        {
+            "symbol": "AAPL",
+            "timestamp": pd.Timestamp("2024-01-02T00:00:00Z"),
+            "action": "buy",
+            "reason": "breakout confirmed",
+            "execution_status": "executed",
+            "target_position_after": 1,
+        },
+        {
+            "symbol": "AAPL",
+            "timestamp": pd.Timestamp("2024-01-03T00:00:00Z"),
+            "action": "hold",
+            "reason": "trend intact",
+            "execution_status": "no_change",
+            "target_position_after": 1,
+        },
+    ]
+    execution_history = [
+        {
+            "symbol": "MSFT",
+            "timestamp": pd.Timestamp("2024-01-01T00:00:00Z"),
+            "action": "buy",
+            "qty": 1,
+            "price": 99.0,
+            "status": "executed",
+        },
+        {
+            "symbol": "AAPL",
+            "timestamp": pd.Timestamp("2024-01-02T00:00:00Z"),
+            "action": "buy",
+            "qty": 1,
+            "price": 101.5,
+            "status": "executed",
+        },
+        {
+            "symbol": "AAPL",
+            "timestamp": pd.Timestamp("2024-01-03T00:00:00Z"),
+            "action": "sell",
+            "qty": 2,
+            "price": 102.5,
+            "status": "simulated",
+        },
+    ]
+
+    payload = build_context_payload(
+        feature_definitions=[
+            {"name": "rsi_14", "type": "technical", "params": {"period": 14}}
+        ],
+        agent_config=agent_config,
+        history=history,
+        current_row=current_row,
+        model_signals={},
+        state=AgentSimulationState(),
+        decision_history=decision_history,
+        execution_history=execution_history,
+        notes_payload={"path": "notes/breakout_gpt.md", "content": "Trade the trend."},
+    )
+
+    assert payload["orders"]["recent_orders"] == [
+        {
+            "timestamp": "2024-01-03T00:00:00+00:00",
+            "action": "sell",
+            "qty": 2,
+            "price": 102.5,
+            "status": "simulated",
+        },
+        {
+            "timestamp": "2024-01-02T00:00:00+00:00",
+            "action": "buy",
+            "qty": 1,
+            "price": 101.5,
+            "status": "executed",
+        },
+    ]
+    assert payload["memory"]["recent_decisions"] == [
+        {
+            "timestamp": "2024-01-03T00:00:00+00:00",
+            "action": "hold",
+            "reason": "trend intact",
+            "execution_status": "no_change",
+            "target_position_after": 1,
+        },
+        {
+            "timestamp": "2024-01-02T00:00:00+00:00",
+            "action": "buy",
+            "reason": "breakout confirmed",
+            "execution_status": "executed",
+            "target_position_after": 1,
+        },
+    ]
+    assert payload["news"]["headlines"] == [
+        {
+            "timestamp": "2024-01-04T00:00:00+00:00",
+            "text": "Apple launches new buyback program",
+        },
+        {
+            "timestamp": "2024-01-03T00:00:00+00:00",
+            "text": "Federal Reserve commentary eases rate fears",
+        },
+    ]
+    assert payload["notes"] == {
+        "path": "notes/breakout_gpt.md",
+        "content": "Trade the trend.",
+    }
+
+
+def test_build_context_payload_keeps_enabled_empty_blocks_stable():
+    history = _history_with_news().drop(columns=["text"])
+    current_row = history.iloc[-1]
+    agent_config = {
+        "name": "breakout_gpt",
+        "kind": "hybrid",
+        "_current_symbol": "AAPL",
+        "context": {
+            "orders": True,
+            "memory": True,
+            "news": True,
+        },
+    }
+
+    payload = build_context_payload(
+        feature_definitions=[],
+        agent_config=agent_config,
+        history=history,
+        current_row=current_row,
+        model_signals={},
+        state=AgentSimulationState(),
+        decision_history=[],
+        execution_history=[],
+    )
+
+    assert payload["orders"] == {"recent_orders": []}
+    assert payload["memory"] == {"recent_decisions": []}
+    assert payload["news"] == {"headlines": []}

--- a/tests/agents/test_paper.py
+++ b/tests/agents/test_paper.py
@@ -93,6 +93,9 @@ def _build_engine(
     gateway_messages: list[dict],
     completion,
     model_signal_runtimes=None,
+    context_overrides: dict | None = None,
+    history_frame: pd.DataFrame | None = None,
+    notes_content: str | None = None,
 ) -> PaperAgentEngine:
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setattr("quanttradeai.agents.llm.completion", completion)
@@ -144,6 +147,16 @@ def _build_engine(
         "tools": ["get_quote", "place_order"],
         "risk": {"max_position_pct": 0.05},
     }
+    if context_overrides:
+        agent_config["context"].update(context_overrides)
+
+    if agent_config["context"].get("notes"):
+        notes_path = tmp_path / "notes" / "paper_agent.md"
+        notes_path.parent.mkdir(parents=True, exist_ok=True)
+        notes_path.write_text(
+            notes_content or "Trade only when the signal is clear.",
+            encoding="utf-8",
+        )
 
     return PaperAgentEngine(
         project_config_path=str(project_path),
@@ -156,7 +169,9 @@ def _build_engine(
         ],
         model_signal_runtimes=model_signal_runtimes or [],
         gateway=ScriptedGateway(gateway_messages),
-        data_loader=FakeLoader({"AAPL": _mock_history()}),
+        data_loader=FakeLoader(
+            {"AAPL": history_frame if history_frame is not None else _mock_history()}
+        ),
         data_processor=DummyProcessor(),
         history_window=512,
     )
@@ -308,6 +323,91 @@ def test_paper_engine_records_prompt_context_and_hybrid_model_signals(
     assert len(context["market_data"]["bars"]) == 2
     assert engine.prompt_samples
     assert "messages" in engine.prompt_samples[0]["prompt_payload"]
+
+
+def test_paper_engine_context_blocks_include_orders_memory_news_and_notes(
+    tmp_path: Path, monkeypatch
+):
+    history = _mock_history()
+    history["text"] = ""
+    history.iloc[-3, history.columns.get_loc("text")] = "Analyst upgrades Apple"
+    history.iloc[-2, history.columns.get_loc("text")] = "Apple expands buyback"
+    history.iloc[-1, history.columns.get_loc("text")] = "Apple expands buyback"
+
+    engine = _build_engine(
+        tmp_path,
+        monkeypatch,
+        gateway_messages=[
+            {
+                "symbol": "AAPL",
+                "price": 121.0,
+                "volume": 10,
+                "timestamp": "2024-09-17T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 123.0,
+                "volume": 12,
+                "timestamp": "2024-09-18T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 124.0,
+                "volume": 14,
+                "timestamp": "2024-09-19T00:00:00Z",
+            },
+        ],
+        completion=_completion_from_actions(["buy", "hold"]),
+        history_frame=history,
+        context_overrides={
+            "orders": {"enabled": True, "max_entries": 2},
+            "memory": {"enabled": True, "max_entries": 2},
+            "news": {"enabled": True, "max_items": 2},
+            "notes": True,
+        },
+        notes_content="Prefer continuation trades over counter-trend calls.",
+    )
+
+    asyncio.run(engine.start())
+
+    assert len(engine.decision_log) == 2
+    first_context = engine.decision_log[0]["context"]
+    assert first_context["orders"] == {"recent_orders": []}
+    assert first_context["memory"] == {"recent_decisions": []}
+    assert first_context["news"]["headlines"] == [
+        {
+            "timestamp": "2024-09-16T00:00:00+00:00",
+            "text": "Apple expands buyback",
+        },
+        {
+            "timestamp": "2024-09-14T00:00:00+00:00",
+            "text": "Analyst upgrades Apple",
+        },
+    ]
+    assert first_context["notes"] == {
+        "path": "notes/paper_agent.md",
+        "content": "Prefer continuation trades over counter-trend calls.",
+    }
+
+    second_context = engine.decision_log[1]["context"]
+    assert second_context["orders"]["recent_orders"] == [
+        {
+            "timestamp": "2024-09-17T00:00:00+00:00",
+            "action": "buy",
+            "qty": engine.execution_log[0]["qty"],
+            "price": 121.0,
+            "status": "executed",
+        }
+    ]
+    assert second_context["memory"]["recent_decisions"] == [
+        {
+            "timestamp": "2024-09-17T00:00:00+00:00",
+            "action": "buy",
+            "reason": "buy signal",
+            "execution_status": "executed",
+            "target_position_after": 1,
+        }
+    ]
 
 
 def test_paper_engine_replay_bootstrap_does_not_double_count_history(

--- a/tests/agents/test_paper.py
+++ b/tests/agents/test_paper.py
@@ -46,6 +46,15 @@ class DummyProcessor:
         return featured
 
 
+class DropTextSensitiveProcessor:
+    def generate_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        featured = df.copy()
+        if "text" in featured.columns:
+            featured = featured.dropna()
+        featured["rsi"] = np.linspace(45.0, 65.0, len(featured))
+        return featured
+
+
 class ScriptedGateway:
     def __init__(self, messages: list[dict]) -> None:
         self.buffer = StreamBuffer(32)
@@ -96,6 +105,7 @@ def _build_engine(
     context_overrides: dict | None = None,
     history_frame: pd.DataFrame | None = None,
     notes_content: str | None = None,
+    processor=None,
 ) -> PaperAgentEngine:
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setattr("quanttradeai.agents.llm.completion", completion)
@@ -172,7 +182,7 @@ def _build_engine(
         data_loader=FakeLoader(
             {"AAPL": history_frame if history_frame is not None else _mock_history()}
         ),
-        data_processor=DummyProcessor(),
+        data_processor=processor or DummyProcessor(),
         history_window=512,
     )
 
@@ -406,6 +416,53 @@ def test_paper_engine_context_blocks_include_orders_memory_news_and_notes(
             "reason": "buy signal",
             "execution_status": "executed",
             "target_position_after": 1,
+        }
+    ]
+
+
+def test_paper_engine_sparse_news_does_not_drop_completed_bar_decisions(
+    tmp_path: Path, monkeypatch
+):
+    history = _mock_history()
+    history["text"] = pd.Series([np.nan] * len(history), index=history.index, dtype=object)
+    history.iloc[-2, history.columns.get_loc("text")] = "Apple updates guidance"
+
+    engine = _build_engine(
+        tmp_path,
+        monkeypatch,
+        gateway_messages=[
+            {
+                "symbol": "AAPL",
+                "price": 121.0,
+                "volume": 10,
+                "timestamp": "2024-09-17T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 123.0,
+                "volume": 12,
+                "timestamp": "2024-09-18T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 124.0,
+                "volume": 14,
+                "timestamp": "2024-09-19T00:00:00Z",
+            },
+        ],
+        completion=_completion_from_actions(["buy", "hold"]),
+        history_frame=history,
+        context_overrides={"news": {"enabled": True, "max_items": 1}},
+        processor=DropTextSensitiveProcessor(),
+    )
+
+    asyncio.run(engine.start())
+
+    assert len(engine.decision_log) == 2
+    assert engine.decision_log[0]["context"]["news"]["headlines"] == [
+        {
+            "timestamp": "2024-09-15T00:00:00+00:00",
+            "text": "Apple updates guidance",
         }
     ]
 

--- a/tests/integration/test_agent_cli.py
+++ b/tests/integration/test_agent_cli.py
@@ -30,6 +30,15 @@ def _mock_history() -> pd.DataFrame:
     )
 
 
+def _mock_history_with_news() -> pd.DataFrame:
+    history = _mock_history()
+    history["text"] = ""
+    history.loc[pd.Timestamp("2024-01-24"), "text"] = "Apple expands its buyback"
+    history.loc[pd.Timestamp("2024-01-25"), "text"] = "Apple expands its buyback"
+    history.loc[pd.Timestamp("2024-01-26"), "text"] = "Analyst raises Apple target"
+    return history
+
+
 def _fake_generate_features(self, df: pd.DataFrame) -> pd.DataFrame:
     featured = df.copy()
     featured["rsi"] = np.linspace(45.0, 65.0, len(featured))
@@ -190,6 +199,103 @@ def test_agent_run_backtest_writes_artifacts(tmp_path: Path, monkeypatch):
     prompt_samples = json.loads((run_dir / "prompt_samples.json").read_text("utf-8"))
     assert prompt_samples
     assert "messages" in prompt_samples[0]["prompt_payload"]
+
+
+def test_llm_agent_backtest_context_blocks_include_orders_memory_news_and_notes(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "llm-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["data"]["start_date"] = "2024-01-01"
+    config_payload["data"]["end_date"] = "2024-02-09"
+    config_payload["data"]["test_start"] = "2024-01-26"
+    config_payload["data"]["test_end"] = "2024-01-31"
+    config_payload["news"] = {"enabled": True}
+    config_payload["agents"][0]["context"].update(
+        {
+            "orders": {"enabled": True, "max_entries": 2},
+            "memory": {"enabled": True, "max_entries": 2},
+            "news": {"enabled": True, "max_items": 2},
+            "notes": True,
+        }
+    )
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    notes_path = Path("notes/breakout_gpt.md")
+    notes_path.parent.mkdir(parents=True, exist_ok=True)
+    notes_path.write_text("Favor continuation setups over noise.", encoding="utf-8")
+
+    with (
+        patch(
+            "quanttradeai.agents.backtest.DataLoader.fetch_data",
+            return_value={"AAPL": _mock_history_with_news()},
+        ),
+        patch(
+            "quanttradeai.agents.backtest.DataProcessor.generate_features",
+            _fake_generate_features,
+        ),
+        patch(
+            "quanttradeai.agents.llm.completion",
+            side_effect=_completion_from_actions(
+                ["buy", "hold", "sell", "hold", "buy", "hold"]
+            ),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--agent",
+                "breakout_gpt",
+                "--config",
+                str(config_path),
+                "--mode",
+                "backtest",
+                "--skip-validation",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    run_dir = Path(payload["run_dir"])
+    decisions = [
+        json.loads(line)
+        for line in (run_dir / "decisions.jsonl")
+        .read_text(encoding="utf-8")
+        .strip()
+        .splitlines()
+    ]
+
+    first_context = decisions[0]["context"]
+    assert first_context["orders"] == {"recent_orders": []}
+    assert first_context["memory"] == {"recent_decisions": []}
+    assert first_context["notes"] == {
+        "path": "notes/breakout_gpt.md",
+        "content": "Favor continuation setups over noise.",
+    }
+    assert first_context["news"]["headlines"][0]["text"] == "Analyst raises Apple target"
+
+    second_context = decisions[1]["context"]
+    assert second_context["orders"]["recent_orders"][0]["action"] == "buy"
+    assert second_context["orders"]["recent_orders"][0]["status"] == "simulated"
+    assert second_context["memory"]["recent_decisions"][0]["action"] == "buy"
+    assert (
+        second_context["memory"]["recent_decisions"][0]["execution_status"]
+        == "simulated"
+    )
 
 
 def test_agent_run_backtest_omits_ledger_artifact_when_no_trades(
@@ -942,6 +1048,130 @@ def test_llm_agent_paper_run_writes_standardized_artifacts(tmp_path: Path, monke
     metrics_payload = json.loads((run_dir / "metrics.json").read_text("utf-8"))
     assert metrics_payload["decision_count"] == 2
     assert metrics_payload["execution_count"] == 1
+
+
+def test_llm_agent_paper_context_blocks_include_orders_memory_news_and_notes(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    _stub_streaming_gateway_module(monkeypatch)
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "llm-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["data"]["start_date"] = "2024-01-01"
+    config_payload["data"]["end_date"] = "2024-02-09"
+    config_payload["data"]["test_start"] = "2024-02-01"
+    config_payload["data"]["test_end"] = "2024-02-09"
+    config_payload["agents"][0]["mode"] = "paper"
+    config_payload["data"]["streaming"]["replay"]["enabled"] = False
+    config_payload["news"] = {"enabled": True}
+    config_payload["agents"][0]["context"].update(
+        {
+            "orders": {"enabled": True, "max_entries": 2},
+            "memory": {"enabled": True, "max_entries": 2},
+            "news": {"enabled": True, "max_items": 2},
+            "notes": True,
+        }
+    )
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    notes_path = Path("notes/breakout_gpt.md")
+    notes_path.parent.mkdir(parents=True, exist_ok=True)
+    notes_path.write_text("Bias toward clear trend continuation.", encoding="utf-8")
+
+    gateway = FakeStreamingGateway(
+        [
+            {
+                "symbol": "AAPL",
+                "price": 121.0,
+                "volume": 10,
+                "timestamp": "2024-02-10T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 123.0,
+                "volume": 12,
+                "timestamp": "2024-02-11T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 124.0,
+                "volume": 14,
+                "timestamp": "2024-02-12T00:00:00Z",
+            },
+        ]
+    )
+
+    with (
+        patch(
+            "quanttradeai.agents.paper.StreamingGateway",
+            return_value=gateway,
+        ),
+        patch(
+            "quanttradeai.agents.paper.DataLoader.fetch_data",
+            return_value={"AAPL": _mock_history_with_news()},
+        ),
+        patch(
+            "quanttradeai.agents.paper.DataProcessor.generate_features",
+            _fake_generate_features,
+        ),
+        patch(
+            "quanttradeai.agents.llm.completion",
+            side_effect=_completion_from_actions(["buy", "hold"]),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--agent",
+                "breakout_gpt",
+                "--config",
+                str(config_path),
+                "--mode",
+                "paper",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    run_dir = Path(payload["run_dir"])
+    decisions = [
+        json.loads(line)
+        for line in (run_dir / "decisions.jsonl")
+        .read_text(encoding="utf-8")
+        .strip()
+        .splitlines()
+    ]
+
+    first_context = decisions[0]["context"]
+    assert first_context["orders"] == {"recent_orders": []}
+    assert first_context["memory"] == {"recent_decisions": []}
+    assert first_context["notes"] == {
+        "path": "notes/breakout_gpt.md",
+        "content": "Bias toward clear trend continuation.",
+    }
+    assert first_context["news"]["headlines"][0]["text"] == "Analyst raises Apple target"
+
+    second_context = decisions[1]["context"]
+    assert second_context["orders"]["recent_orders"][0]["action"] == "buy"
+    assert second_context["orders"]["recent_orders"][0]["status"] == "executed"
+    assert second_context["memory"]["recent_decisions"][0]["action"] == "buy"
+    assert (
+        second_context["memory"]["recent_decisions"][0]["execution_status"]
+        == "executed"
+    )
 
 
 def test_llm_agent_paper_run_uses_replay_without_realtime_streaming(

--- a/tests/integration/test_agent_cli.py
+++ b/tests/integration/test_agent_cli.py
@@ -32,7 +32,7 @@ def _mock_history() -> pd.DataFrame:
 
 def _mock_history_with_news() -> pd.DataFrame:
     history = _mock_history()
-    history["text"] = ""
+    history["text"] = pd.Series([np.nan] * len(history), index=history.index, dtype=object)
     history.loc[pd.Timestamp("2024-01-24"), "text"] = "Apple expands its buyback"
     history.loc[pd.Timestamp("2024-01-25"), "text"] = "Apple expands its buyback"
     history.loc[pd.Timestamp("2024-01-26"), "text"] = "Analyst raises Apple target"
@@ -41,6 +41,15 @@ def _mock_history_with_news() -> pd.DataFrame:
 
 def _fake_generate_features(self, df: pd.DataFrame) -> pd.DataFrame:
     featured = df.copy()
+    featured["rsi"] = np.linspace(45.0, 65.0, len(featured))
+    featured["volume_momentum_20"] = np.linspace(0.1, 0.3, len(featured))
+    return featured
+
+
+def _drop_text_sensitive_generate_features(self, df: pd.DataFrame) -> pd.DataFrame:
+    featured = df.copy()
+    if "text" in featured.columns:
+        featured = featured.dropna()
     featured["rsi"] = np.linspace(45.0, 65.0, len(featured))
     featured["volume_momentum_20"] = np.linspace(0.1, 0.3, len(featured))
     return featured
@@ -244,7 +253,7 @@ def test_llm_agent_backtest_context_blocks_include_orders_memory_news_and_notes(
         ),
         patch(
             "quanttradeai.agents.backtest.DataProcessor.generate_features",
-            _fake_generate_features,
+            _drop_text_sensitive_generate_features,
         ),
         patch(
             "quanttradeai.agents.llm.completion",
@@ -616,6 +625,7 @@ def test_rule_agent_backtest_writes_standardized_artifacts(tmp_path: Path, monke
     config_payload["data"]["test_end"] = "2024-01-31"
     config_payload["agents"][0]["rule"]["buy_below"] = 50.0
     config_payload["agents"][0]["rule"]["sell_above"] = 60.0
+    config_payload["agents"][0]["context"]["notes"] = True
     config_path.write_text(
         yaml.safe_dump(config_payload, sort_keys=False),
         encoding="utf-8",
@@ -1255,6 +1265,7 @@ def test_rule_agent_paper_run_writes_metrics_and_execution_log(
     config_payload["data"]["test_end"] = "2024-02-09"
     config_payload["agents"][0]["rule"]["buy_below"] = 50.0
     config_payload["agents"][0]["rule"]["sell_above"] = 60.0
+    config_payload["agents"][0]["context"]["notes"] = True
     config_payload["data"]["streaming"]["replay"]["enabled"] = False
     config_path.write_text(
         yaml.safe_dump(config_payload, sort_keys=False),

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -1030,6 +1030,147 @@ def test_validate_fails_when_agent_prompt_file_missing(tmp_path: Path, monkeypat
     assert "prompt file does not exist" in result.stderr.lower()
 
 
+def test_validate_passes_when_llm_context_blocks_use_bool_shorthand(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path = Path("prompts/breakout.md")
+    prompt_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path.write_text("Return JSON only.", encoding="utf-8")
+    notes_path = Path("notes/breakout_gpt.md")
+    notes_path.parent.mkdir(parents=True, exist_ok=True)
+    notes_path.write_text("Trade with the prevailing trend.", encoding="utf-8")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["llm-agent"], sort_keys=False)
+    )
+    config_payload["news"] = {"enabled": True}
+    config_payload["agents"][0]["context"].update(
+        {
+            "orders": True,
+            "memory": True,
+            "news": True,
+            "notes": True,
+        }
+    )
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False), encoding="utf-8"
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 0, result.stdout
+
+
+def test_validate_passes_when_llm_context_blocks_use_object_form(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path = Path("prompts/breakout.md")
+    prompt_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path.write_text("Return JSON only.", encoding="utf-8")
+    notes_path = Path("notes/custom_breakout.md")
+    notes_path.parent.mkdir(parents=True, exist_ok=True)
+    notes_path.write_text("Only take high-conviction setups.", encoding="utf-8")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["llm-agent"], sort_keys=False)
+    )
+    config_payload["news"] = {"enabled": True}
+    config_payload["agents"][0]["context"].update(
+        {
+            "orders": {"enabled": True, "max_entries": 3},
+            "memory": {"enabled": True, "max_entries": 4},
+            "news": {"enabled": True, "max_items": 2},
+            "notes": {"enabled": True, "file": "notes/custom_breakout.md"},
+        }
+    )
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False), encoding="utf-8"
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    resolved = yaml.safe_load(
+        Path(payload["artifacts"]["resolved_config"]).read_text(encoding="utf-8")
+    )
+    context = resolved["agents"][0]["context"]
+    assert context["orders"]["max_entries"] == 3
+    assert context["memory"]["max_entries"] == 4
+    assert context["news"]["max_items"] == 2
+    assert context["notes"]["file"] == "notes/custom_breakout.md"
+
+
+def test_validate_fails_when_context_news_enabled_without_top_level_news(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path = Path("prompts/breakout.md")
+    prompt_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path.write_text("Return JSON only.", encoding="utf-8")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["llm-agent"], sort_keys=False)
+    )
+    config_payload["agents"][0]["context"]["news"] = True
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False), encoding="utf-8"
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert "context.news" in result.stderr
+    assert "news.enabled" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("notes_payload", "expected_message"),
+    [
+        (None, "notes file does not exist"),
+        ("", "notes file is empty"),
+    ],
+)
+def test_validate_fails_when_context_notes_file_is_missing_or_empty(
+    tmp_path: Path,
+    monkeypatch,
+    notes_payload: str | None,
+    expected_message: str,
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path = Path("prompts/breakout.md")
+    prompt_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path.write_text("Return JSON only.", encoding="utf-8")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["llm-agent"], sort_keys=False)
+    )
+    config_payload["agents"][0]["context"]["notes"] = True
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False), encoding="utf-8"
+    )
+
+    notes_path = Path("notes/breakout_gpt.md")
+    if notes_payload is not None:
+        notes_path.parent.mkdir(parents=True, exist_ok=True)
+        notes_path.write_text(notes_payload, encoding="utf-8")
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert expected_message in result.stderr.lower()
+
+
 def test_validate_warns_for_deprecated_model_signal_source_strings(
     tmp_path: Path, monkeypatch
 ):


### PR DESCRIPTION
## What changed
- completed first-class prompt context blocks for `llm` and `hybrid` agents across backtest, paper, and live happy paths
- added schema support for boolean shorthand and object-form config for `orders`, `memory`, `news`, and `notes`
- added validation for `context.news` requiring top-level `news.enabled: true` and for `context.notes` requiring a non-empty resolved notes file
- wired deterministic context assembly for recent orders, recent decisions, deduped news headlines from history `text`, and per-run notes payloads
- updated docs and examples so the documented project YAML matches the shipped runtime surface

## Why
The roadmap already exposed these context blocks as part of the agent prompt contract, but runtime assembly stopped at `risk_state`. This change closes that gap without changing rule/model behavior or removing any existing working path.

## Impact
- LLM and hybrid agents now receive auditable context for prior executions, prior decisions, optional news, and notes
- existing boolean YAML remains valid, with default caps applied automatically
- validation now fails early for misconfigured news and notes dependencies instead of silently producing partial context

## Validation
- `make lint.format.test`
- `poetry run pytest tests/agents/test_context.py -q`
- `poetry run pytest tests/test_project_config_cli.py -q`
- `poetry run pytest tests/agents/test_paper.py -q`
- `poetry run pytest tests/integration/test_agent_cli.py -q`
- `poetry run pytest tests/integration/test_runs_cli.py -q`
- `poetry run quanttradeai validate -c config/project.yaml`
