### PR TITLE
feat: add artifact-backed run comparison workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai runs list
 poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
+poetry run quanttradeai runs list --compare research/<run_id_a> --compare research/<run_id_b>
 ```
 
 This path gives you:
@@ -123,6 +124,7 @@ This path gives you:
 - a research run with metrics and artifacts
 - standardized outputs under `runs/research/...`
 - a quick scoreboard view for ranking local runs by the metrics that matter
+- an artifact-backed compare flow for inspecting meaningful config deltas between shortlisted runs
 
 To make a winning research artifact available to model or hybrid agents through a stable path:
 
@@ -254,7 +256,7 @@ This writes batch artifacts under `runs/agent/batches/<timestamp>_<project>_back
 - `scoreboard.json`
 - `scoreboard.txt`
 
-Each child agent still writes its normal run under `runs/agent/backtest/...` or `runs/agent/paper/...`, so `quanttradeai runs list --scoreboard` continues to work without a separate comparison path. Backtest batches rank by `net_sharpe`; paper batches rank by `total_pnl`.
+Each child agent still writes its normal run under `runs/agent/backtest/...` or `runs/agent/paper/...`, so `quanttradeai runs list --scoreboard` continues to work for ranking and `quanttradeai runs list --compare ...` can inspect shortlisted runs in detail. Backtest batches rank by `net_sharpe`; paper batches rank by `total_pnl`.
 
 ### Sweep One Agent
 
@@ -361,13 +363,15 @@ Sweep batch artifacts:
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/scoreboard.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/scoreboard.txt`
 
-This makes it easier to compare runs, audit what actually executed, and reuse winning configurations.
+This makes it easier to rank runs, inspect what actually changed, and reuse winning configurations.
 
-To compare local runs directly from the CLI, use the metrics-aware scoreboard:
+To rank and compare local runs directly from the CLI, use the scoreboard first and then compare explicit run ids:
 
 ```bash
 poetry run quanttradeai runs list --scoreboard
 poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
+poetry run quanttradeai runs list --compare research/<run_id_a> --compare research/<run_id_b>
+poetry run quanttradeai runs list --compare agent/backtest/<run_id_a> --compare agent/backtest/<run_id_b> --sort-by net_sharpe
 poetry run quanttradeai runs list --type agent --mode live --scoreboard --sort-by total_pnl
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,6 +17,8 @@ poetry run quanttradeai init --template research -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai runs list
+poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
+poetry run quanttradeai runs list --compare research/<run_id_a> --compare research/<run_id_b>
 ```
 
 This path gives you:
@@ -25,6 +27,7 @@ This path gives you:
 - resolved-config validation output
 - a full research run with metrics and artifacts
 - standardized run records under `runs/research/...`
+- a scoreboard for ranking local runs and a compare flow for inspecting the shortlisted winners
 
 To promote a successful research run into the stable model path used by the `model-agent` and `hybrid` templates:
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -38,6 +38,8 @@ poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 poetry run quanttradeai runs list
 poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
+poetry run quanttradeai runs list --compare research/<run_id_a> --compare research/<run_id_b>
+poetry run quanttradeai runs list --compare agent/backtest/<run_id_a> --compare agent/backtest/<run_id_b> --sort-by net_sharpe
 
 # Run a YAML-defined llm or hybrid agent
 poetry run quanttradeai init --template llm-agent -o config/project.yaml
@@ -323,7 +325,7 @@ Quick decision rule:
 
 - Use `config/project.yaml` for `validate`, `research run`, `agent run`, and `agent run --sweep`
 - Use `data.streaming.replay` for deterministic local paper runs; keep provider/websocket fields in place for later deployment or live promotion
-- Use `quanttradeai runs list --scoreboard` to compare local research and agent runs by metrics
+- Use `quanttradeai runs list --scoreboard` to rank local runs, then `quanttradeai runs list --compare ...` to inspect shortlisted runs by metrics and config deltas
 - Use the runtime YAML files for `live-trade`, `backtest-model`, and operational streaming setup
 
 ## Time-Aware Splitting

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -31,6 +31,7 @@ from .utils.run_records import (
     discover_runs,
     filter_runs,
 )
+from .utils.run_compare import build_run_comparison, render_run_comparison
 from .utils.run_scoreboard import (
     SCOREBOARD_SORT_FIELDS,
     attach_scoreboard,
@@ -1234,8 +1235,54 @@ def cmd_runs_list(
     json_output: bool = typer.Option(
         False, "--json", help="Emit normalized run records as JSON"
     ),
+    compare: Optional[list[str]] = typer.Option(
+        None,
+        "--compare",
+        help="Explicit run id to compare. Repeat 2-4 times for detailed comparison.",
+    ),
 ):
     """List normalized research and agent runs from the local runs directory."""
+
+    normalized_sort_by = _normalize_choice(
+        sort_by,
+        allowed=SCOREBOARD_SORT_FIELDS,
+        field_name="sort-by",
+    )
+
+    compare_values = list(compare or [])
+    if compare_values:
+        incompatible_flags = []
+        if run_type != "all":
+            incompatible_flags.append("--type")
+        if mode != "all":
+            incompatible_flags.append("--mode")
+        if status != "all":
+            incompatible_flags.append("--status")
+        if limit != 20:
+            incompatible_flags.append("--limit")
+        if scoreboard:
+            incompatible_flags.append("--scoreboard")
+        if incompatible_flags:
+            raise typer.BadParameter(
+                "Compare mode does not support " + ", ".join(incompatible_flags) + "."
+            )
+
+        try:
+            comparison = build_run_comparison(
+                run_ids=compare_values,
+                sort_by=normalized_sort_by,
+                ascending=ascending,
+            )
+        except Exception as exc:
+            typer.echo(f"Run comparison failed: {exc}", err=True)
+            raise typer.Exit(code=1)
+
+        if json_output:
+            typer.echo(json.dumps(comparison, indent=2))
+            return
+
+        typer.echo(render_run_comparison(comparison))
+        return
 
     discovered = discover_runs()
     filters = RunFilters(
@@ -1253,11 +1300,6 @@ def cmd_runs_list(
             field_name="status",
         ),
         limit=max(len(discovered), 1),
-    )
-    normalized_sort_by = _normalize_choice(
-        sort_by,
-        allowed=SCOREBOARD_SORT_FIELDS,
-        field_name="sort-by",
     )
     records = filter_runs(discovered, filters)
     needs_scoreboard = scoreboard or normalized_sort_by not in {

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -1263,9 +1263,13 @@ def cmd_runs_list(
         if scoreboard:
             incompatible_flags.append("--scoreboard")
         if incompatible_flags:
-            raise typer.BadParameter(
-                "Compare mode does not support " + ", ".join(incompatible_flags) + "."
+            typer.echo(
+                "Run comparison failed: Compare mode does not support "
+                + ", ".join(incompatible_flags)
+                + ".",
+                err=True,
             )
+            raise typer.Exit(code=1)
 
         try:
             comparison = build_run_comparison(

--- a/quanttradeai/utils/run_compare.py
+++ b/quanttradeai/utils/run_compare.py
@@ -1,0 +1,513 @@
+"""Artifact-backed run comparison helpers for canonical workflows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from quanttradeai.utils.project_config import resolve_paper_replay_window
+from quanttradeai.utils.run_records import RUNS_ROOT, discover_runs
+from quanttradeai.utils.run_scoreboard import (
+    attach_scoreboard,
+    render_scoreboard_table,
+    sort_run_records,
+)
+
+
+COMPARE_RUN_LIMIT_MIN = 2
+COMPARE_RUN_LIMIT_MAX = 4
+
+RUN_FAMILY_METRICS = {
+    "research": ["accuracy", "f1", "net_sharpe", "net_pnl"],
+    "agent/backtest": ["net_sharpe", "net_pnl", "net_mdd", "decision_count"],
+    "agent/paper": [
+        "total_pnl",
+        "portfolio_value",
+        "execution_count",
+        "decision_count",
+        "risk_status",
+    ],
+    "agent/live": [
+        "total_pnl",
+        "portfolio_value",
+        "execution_count",
+        "decision_count",
+        "risk_status",
+    ],
+}
+
+
+def _normalize_run_id(value: str | Path) -> str:
+    normalized = str(value).replace("\\", "/").strip().strip("/")
+    parts = [part for part in normalized.split("/") if part and part != "."]
+    if "runs" in parts:
+        parts = parts[parts.index("runs") + 1 :]
+    return "/".join(parts)
+
+
+def _run_family(record: dict[str, Any]) -> str:
+    run_type = str(record.get("run_type") or "").strip()
+    mode = str(record.get("mode") or "").strip()
+    if run_type == "research":
+        return "research"
+    return f"{run_type}/{mode}"
+
+
+def _resolve_run_artifact_path(
+    record: dict[str, Any],
+    *,
+    artifact_key: str,
+    default_filename: str,
+) -> Path:
+    run_dir = Path(str(record.get("run_dir") or ""))
+    artifacts = dict(record.get("artifacts") or {})
+    artifact_path = artifacts.get(artifact_key)
+    if artifact_path:
+        candidate = Path(str(artifact_path))
+        if candidate.is_absolute():
+            return candidate
+        if run_dir.parts and candidate.parts[: len(run_dir.parts)] == run_dir.parts:
+            return candidate
+        return run_dir / candidate
+    return run_dir / default_filename
+
+
+def _load_json_mapping(path: Path, *, label: str) -> dict[str, Any]:
+    if not path.is_file():
+        raise ValueError(f"Run is missing {label}: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Run {label} is not valid JSON: {path}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"Run {label} must contain a JSON object: {path}")
+    return payload
+
+
+def _load_yaml_mapping(path: Path, *, label: str) -> dict[str, Any]:
+    if not path.is_file():
+        raise ValueError(f"Run is missing {label}: {path}")
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Run {label} must contain a YAML mapping: {path}")
+    return payload
+
+
+def _ensure_compare_candidates(run_ids: list[str]) -> None:
+    if len(run_ids) < COMPARE_RUN_LIMIT_MIN:
+        raise ValueError(
+            "Compare mode requires at least two explicit --compare values."
+        )
+    if len(run_ids) > COMPARE_RUN_LIMIT_MAX:
+        raise ValueError(
+            "Compare mode supports at most four explicit --compare values."
+        )
+
+    normalized = [_normalize_run_id(run_id) for run_id in run_ids]
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("Compare mode does not allow duplicate run ids.")
+
+
+def _resolve_compare_records(
+    *,
+    run_ids: list[str],
+    runs_root: Path | str = RUNS_ROOT,
+) -> list[dict[str, Any]]:
+    discovered = discover_runs(runs_root)
+    records: list[dict[str, Any]] = []
+    for run_id in run_ids:
+        expected = _normalize_run_id(run_id)
+        matched = None
+        for record in discovered:
+            candidates = {
+                _normalize_run_id(str(record.get("run_id") or "")),
+                _normalize_run_id(str(record.get("run_dir") or "")),
+            }
+            if expected in candidates:
+                matched = dict(record)
+                break
+        if matched is None:
+            raise ValueError(f"Run not found for compare: {run_id}")
+        records.append(matched)
+    return records
+
+
+def _normalize_context(context_cfg: dict[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    if "features" in context_cfg:
+        normalized["features"] = list(context_cfg.get("features") or [])
+    if "model_signals" in context_cfg:
+        normalized["model_signals"] = list(context_cfg.get("model_signals") or [])
+
+    for key in (
+        "market_data",
+        "positions",
+        "orders",
+        "risk_state",
+        "news",
+        "memory",
+        "notes",
+    ):
+        if key not in context_cfg:
+            continue
+        value = context_cfg.get(key)
+        normalized[key] = dict(value) if isinstance(value, dict) else value
+
+    return normalized
+
+
+def _extract_research_view(project_config: dict[str, Any]) -> dict[str, Any]:
+    data_cfg = dict(project_config.get("data") or {})
+    research_cfg = dict(project_config.get("research") or {})
+    feature_definitions = list(
+        (project_config.get("features") or {}).get("definitions") or []
+    )
+
+    return {
+        "project": {
+            "name": (project_config.get("project") or {}).get("name"),
+            "profile": (project_config.get("project") or {}).get("profile"),
+        },
+        "data": {
+            "symbols": list(data_cfg.get("symbols") or []),
+            "timeframe": data_cfg.get("timeframe"),
+            "start_date": data_cfg.get("start_date"),
+            "end_date": data_cfg.get("end_date"),
+            "test_start": data_cfg.get("test_start"),
+            "test_end": data_cfg.get("test_end"),
+        },
+        "features": {
+            "definitions": [
+                item.get("name") for item in feature_definitions if item.get("name")
+            ]
+        },
+        "labels": dict(research_cfg.get("labels") or {}),
+        "model": {
+            "kind": (research_cfg.get("model") or {}).get("kind"),
+            "family": (research_cfg.get("model") or {}).get("family"),
+            "tuning": dict(((research_cfg.get("model") or {}).get("tuning") or {})),
+        },
+        "evaluation": dict(research_cfg.get("evaluation") or {}),
+        "backtest_costs": dict(
+            ((research_cfg.get("backtest") or {}).get("costs") or {})
+        ),
+    }
+
+
+def _find_agent_config(
+    *,
+    project_config: dict[str, Any],
+    agent_name: str,
+) -> dict[str, Any]:
+    for agent in project_config.get("agents") or []:
+        if isinstance(agent, dict) and agent.get("name") == agent_name:
+            return dict(agent)
+    raise ValueError(
+        f"Resolved project config does not contain compared agent '{agent_name}'."
+    )
+
+
+def _extract_agent_view(
+    project_config: dict[str, Any],
+    *,
+    family: str,
+    agent_name: str,
+) -> dict[str, Any]:
+    data_cfg = dict(project_config.get("data") or {})
+    streaming_cfg = dict(data_cfg.get("streaming") or {})
+    agent_cfg = _find_agent_config(project_config=project_config, agent_name=agent_name)
+    context_cfg = dict(agent_cfg.get("context") or {})
+
+    view: dict[str, Any] = {
+        "project": {
+            "name": (project_config.get("project") or {}).get("name"),
+            "profile": (project_config.get("project") or {}).get("profile"),
+        },
+        "data": {
+            "symbols": list(data_cfg.get("symbols") or []),
+            "timeframe": data_cfg.get("timeframe"),
+            "start_date": data_cfg.get("start_date"),
+            "end_date": data_cfg.get("end_date"),
+            "test_start": data_cfg.get("test_start"),
+            "test_end": data_cfg.get("test_end"),
+        },
+        "agent": {
+            "name": agent_cfg.get("name"),
+            "kind": agent_cfg.get("kind"),
+            "mode": agent_cfg.get("mode"),
+            "tools": list(agent_cfg.get("tools") or []),
+            "context": _normalize_context(context_cfg),
+            "risk": dict(agent_cfg.get("risk") or {}),
+        },
+    }
+
+    if agent_cfg.get("kind") == "rule":
+        view["agent"]["rule"] = dict(agent_cfg.get("rule") or {})
+    if agent_cfg.get("kind") == "model":
+        view["agent"]["model"] = dict(agent_cfg.get("model") or {})
+    if agent_cfg.get("kind") in {"llm", "hybrid"}:
+        llm_cfg = dict(agent_cfg.get("llm") or {})
+        view["agent"]["llm"] = {
+            "provider": llm_cfg.get("provider"),
+            "model": llm_cfg.get("model"),
+            "prompt_file": llm_cfg.get("prompt_file"),
+        }
+    if agent_cfg.get("kind") == "hybrid":
+        view["agent"]["model_signal_sources"] = list(
+            agent_cfg.get("model_signal_sources") or []
+        )
+
+    if family == "agent/paper":
+        replay_window = resolve_paper_replay_window(project_config)
+        view["paper"] = {
+            "source": "replay" if replay_window is not None else "realtime",
+            "streaming": {
+                "provider": streaming_cfg.get("provider"),
+                "symbols": list(streaming_cfg.get("symbols") or []),
+                "channels": list(streaming_cfg.get("channels") or []),
+                "auth_method": streaming_cfg.get("auth_method"),
+            },
+            "replay_window": (
+                {
+                    "start_date": replay_window.start_date,
+                    "end_date": replay_window.end_date,
+                    "pace_delay_ms": replay_window.pace_delay_ms,
+                }
+                if replay_window is not None
+                else None
+            ),
+        }
+
+    if family == "agent/live":
+        view["live"] = {
+            "streaming": {
+                "provider": streaming_cfg.get("provider"),
+                "symbols": list(streaming_cfg.get("symbols") or []),
+                "channels": list(streaming_cfg.get("channels") or []),
+                "auth_method": streaming_cfg.get("auth_method"),
+            },
+            "risk": dict(project_config.get("risk") or {}),
+            "position_manager": dict(project_config.get("position_manager") or {}),
+        }
+
+    return view
+
+
+def _extract_config_view(
+    *,
+    family: str,
+    record: dict[str, Any],
+    summary: dict[str, Any],
+    project_config: dict[str, Any],
+) -> dict[str, Any]:
+    if family == "research":
+        return _extract_research_view(project_config)
+
+    agent_name = str(
+        summary.get("agent_name") or summary.get("name") or record.get("name") or ""
+    ).strip()
+    if not agent_name:
+        raise ValueError("Compared agent run is missing an agent name.")
+    return _extract_agent_view(project_config, family=family, agent_name=agent_name)
+
+
+def _flatten_view(
+    value: Any,
+    *,
+    prefix: str = "",
+) -> dict[str, Any]:
+    flattened: dict[str, Any] = {}
+    if isinstance(value, dict):
+        if not value and prefix:
+            flattened[prefix] = {}
+            return flattened
+        for key in sorted(value):
+            next_prefix = f"{prefix}.{key}" if prefix else str(key)
+            flattened.update(_flatten_view(value[key], prefix=next_prefix))
+        return flattened
+
+    flattened[prefix] = value
+    return flattened
+
+
+def _diff_config_views(run_entries: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    flattened_views = {
+        entry["run_id"]: _flatten_view(entry["config_view"]) for entry in run_entries
+    }
+    fields = sorted(
+        {field for flattened in flattened_views.values() for field in flattened.keys()}
+    )
+
+    differences: dict[str, dict[str, Any]] = {}
+    for field in fields:
+        values_by_run = {
+            entry["run_id"]: flattened_views[entry["run_id"]].get(field)
+            for entry in run_entries
+        }
+        unique_values = list(values_by_run.values())
+        if unique_values[1:] and any(
+            value != unique_values[0] for value in unique_values[1:]
+        ):
+            differences[field] = values_by_run
+    return differences
+
+
+def build_run_comparison(
+    *,
+    run_ids: list[str],
+    sort_by: str = "started_at",
+    ascending: bool = False,
+    runs_root: Path | str = RUNS_ROOT,
+) -> dict[str, Any]:
+    """Return a stable comparison payload for explicit run ids."""
+
+    _ensure_compare_candidates(run_ids)
+    records = _resolve_compare_records(run_ids=run_ids, runs_root=runs_root)
+    enriched_records = attach_scoreboard(records)
+
+    run_families = {_run_family(record) for record in enriched_records}
+    if len(run_families) != 1:
+        raise ValueError(
+            "Compare mode requires runs from the same family only. Use `quanttradeai runs list --scoreboard` to rank mixed runs first."
+        )
+    run_family = run_families.pop()
+    if run_family not in RUN_FAMILY_METRICS:
+        raise ValueError(f"Compare mode does not support run family: {run_family}")
+
+    enriched_records = sort_run_records(
+        enriched_records,
+        sort_by=sort_by,
+        ascending=ascending,
+    )
+
+    runs: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for record in enriched_records:
+        summary_path = _resolve_run_artifact_path(
+            record,
+            artifact_key="summary",
+            default_filename="summary.json",
+        )
+        metrics_path = _resolve_run_artifact_path(
+            record,
+            artifact_key="metrics",
+            default_filename="metrics.json",
+        )
+        config_path = _resolve_run_artifact_path(
+            record,
+            artifact_key="resolved_project_config",
+            default_filename="resolved_project_config.yaml",
+        )
+
+        summary_payload = _load_json_mapping(summary_path, label="summary.json")
+        _load_json_mapping(metrics_path, label="metrics.json")
+        project_config = _load_yaml_mapping(
+            config_path,
+            label="resolved_project_config.yaml",
+        )
+        scoreboard = dict(record.get("scoreboard") or {})
+        if scoreboard.get("error"):
+            warnings.append(f"{record['run_id']}: {scoreboard['error']}")
+
+        run_entry = {
+            "run_id": record.get("run_id"),
+            "run_type": record.get("run_type"),
+            "mode": record.get("mode"),
+            "name": record.get("name"),
+            "status": record.get("status"),
+            "symbols": list(record.get("symbols") or []),
+            "timestamps": dict(record.get("timestamps") or {}),
+            "artifacts": {
+                "summary": str(summary_path),
+                "metrics": str(metrics_path),
+                "resolved_project_config": str(config_path),
+            },
+            "warnings": list(record.get("warnings") or []),
+            "scoreboard": scoreboard,
+            "config_view": _extract_config_view(
+                family=run_family,
+                record=record,
+                summary=summary_payload,
+                project_config=project_config,
+            ),
+        }
+        warnings.extend(run_entry["warnings"])
+        runs.append(run_entry)
+
+    metric_columns = list(RUN_FAMILY_METRICS[run_family])
+    rows = [
+        {
+            "run_id": run["run_id"],
+            "name": run["name"],
+            "status": run["status"],
+            "started_at": (run.get("timestamps") or {}).get("started_at"),
+            "symbols": list(run.get("symbols") or []),
+            "metrics": {
+                metric_name: (run.get("scoreboard") or {}).get(metric_name)
+                for metric_name in metric_columns
+            },
+        }
+        for run in runs
+    ]
+
+    return {
+        "kind": "run_comparison",
+        "run_family": run_family,
+        "runs": runs,
+        "metric_columns": metric_columns,
+        "rows": rows,
+        "config_differences": _diff_config_views(runs),
+        "warnings": list(dict.fromkeys(warnings)),
+    }
+
+
+def render_run_comparison(comparison: dict[str, Any]) -> str:
+    """Render a human-readable run comparison."""
+
+    runs = list(comparison.get("runs") or [])
+    lines = [
+        f"Run comparison: {comparison.get('run_family')}",
+        "",
+        "Metrics:",
+        render_scoreboard_table(runs),
+        "",
+        "Config differences:",
+    ]
+
+    config_differences = dict(comparison.get("config_differences") or {})
+    if not config_differences:
+        lines.append("- No config differences detected.")
+    else:
+        for field, values in config_differences.items():
+            lines.append(f"- {field}")
+            for run in runs:
+                run_id = str(run.get("run_id"))
+                lines.append(f"  {run_id}: {_render_value(values.get(run_id))}")
+
+    lines.extend(["", "Artifacts:"])
+    for run in runs:
+        lines.append(f"- {run.get('run_id')}")
+        for artifact_name, artifact_path in dict(run.get("artifacts") or {}).items():
+            lines.append(f"  {artifact_name}: {artifact_path}")
+
+    warnings = list(comparison.get("warnings") or [])
+    if warnings:
+        lines.extend(["", "Warnings:"])
+        for warning in warnings:
+            lines.append(f"- {warning}")
+
+    return "\n".join(lines)
+
+
+def _render_value(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, (dict, list, bool)):
+        return json.dumps(value, sort_keys=True)
+    return str(value)

--- a/roadmap.md
+++ b/roadmap.md
@@ -354,13 +354,14 @@ Status on 2026-04-10:
 Goal:
 Make running many agents and many experiments on one machine easy and trustworthy.
 
-Status on 2026-04-14:
+Status on 2026-04-17:
 
 - `quanttradeai runs list --scoreboard` is implemented for local research and agent runs, with metric-aware sorting via `--sort-by` and additive JSON scoreboard payloads.
+- `quanttradeai runs list --compare <run_id> --compare <run_id>` is implemented for same-family research and agent runs, loading `summary.json`, `metrics.json`, and `resolved_project_config.yaml` to show metric tables plus compact config deltas before promotion.
 - `quanttradeai agent run --all -c config/project.yaml --mode backtest` is implemented for local multi-agent backtest batches, with bounded concurrency, preserved child runs, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 - `quanttradeai agent run --all -c config/project.yaml --mode paper` is implemented for local multi-agent paper batches, reusing the existing replay-backed paper path, preserving child runs under `runs/agent/paper/...`, and writing batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 - `quanttradeai agent run --sweep <name> -c config/project.yaml --mode backtest` is implemented for backtest-only parameter sweeps defined under `sweeps:` in `config/project.yaml`, with deterministic variant expansion, preserved child runs, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
-- Live multi-agent orchestration and richer comparison workflows remain future Stage 2 work.
+- Live multi-agent orchestration remains future Stage 2 work.
 
 Deliverables:
 

--- a/tests/integration/test_runs_cli.py
+++ b/tests/integration/test_runs_cli.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import yaml
 from typer.testing import CliRunner
 
 from quanttradeai.cli import app
@@ -14,17 +15,142 @@ def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
+def _write_yaml(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
 def _write_run_bundle(
     root: Path,
     *,
     relative_dir: str,
     summary_payload: dict,
     metrics_payload: dict | None = None,
+    resolved_config_payload: dict | None = None,
 ) -> None:
     run_dir = root / Path(relative_dir)
-    _write_json(run_dir / "summary.json", summary_payload)
+    summary = dict(summary_payload)
+    if resolved_config_payload is not None:
+        artifacts = dict(summary.get("artifacts") or {})
+        artifacts.setdefault("resolved_project_config", "resolved_project_config.yaml")
+        summary["artifacts"] = artifacts
+        _write_yaml(run_dir / "resolved_project_config.yaml", resolved_config_payload)
+    _write_json(run_dir / "summary.json", summary)
     if metrics_payload is not None:
         _write_json(run_dir / "metrics.json", metrics_payload)
+
+
+def _research_project_config(
+    *,
+    timeframe: str = "1d",
+    horizon: int = 5,
+    feature_names: list[str] | None = None,
+    model_family: str = "voting",
+    trials: int = 50,
+    bps: int = 5,
+) -> dict:
+    return {
+        "project": {"name": "research_lab", "profile": "research"},
+        "profiles": {
+            "research": {"mode": "research"},
+            "paper": {"mode": "paper"},
+            "live": {"mode": "live"},
+        },
+        "data": {
+            "symbols": ["AAPL", "MSFT"],
+            "start_date": "2020-01-01",
+            "end_date": "2020-12-31",
+            "timeframe": timeframe,
+            "test_start": "2020-09-01",
+            "test_end": "2020-12-31",
+        },
+        "features": {
+            "definitions": [
+                {"name": name, "type": "technical", "params": {"period": 14}}
+                for name in (feature_names or ["rsi_14"])
+            ]
+        },
+        "research": {
+            "enabled": True,
+            "labels": {
+                "type": "forward_return",
+                "horizon": horizon,
+                "buy_threshold": 0.01,
+                "sell_threshold": -0.01,
+            },
+            "model": {
+                "kind": "classifier",
+                "family": model_family,
+                "tuning": {"enabled": True, "trials": trials},
+            },
+            "evaluation": {
+                "split": "time_aware",
+                "use_configured_test_window": True,
+            },
+            "backtest": {"costs": {"enabled": True, "bps": bps}},
+        },
+        "agents": [],
+        "deployment": {"target": "docker-compose", "mode": "paper"},
+    }
+
+
+def _agent_project_config(
+    *,
+    agent_name: str,
+    llm_model: str = "gpt-5.3",
+    max_position_pct: float = 0.05,
+    tools: list[str] | None = None,
+    context_features: list[str] | None = None,
+) -> dict:
+    return {
+        "project": {"name": "agent_lab", "profile": "paper"},
+        "profiles": {
+            "research": {"mode": "research"},
+            "paper": {"mode": "paper"},
+            "live": {"mode": "live"},
+        },
+        "data": {
+            "symbols": ["AAPL"],
+            "start_date": "2022-01-01",
+            "end_date": "2024-12-31",
+            "timeframe": "1d",
+            "test_start": "2024-09-01",
+            "test_end": "2024-12-31",
+        },
+        "features": {
+            "definitions": [
+                {"name": name, "type": "technical", "params": {"period": 14}}
+                for name in (context_features or ["rsi_14"])
+            ]
+        },
+        "research": {
+            "enabled": False,
+            "labels": {},
+            "model": {},
+            "evaluation": {},
+            "backtest": {},
+        },
+        "agents": [
+            {
+                "name": agent_name,
+                "kind": "llm",
+                "mode": "paper",
+                "llm": {
+                    "provider": "openai",
+                    "model": llm_model,
+                    "prompt_file": "prompts/breakout.md",
+                },
+                "context": {
+                    "features": list(context_features or ["rsi_14"]),
+                    "positions": True,
+                    "risk_state": True,
+                },
+                "tools": list(tools or ["get_quote", "place_order"]),
+                "risk": {"max_position_pct": max_position_pct},
+            }
+        ],
+        "deployment": {"target": "docker-compose", "mode": "paper"},
+    }
 
 
 def _seed_runs(root: Path) -> None:
@@ -548,7 +674,9 @@ def test_runs_list_ignores_batch_artifacts_without_child_run_summaries(
     runs_root = Path("runs")
     _seed_runs(runs_root)
 
-    batch_root = runs_root / "agent" / "batches" / "20260101_000000_multi_agent_backtest"
+    batch_root = (
+        runs_root / "agent" / "batches" / "20260101_000000_multi_agent_backtest"
+    )
     batch_root.mkdir(parents=True, exist_ok=True)
     (batch_root / "batch_manifest.json").write_text("{}", encoding="utf-8")
     (batch_root / "results.json").write_text("{}", encoding="utf-8")
@@ -560,3 +688,521 @@ def test_runs_list_ignores_batch_artifacts_without_child_run_summaries(
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
     assert all("batches" not in record["run_dir"] for record in payload)
+
+
+def test_runs_list_compare_renders_research_metrics_and_config_differences(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="research/20260101_000000_alpha",
+        summary_payload={
+            "run_type": "research",
+            "mode": "research",
+            "name": "alpha",
+            "project_name": "alpha",
+            "status": "success",
+            "symbols": ["AAPL", "MSFT"],
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "research/20260101_000000_alpha",
+            "run_dir": "runs/research/20260101_000000_alpha",
+        },
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.75, "f1": 0.55}},
+            "backtest_metrics_by_symbol": {
+                "AAPL": {"net_sharpe": 1.10, "net_pnl": 0.15}
+            },
+        },
+        resolved_config_payload=_research_project_config(
+            timeframe="1d",
+            horizon=5,
+            feature_names=["rsi_14"],
+        ),
+    )
+    _write_run_bundle(
+        runs_root,
+        relative_dir="research/20260102_000000_beta",
+        summary_payload={
+            "run_type": "research",
+            "mode": "research",
+            "name": "beta",
+            "project_name": "beta",
+            "status": "success",
+            "symbols": ["AAPL", "MSFT"],
+            "timestamps": {"started_at": "2026-01-02T00:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "research/20260102_000000_beta",
+            "run_dir": "runs/research/20260102_000000_beta",
+        },
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.82, "f1": 0.61}},
+            "backtest_metrics_by_symbol": {
+                "AAPL": {"net_sharpe": 1.40, "net_pnl": 0.22}
+            },
+        },
+        resolved_config_payload=_research_project_config(
+            timeframe="1h",
+            horizon=10,
+            feature_names=["rsi_14", "macd_fast"],
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "runs",
+            "list",
+            "--compare",
+            "research/20260101_000000_alpha",
+            "--compare",
+            "research/20260102_000000_beta",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Run comparison: research" in result.stdout
+    assert "Metrics:" in result.stdout
+    assert "ACC" in result.stdout
+    assert "NET_SHARPE" in result.stdout
+    assert "Config differences:" in result.stdout
+    assert "data.timeframe" in result.stdout
+    assert "labels.horizon" in result.stdout
+    assert "features.definitions" in result.stdout
+    assert "Artifacts:" in result.stdout
+    assert "resolved_project_config.yaml" in result.stdout
+
+
+def test_runs_list_compare_renders_agent_backtest_differences(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/backtest/20260101_010000_breakout_gpt",
+        summary_payload={
+            "run_type": "agent",
+            "mode": "backtest",
+            "name": "breakout_gpt",
+            "agent_name": "breakout_gpt",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "decision_count": 11,
+            "timestamps": {"started_at": "2026-01-01T01:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "agent/backtest/20260101_010000_breakout_gpt",
+            "run_dir": "runs/agent/backtest/20260101_010000_breakout_gpt",
+        },
+        metrics_payload={
+            "net_sharpe": 1.25,
+            "net_pnl": 0.18,
+            "net_mdd": -0.07,
+        },
+        resolved_config_payload=_agent_project_config(
+            agent_name="breakout_gpt",
+            llm_model="gpt-5.3",
+            max_position_pct=0.05,
+            tools=["get_quote", "place_order"],
+            context_features=["rsi_14"],
+        ),
+    )
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/backtest/20260102_010000_breakout_gpt_alt",
+        summary_payload={
+            "run_type": "agent",
+            "mode": "backtest",
+            "name": "breakout_gpt_alt",
+            "agent_name": "breakout_gpt_alt",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "decision_count": 9,
+            "timestamps": {"started_at": "2026-01-02T01:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "agent/backtest/20260102_010000_breakout_gpt_alt",
+            "run_dir": "runs/agent/backtest/20260102_010000_breakout_gpt_alt",
+        },
+        metrics_payload={
+            "net_sharpe": 1.55,
+            "net_pnl": 0.26,
+            "net_mdd": -0.05,
+        },
+        resolved_config_payload=_agent_project_config(
+            agent_name="breakout_gpt_alt",
+            llm_model="gpt-5.4",
+            max_position_pct=0.08,
+            tools=["get_quote", "get_position", "place_order"],
+            context_features=["rsi_14", "macd_fast"],
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "runs",
+            "list",
+            "--compare",
+            "agent/backtest/20260101_010000_breakout_gpt",
+            "--compare",
+            "agent/backtest/20260102_010000_breakout_gpt_alt",
+            "--sort-by",
+            "net_sharpe",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Run comparison: agent/backtest" in result.stdout
+    assert "NET_MDD" in result.stdout
+    assert "agent.llm.model" in result.stdout
+    assert "agent.risk.max_position_pct" in result.stdout
+    assert "agent.tools" in result.stdout
+
+
+def test_runs_list_compare_json_returns_stable_shape(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="research/20260101_000000_alpha",
+        summary_payload={
+            "run_type": "research",
+            "mode": "research",
+            "name": "alpha",
+            "project_name": "alpha",
+            "status": "success",
+            "symbols": ["AAPL", "MSFT"],
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "research/20260101_000000_alpha",
+            "run_dir": "runs/research/20260101_000000_alpha",
+        },
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.75, "f1": 0.55}},
+            "backtest_metrics_by_symbol": {
+                "AAPL": {"net_sharpe": 1.10, "net_pnl": 0.15}
+            },
+        },
+        resolved_config_payload=_research_project_config(),
+    )
+    _write_run_bundle(
+        runs_root,
+        relative_dir="research/20260102_000000_beta",
+        summary_payload={
+            "run_type": "research",
+            "mode": "research",
+            "name": "beta",
+            "project_name": "beta",
+            "status": "success",
+            "symbols": ["AAPL", "MSFT"],
+            "timestamps": {"started_at": "2026-01-02T00:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "research/20260102_000000_beta",
+            "run_dir": "runs/research/20260102_000000_beta",
+        },
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.82, "f1": 0.61}},
+            "backtest_metrics_by_symbol": {
+                "AAPL": {"net_sharpe": 1.40, "net_pnl": 0.22}
+            },
+        },
+        resolved_config_payload=_research_project_config(timeframe="1h", horizon=10),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "runs",
+            "list",
+            "--compare",
+            "research/20260101_000000_alpha",
+            "--compare",
+            "research/20260102_000000_beta",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "run_comparison"
+    assert payload["run_family"] == "research"
+    assert payload["metric_columns"] == ["accuracy", "f1", "net_sharpe", "net_pnl"]
+    assert len(payload["runs"]) == 2
+    assert len(payload["rows"]) == 2
+    assert "config_differences" in payload
+    assert "warnings" in payload
+    assert payload["rows"][0]["metrics"]["accuracy"] is not None
+
+
+def test_runs_list_compare_rejects_mixed_run_families(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="research/20260101_000000_alpha",
+        summary_payload={
+            "run_type": "research",
+            "mode": "research",
+            "name": "alpha",
+            "project_name": "alpha",
+            "status": "success",
+            "symbols": ["AAPL", "MSFT"],
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "research/20260101_000000_alpha",
+            "run_dir": "runs/research/20260101_000000_alpha",
+        },
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.75, "f1": 0.55}},
+            "backtest_metrics_by_symbol": {
+                "AAPL": {"net_sharpe": 1.10, "net_pnl": 0.15}
+            },
+        },
+        resolved_config_payload=_research_project_config(),
+    )
+    _write_run_bundle(
+        runs_root,
+        relative_dir="agent/backtest/20260101_010000_breakout_gpt",
+        summary_payload={
+            "run_type": "agent",
+            "mode": "backtest",
+            "name": "breakout_gpt",
+            "agent_name": "breakout_gpt",
+            "status": "success",
+            "symbols": ["AAPL"],
+            "decision_count": 11,
+            "timestamps": {"started_at": "2026-01-01T01:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "agent/backtest/20260101_010000_breakout_gpt",
+            "run_dir": "runs/agent/backtest/20260101_010000_breakout_gpt",
+        },
+        metrics_payload={
+            "net_sharpe": 1.25,
+            "net_pnl": 0.18,
+            "net_mdd": -0.07,
+        },
+        resolved_config_payload=_agent_project_config(agent_name="breakout_gpt"),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "runs",
+            "list",
+            "--compare",
+            "research/20260101_000000_alpha",
+            "--compare",
+            "agent/backtest/20260101_010000_breakout_gpt",
+        ],
+    )
+
+    assert result.exit_code == 1
+    combined = result.output
+    assert "same family only" in combined
+    assert "runs list --scoreboard" in combined
+
+
+def test_runs_list_compare_rejects_too_few_runs(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="research/20260101_000000_alpha",
+        summary_payload={
+            "run_type": "research",
+            "mode": "research",
+            "name": "alpha",
+            "project_name": "alpha",
+            "status": "success",
+            "symbols": ["AAPL", "MSFT"],
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "research/20260101_000000_alpha",
+            "run_dir": "runs/research/20260101_000000_alpha",
+        },
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.75, "f1": 0.55}},
+            "backtest_metrics_by_symbol": {
+                "AAPL": {"net_sharpe": 1.10, "net_pnl": 0.15}
+            },
+        },
+        resolved_config_payload=_research_project_config(),
+    )
+
+    result = runner.invoke(
+        app,
+        ["runs", "list", "--compare", "research/20260101_000000_alpha"],
+    )
+
+    assert result.exit_code == 1
+    combined = result.output
+    assert "at least two explicit --compare values" in combined
+
+
+def test_runs_list_compare_rejects_unknown_run_id(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    _write_run_bundle(
+        runs_root,
+        relative_dir="research/20260101_000000_alpha",
+        summary_payload={
+            "run_type": "research",
+            "mode": "research",
+            "name": "alpha",
+            "project_name": "alpha",
+            "status": "success",
+            "symbols": ["AAPL", "MSFT"],
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "artifacts": {},
+            "warnings": [],
+            "run_id": "research/20260101_000000_alpha",
+            "run_dir": "runs/research/20260101_000000_alpha",
+        },
+        metrics_payload={
+            "status": "available",
+            "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.75, "f1": 0.55}},
+            "backtest_metrics_by_symbol": {
+                "AAPL": {"net_sharpe": 1.10, "net_pnl": 0.15}
+            },
+        },
+        resolved_config_payload=_research_project_config(),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "runs",
+            "list",
+            "--compare",
+            "research/20260101_000000_alpha",
+            "--compare",
+            "research/does_not_exist",
+        ],
+    )
+
+    assert result.exit_code == 1
+    combined = result.output
+    assert "Run not found for compare" in combined
+
+
+def test_runs_list_compare_rejects_more_than_four_runs(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    for idx in range(1, 6):
+        run_id = f"research/2026010{idx}_000000_run_{idx}"
+        _write_run_bundle(
+            runs_root,
+            relative_dir=run_id,
+            summary_payload={
+                "run_type": "research",
+                "mode": "research",
+                "name": f"run_{idx}",
+                "project_name": f"run_{idx}",
+                "status": "success",
+                "symbols": ["AAPL", "MSFT"],
+                "timestamps": {"started_at": f"2026-01-0{idx}T00:00:00+00:00"},
+                "artifacts": {},
+                "warnings": [],
+                "run_id": run_id,
+                "run_dir": f"runs/{run_id}",
+            },
+            metrics_payload={
+                "status": "available",
+                "research_metrics_by_symbol": {
+                    "AAPL": {"accuracy": 0.70 + idx / 100.0, "f1": 0.50}
+                },
+                "backtest_metrics_by_symbol": {
+                    "AAPL": {"net_sharpe": 1.0 + idx / 10.0, "net_pnl": 0.10}
+                },
+            },
+            resolved_config_payload=_research_project_config(horizon=idx),
+        )
+
+    result = runner.invoke(
+        app,
+        [
+            "runs",
+            "list",
+            "--compare",
+            "research/20260101_000000_run_1",
+            "--compare",
+            "research/20260102_000000_run_2",
+            "--compare",
+            "research/20260103_000000_run_3",
+            "--compare",
+            "research/20260104_000000_run_4",
+            "--compare",
+            "research/20260105_000000_run_5",
+        ],
+    )
+
+    assert result.exit_code == 1
+    combined = result.output
+    assert "at most four explicit --compare values" in combined
+
+
+def test_runs_list_compare_rejects_filter_flags(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runs_root = Path("runs")
+    for idx in range(1, 3):
+        run_id = f"research/2026010{idx}_000000_run_{idx}"
+        _write_run_bundle(
+            runs_root,
+            relative_dir=run_id,
+            summary_payload={
+                "run_type": "research",
+                "mode": "research",
+                "name": f"run_{idx}",
+                "project_name": f"run_{idx}",
+                "status": "success",
+                "symbols": ["AAPL", "MSFT"],
+                "timestamps": {"started_at": f"2026-01-0{idx}T00:00:00+00:00"},
+                "artifacts": {},
+                "warnings": [],
+                "run_id": run_id,
+                "run_dir": f"runs/{run_id}",
+            },
+            metrics_payload={
+                "status": "available",
+                "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.75, "f1": 0.55}},
+                "backtest_metrics_by_symbol": {
+                    "AAPL": {"net_sharpe": 1.10, "net_pnl": 0.15}
+                },
+            },
+            resolved_config_payload=_research_project_config(horizon=idx),
+        )
+
+    result = runner.invoke(
+        app,
+        [
+            "runs",
+            "list",
+            "--type",
+            "research",
+            "--compare",
+            "research/20260101_000000_run_1",
+            "--compare",
+            "research/20260102_000000_run_2",
+        ],
+    )
+
+    assert result.exit_code != 0
+    combined = result.output
+    assert "Compare mode does not support --type" in combined


### PR DESCRIPTION
## Summary
- add artifact-backed run comparison support to `quanttradeai runs list` via repeated `--compare` flags
- load `summary.json`, `metrics.json`, and `resolved_project_config.yaml` to render same-family run metrics plus compact config deltas
- update integration coverage, docs, and roadmap status to reflect the new ranking-then-compare workflow

## Why
Stage 2 called for run listing, filtering, and comparison UX. The CLI already ranked runs with `--scoreboard`, but it did not let users inspect what materially changed between shortlisted runs before promotion.

## Impact
Users can now rank runs with `runs list --scoreboard` and then compare specific research or agent runs directly from the CLI without digging through artifacts manually.

## Validation
- `make lint.format.test`
- commit hooks: format, lint, test