### PR TITLE
feat: add alpaca-backed paper and live execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ If you prefer a package install, `pip install .` also works.
 
 Local `agent run --mode paper` now defaults to deterministic historical replay through `data.streaming.replay`. If you do not set explicit replay dates, QuantTradeAI uses `data.test_start` and `data.test_end`, then falls back to `data.start_date` and `data.end_date`.
 
+If you want real broker submission for happy-path paper or live runs, set `agents[].execution.backend: alpaca`. That switches execution from local simulated fills to Alpaca-backed market orders, requires real-time Alpaca streaming, and writes broker account and position snapshots into the run directory.
+
 ### Research In 4 Commands
 
 Use this if you want the simplest end-to-end quant workflow.
@@ -147,6 +149,8 @@ agents:
   - name: "rsi_reversion"
     kind: "rule"
     mode: "paper"
+    execution:
+      backend: "simulated"
     rule:
       preset: "rsi_threshold"
       feature: "rsi_14"
@@ -217,6 +221,8 @@ agents:
   - name: "breakout_gpt"
     kind: "llm"
     mode: "paper"
+    execution:
+      backend: "simulated"
     llm:
       provider: "openai"
       model: "gpt-5.3"
@@ -299,6 +305,8 @@ This writes a deployment bundle under `reports/deployments/<agent>/<timestamp>/`
 
 Paper bundles always disable replay in the emitted resolved project config and expect real-time streaming credentials. Local replay-backed paper runs stay unchanged in your source `config/project.yaml`.
 
+If the target agent uses `execution.backend: alpaca`, the generated bundle README and manifest call out that the service will submit real Alpaca paper/live market orders instead of simulated local fills.
+
 Live bundles keep the emitted replay settings unchanged, but they require all live safety prerequisites to already be configured in `config/project.yaml`:
 
 - the agent must already be set to `mode: live`
@@ -343,6 +351,8 @@ agents:
   - name: "paper_momentum"
     kind: "model"
     mode: "paper"
+    execution:
+      backend: "simulated"
     model:
       path: "models/promoted/aapl_daily_classifier"
 ```
@@ -355,8 +365,8 @@ For the full shape, field reference, and supported agent modes, see [Project YAM
 | --- | --- | --- |
 | Research | `runs/research/<timestamp>_<project>/` | `resolved_project_config.yaml`, runtime YAML snapshots, `summary.json`, `metrics.json`, backtest artifacts |
 | Agent backtest | `runs/agent/backtest/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, backtest files |
-| Agent paper | `runs/agent/paper/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime YAML snapshots, and `replay_manifest.json` when replay is enabled |
-| Agent live | `runs/agent/live/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime streaming/risk/position-manager YAML snapshots |
+| Agent paper | `runs/agent/paper/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime YAML snapshots, `replay_manifest.json` when replay is enabled, and broker snapshots when `execution.backend: alpaca` |
+| Agent live | `runs/agent/live/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime streaming/risk/position-manager YAML snapshots, and broker snapshots when `execution.backend: alpaca` |
 
 Sweep batch artifacts:
 

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -15,6 +15,8 @@ It drives:
 
 For local project-defined agents, `agent run --mode paper` defaults to deterministic replay when `data.streaming.replay.enabled: true`.
 
+If an agent sets `execution.backend: alpaca`, QuantTradeAI switches paper/live execution from local simulated fills to Alpaca-backed market orders. That happy path requires `data.streaming.enabled: true`, `data.streaming.provider: alpaca`, and a real-time paper/live run instead of replay-backed paper mode.
+
 ## Supported Project Workflows
 
 ### Research
@@ -212,6 +214,8 @@ agents:
   - name: "paper_momentum"
     kind: "model"
     mode: "paper"
+    execution:
+      backend: "simulated"
     model:
       path: "models/promoted/aapl_daily_classifier"
     context:
@@ -265,6 +269,8 @@ agents:
   - name: "rsi_reversion"
     kind: "rule"
     mode: "paper"
+    execution:
+      backend: "simulated"
     rule:
       preset: "rsi_threshold"
       feature: "rsi_14"
@@ -415,6 +421,29 @@ Even when `research.enabled` is `false`, the agent runtime still reuses these de
 
 ### `agents`
 
+Every agent can optionally define:
+
+- `execution.backend`
+
+Current execution backend support:
+
+- `simulated`: default local execution path for backtest, replay-backed paper, and existing live simulations
+- `alpaca`: real broker submission path for happy-path paper/live runs with Alpaca market data and broker credentials
+
+Validation rules for `execution.backend: alpaca`:
+
+- only supported when the agent itself is configured with `mode: paper` or `mode: live`
+- requires `data.streaming.enabled: true`
+- requires `data.streaming.provider: alpaca`
+- rejects replay-backed paper mode
+- warns during `validate` when `ALPACA_API_KEY` or `ALPACA_API_SECRET` are missing from the current environment
+
+Broker-backed paper/live runs add:
+
+- `summary.json` fields: `execution_backend`, `broker_provider`
+- enriched `executions.jsonl` records with broker order IDs, statuses, fill quantities, and fill timestamps
+- `broker_account_start.json`, `broker_account_end.json`, `broker_positions_start.json`, and `broker_positions_end.json`
+
 #### `rule` agents
 
 Required fields:
@@ -452,6 +481,7 @@ Paper mode:
 - evaluates the configured rule on each completed streaming bar
 - writes `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, and `runtime_streaming_config.yaml`
 - writes `replay_manifest.json` and records `paper_source: replay` in `summary.json` when replay is enabled
+- when `execution.backend: alpaca`, also writes broker account and position snapshots plus broker-enriched execution records
 - does not emit `prompt_samples.json`
 
 Live mode:
@@ -460,6 +490,7 @@ Live mode:
 - rejects `--skip-validation`
 - compiles `data.streaming`, top-level `risk`, and top-level `position_manager` into runtime YAML snapshots inside the run directory
 - writes `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, `runtime_streaming_config.yaml`, `runtime_risk_config.yaml`, and `runtime_position_manager_config.yaml`
+- when `execution.backend: alpaca`, also writes broker account and position snapshots plus broker-enriched execution records
 
 #### `model` agents
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,16 @@ pre-commit = "^4.2.0"
 pytest-asyncio = "^1.2.0"
 hypothesis = "^6.140.3"
 
+[tool.pytest.ini_options]
+norecursedirs = [
+    ".git",
+    ".venv",
+    ".pytest_cache",
+    "pytest-cache-files-*",
+    "tmp",
+    "tmp_*",
+]
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/quanttradeai/agents/context.py
+++ b/quanttradeai/agents/context.py
@@ -154,15 +154,24 @@ def _recent_execution_records(
     for record in reversed(execution_history or []):
         if symbol and record.get("symbol") != symbol:
             continue
-        items.append(
-            {
-                "timestamp": _serialize_scalar(record.get("timestamp")),
-                "action": record.get("action"),
-                "qty": _serialize_scalar(record.get("qty")),
-                "price": _serialize_scalar(record.get("price")),
-                "status": record.get("status") or record.get("execution_status"),
-            }
-        )
+        item = {
+            "timestamp": _serialize_scalar(record.get("timestamp")),
+            "action": record.get("action"),
+            "qty": _serialize_scalar(record.get("qty")),
+            "price": _serialize_scalar(record.get("price")),
+            "status": record.get("status") or record.get("execution_status"),
+        }
+        for key in (
+            "order_id",
+            "filled_qty",
+            "filled_avg_price",
+            "submitted_at",
+            "filled_at",
+            "broker_provider",
+        ):
+            if key in record and record.get(key) is not None:
+                item[key] = _serialize_scalar(record.get(key))
+        items.append(item)
         if len(items) >= max_entries:
             break
     return items
@@ -178,20 +187,34 @@ def _recent_decision_records(
     for record in reversed(decision_history or []):
         if symbol and record.get("symbol") != symbol:
             continue
-        items.append(
-            {
-                "timestamp": _serialize_scalar(record.get("timestamp")),
-                "action": record.get("action"),
-                "reason": record.get("reason"),
-                "execution_status": record.get("execution_status"),
-                "target_position_after": _serialize_scalar(
-                    record.get(
-                        "target_position_after",
-                        record.get("position_after", record.get("target_position")),
-                    )
-                ),
-            }
-        )
+        item = {
+            "timestamp": _serialize_scalar(record.get("timestamp")),
+            "action": record.get("action"),
+            "reason": record.get("reason"),
+            "execution_status": record.get("execution_status"),
+            "target_position_after": _serialize_scalar(
+                record.get(
+                    "target_position_after",
+                    record.get("position_after", record.get("target_position")),
+                )
+            ),
+        }
+        execution_payload = record.get("execution")
+        if isinstance(execution_payload, dict):
+            keys = [
+                "order_id",
+                "filled_qty",
+                "filled_avg_price",
+                "submitted_at",
+                "filled_at",
+                "broker_provider",
+            ]
+            if execution_payload.get("order_id") is not None:
+                keys.append("status")
+            for key in keys:
+                if key in execution_payload and execution_payload.get(key) is not None:
+                    item[key] = _serialize_scalar(execution_payload.get(key))
+        items.append(item)
         if len(items) >= max_entries:
             break
     return items

--- a/quanttradeai/agents/model_agent.py
+++ b/quanttradeai/agents/model_agent.py
@@ -12,6 +12,11 @@ from typing import Any
 import pandas as pd
 import yaml
 
+from quanttradeai.brokers import (
+    BrokerExecutionRuntime,
+    create_broker_client_for_agent,
+    resolve_execution_backend,
+)
 from quanttradeai.backtest.backtester import compute_metrics, simulate_trades
 from quanttradeai.data.loader import DataLoader
 from quanttradeai.data.processor import DataProcessor
@@ -515,7 +520,11 @@ def _streaming_metrics(engine: LiveTradingEngine) -> dict[str, Any]:
         "cash": engine.portfolio.cash,
         "portfolio_value": portfolio_value,
         "open_positions": positions,
+        "execution_backend": getattr(engine, "execution_backend", "simulated"),
     }
+    broker_provider = getattr(engine, "broker_provider", None)
+    if broker_provider:
+        payload["broker_provider"] = broker_provider
     risk_manager = getattr(engine, "risk_manager", None)
     if risk_manager is not None:
         try:
@@ -636,6 +645,7 @@ def _run_model_agent_streaming(
             max_risk_per_trade,
             max_portfolio_risk,
         ) = _resolve_risk_settings(agent_config, model_cfg)
+        execution_backend = resolve_execution_backend(agent_config)
         gateway: ReplayGateway | None = None
         bootstrap_history_frames: dict[str, pd.DataFrame] | None = None
         paper_source = "realtime"
@@ -661,6 +671,11 @@ def _run_model_agent_streaming(
             artifacts["replay_manifest"] = str(replay_manifest_path)
             paper_source = "replay"
 
+        broker_client = create_broker_client_for_agent(
+            agent_config,
+            mode=mode,
+        )
+
         engine = LiveTradingEngine(
             model_config=str(runtime_model_path),
             model_path=str(model_path),
@@ -678,7 +693,15 @@ def _run_model_agent_streaming(
             stop_loss_pct=stop_loss_pct,
             gateway=gateway,
             bootstrap_history_frames=bootstrap_history_frames,
+            execution_backend=execution_backend,
         )
+        if broker_client is not None:
+            engine.broker_runtime = BrokerExecutionRuntime(
+                broker_client=broker_client,
+                portfolio=engine.portfolio,
+                position_manager=engine.position_manager,
+                stop_loss_pct=stop_loss_pct,
+            )
         asyncio.run(engine.start())
 
         decision_records = _model_decision_records_from_engine(engine)
@@ -696,6 +719,36 @@ def _run_model_agent_streaming(
         }
         if decision_records:
             artifacts["decisions"] = str(run_dir / "decisions.jsonl")
+        broker_runtime = getattr(engine, "broker_runtime", None)
+        if broker_runtime is not None:
+            broker_account_start_path = run_dir / "broker_account_start.json"
+            broker_account_end_path = run_dir / "broker_account_end.json"
+            broker_positions_start_path = run_dir / "broker_positions_start.json"
+            broker_positions_end_path = run_dir / "broker_positions_end.json"
+            _write_json(
+                broker_account_start_path,
+                broker_runtime.start_account or {},
+            )
+            _write_json(
+                broker_account_end_path,
+                broker_runtime.end_account or {},
+            )
+            _write_json(
+                broker_positions_start_path,
+                broker_runtime.start_positions or [],
+            )
+            _write_json(
+                broker_positions_end_path,
+                broker_runtime.end_positions or [],
+            )
+            artifacts.update(
+                {
+                    "broker_account_start": str(broker_account_start_path),
+                    "broker_account_end": str(broker_account_end_path),
+                    "broker_positions_start": str(broker_positions_start_path),
+                    "broker_positions_end": str(broker_positions_end_path),
+                }
+            )
         summary.update(
             {
                 "status": "success",
@@ -710,6 +763,8 @@ def _run_model_agent_streaming(
                 ),
                 "decision_count": len(decision_records),
                 "execution_count": len(engine.execution_log),
+                "execution_backend": execution_backend,
+                "broker_provider": getattr(engine, "broker_provider", None),
                 "artifacts": artifacts,
                 "metrics": metrics_payload,
             }

--- a/quanttradeai/agents/paper.py
+++ b/quanttradeai/agents/paper.py
@@ -14,6 +14,11 @@ from typing import Any
 import pandas as pd
 import yaml
 
+from quanttradeai.brokers import (
+    BrokerExecutionRuntime,
+    create_broker_client_for_agent,
+    resolve_execution_backend,
+)
 from quanttradeai.data.loader import DataLoader
 from quanttradeai.data.processor import DataProcessor
 from quanttradeai.streaming.gateway import StreamingGateway
@@ -284,6 +289,8 @@ class PaperAgentEngine:
     history_window: int = 512
     shutdown_drain_timeout: float = 0.5
     prompt_sample_limit: int = PROMPT_SAMPLE_LIMIT
+    execution_backend: str = "simulated"
+    broker_runtime: BrokerExecutionRuntime | None = None
     _consumer: asyncio.Task | None = field(default=None, init=False)
     _history: dict[str, pd.DataFrame] = field(default_factory=dict, init=False)
     _states: dict[str, AgentSimulationState] = field(default_factory=dict, init=False)
@@ -338,6 +345,12 @@ class PaperAgentEngine:
         self.configured_symbols = list(
             (runtime_model.get("data") or {}).get("symbols") or []
         )
+
+    @property
+    def broker_provider(self) -> str | None:
+        if self.broker_runtime is None:
+            return None
+        return self.broker_runtime.provider
 
     def _extract_timestamp(self, message: dict[str, Any]) -> pd.Timestamp:
         ts = (
@@ -624,6 +637,32 @@ class PaperAgentEngine:
         execution_status = "hold"
         execution_payload: dict[str, Any] | None = None
 
+        if self.broker_runtime is not None and decision.action in {"buy", "sell"}:
+            execution_status, execution_payload = self.broker_runtime.execute_action(
+                symbol=symbol,
+                action=decision.action,
+                price=price,
+                timestamp=timestamp.to_pydatetime(),
+                extra={"decision_action": decision.action},
+            )
+            if execution_payload is not None:
+                self.execution_log.append(execution_payload)
+            self._mark_to_market(symbol, price, timestamp=timestamp)
+            position_after = 1 if symbol in self.portfolio.positions else 0
+            state = self._states.setdefault(symbol, AgentSimulationState())
+            state.target_position = position_after
+            state.last_action = decision.action
+            state.last_reason = decision.reason
+            state.decision_count += 1
+            return {
+                "desired_target_position": desired_target,
+                "target_position": position_after,
+                "position_before": position_before,
+                "position_after": position_after,
+                "execution_status": execution_status,
+                "execution": execution_payload,
+            }
+
         if decision.action == "buy":
             if had_position:
                 execution_status = "already_long"
@@ -830,6 +869,8 @@ class PaperAgentEngine:
                 logger.error("paper_agent_error", exc_info=exc)
 
     async def start(self) -> None:
+        if self.broker_runtime is not None:
+            self.broker_runtime.start_session()
         self.bootstrap_history()
         self._consumer = asyncio.create_task(self._consume_buffer())
         completed_via_signal = False
@@ -857,6 +898,8 @@ class PaperAgentEngine:
                 self._consumer.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await self._consumer
+            if self.broker_runtime is not None:
+                self.broker_runtime.finish_session()
 
 
 def run_agent_paper(
@@ -959,6 +1002,7 @@ def _run_agent_streaming(
             raise ValueError(
                 f"Agent '{agent_name}' is kind={agent_config.get('kind')}; expected kind=rule, kind=llm, or kind=hybrid."
             )
+        execution_backend = resolve_execution_backend(agent_config)
         if (
             mode == "live"
             and str(agent_config.get("mode") or "").strip().lower() != "live"
@@ -1087,6 +1131,11 @@ def _run_agent_streaming(
             artifacts["replay_manifest"] = str(replay_manifest_path)
             paper_source = "replay"
 
+        broker_client = create_broker_client_for_agent(
+            agent_config,
+            mode=mode,
+        )
+
         engine = PaperAgentEngine(
             project_config_path=project_config_path,
             agent_config=agent_config,
@@ -1112,7 +1161,15 @@ def _run_agent_streaming(
             max_portfolio_risk=max_portfolio_risk,
             stop_loss_pct=stop_loss_pct,
             history_window=history_window,
+            execution_backend=execution_backend,
         )
+        if broker_client is not None:
+            engine.broker_runtime = BrokerExecutionRuntime(
+                broker_client=broker_client,
+                portfolio=engine.portfolio,
+                position_manager=engine.position_manager,
+                stop_loss_pct=stop_loss_pct,
+            )
         asyncio.run(engine.start())
 
         _write_jsonl(run_dir / "decisions.jsonl", engine.decision_log)
@@ -1122,6 +1179,9 @@ def _run_agent_streaming(
             engine.execution_log,
             risk_manager=engine.risk_manager,
         )
+        metrics_payload["execution_backend"] = execution_backend
+        if engine.broker_provider:
+            metrics_payload["broker_provider"] = engine.broker_provider
         metrics_payload["decision_count"] = len(engine.decision_log)
         _write_json(run_dir / "metrics.json", metrics_payload)
 
@@ -1134,6 +1194,35 @@ def _run_agent_streaming(
         if engine.include_prompt_artifacts:
             _write_json(run_dir / "prompt_samples.json", engine.prompt_samples)
             artifacts["prompt_samples"] = str(run_dir / "prompt_samples.json")
+        if engine.broker_runtime is not None:
+            broker_account_start_path = run_dir / "broker_account_start.json"
+            broker_account_end_path = run_dir / "broker_account_end.json"
+            broker_positions_start_path = run_dir / "broker_positions_start.json"
+            broker_positions_end_path = run_dir / "broker_positions_end.json"
+            _write_json(
+                broker_account_start_path,
+                engine.broker_runtime.start_account or {},
+            )
+            _write_json(
+                broker_account_end_path,
+                engine.broker_runtime.end_account or {},
+            )
+            _write_json(
+                broker_positions_start_path,
+                engine.broker_runtime.start_positions or [],
+            )
+            _write_json(
+                broker_positions_end_path,
+                engine.broker_runtime.end_positions or [],
+            )
+            artifacts.update(
+                {
+                    "broker_account_start": str(broker_account_start_path),
+                    "broker_account_end": str(broker_account_end_path),
+                    "broker_positions_start": str(broker_positions_start_path),
+                    "broker_positions_end": str(broker_positions_end_path),
+                }
+            )
         summary.update(
             {
                 "status": "success",
@@ -1145,6 +1234,8 @@ def _run_agent_streaming(
                 ),
                 "decision_count": len(engine.decision_log),
                 "execution_count": len(engine.execution_log),
+                "execution_backend": execution_backend,
+                "broker_provider": engine.broker_provider,
                 "artifacts": artifacts,
                 "metrics": metrics_payload,
             }

--- a/quanttradeai/brokers/__init__.py
+++ b/quanttradeai/brokers/__init__.py
@@ -1,0 +1,29 @@
+"""Broker execution helpers."""
+
+from .alpaca import AlpacaBrokerClient
+from .base import (
+    BrokerAccountSnapshot,
+    BrokerClient,
+    BrokerCredentialsError,
+    BrokerError,
+    BrokerOrderResult,
+    BrokerPositionSnapshot,
+)
+from .runtime import (
+    BrokerExecutionRuntime,
+    create_broker_client_for_agent,
+    resolve_execution_backend,
+)
+
+__all__ = [
+    "AlpacaBrokerClient",
+    "BrokerAccountSnapshot",
+    "BrokerClient",
+    "BrokerCredentialsError",
+    "BrokerError",
+    "BrokerExecutionRuntime",
+    "BrokerOrderResult",
+    "BrokerPositionSnapshot",
+    "create_broker_client_for_agent",
+    "resolve_execution_backend",
+]

--- a/quanttradeai/brokers/alpaca.py
+++ b/quanttradeai/brokers/alpaca.py
@@ -1,0 +1,220 @@
+"""Alpaca REST broker implementation for paper and live execution."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any
+from urllib import error, request
+
+from .base import (
+    BrokerAccountSnapshot,
+    BrokerClient,
+    BrokerCredentialsError,
+    BrokerError,
+    BrokerOrderResult,
+    BrokerPositionSnapshot,
+    _safe_float,
+    _safe_int,
+)
+
+ALPACA_PAPER_BASE_URL = "https://paper-api.alpaca.markets"
+ALPACA_LIVE_BASE_URL = "https://api.alpaca.markets"
+ALPACA_TERMINAL_ORDER_STATUSES = {
+    "filled",
+    "canceled",
+    "expired",
+    "rejected",
+    "done_for_day",
+    "stopped",
+    "suspended",
+    "calculated",
+}
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    normalized = raw.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+class AlpacaBrokerClient(BrokerClient):
+    """Happy-path Alpaca trading client using REST polling only."""
+
+    provider = "alpaca"
+
+    def __init__(
+        self,
+        *,
+        mode: str = "paper",
+        api_key: str | None = None,
+        api_secret: str | None = None,
+        base_url: str | None = None,
+        request_timeout: float = 10.0,
+        poll_interval: float = 0.5,
+        order_timeout: float = 15.0,
+    ) -> None:
+        self.mode = str(mode or "paper").strip().lower()
+        self.api_key = str(api_key or os.environ.get("ALPACA_API_KEY") or "").strip()
+        self.api_secret = str(
+            api_secret or os.environ.get("ALPACA_API_SECRET") or ""
+        ).strip()
+        if not self.api_key or not self.api_secret:
+            raise BrokerCredentialsError(
+                "ALPACA_API_KEY and ALPACA_API_SECRET are required for Alpaca-backed execution."
+            )
+
+        if base_url:
+            self.base_url = base_url.rstrip("/")
+        elif self.mode == "live":
+            self.base_url = ALPACA_LIVE_BASE_URL
+        else:
+            self.base_url = ALPACA_PAPER_BASE_URL
+
+        self.request_timeout = float(request_timeout)
+        self.poll_interval = float(poll_interval)
+        self.order_timeout = float(order_timeout)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        url = f"{self.base_url}{path}"
+        data = None
+        headers = {
+            "APCA-API-KEY-ID": self.api_key,
+            "APCA-API-SECRET-KEY": self.api_secret,
+            "Accept": "application/json",
+        }
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+            data = json.dumps(payload).encode("utf-8")
+
+        req = request.Request(url, method=method.upper(), data=data, headers=headers)
+        try:
+            with request.urlopen(req, timeout=self.request_timeout) as response:
+                body = response.read().decode("utf-8")
+        except error.HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="ignore")
+            raise BrokerError(
+                f"Alpaca request failed: {method.upper()} {path} returned {exc.code}: {details or exc.reason}"
+            ) from exc
+        except error.URLError as exc:
+            raise BrokerError(f"Alpaca request failed: {exc.reason}") from exc
+
+        if not body.strip():
+            return {}
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise BrokerError(
+                f"Alpaca returned invalid JSON for {method.upper()} {path}."
+            ) from exc
+
+    def _parse_account(self, payload: dict[str, Any]) -> BrokerAccountSnapshot:
+        return BrokerAccountSnapshot(
+            account_id=str(payload.get("id") or ""),
+            cash=_safe_float(payload.get("cash"), 0.0),
+            equity=_safe_float(payload.get("equity"), 0.0),
+            buying_power=_safe_float(payload.get("buying_power"), 0.0),
+            currency=str(payload.get("currency") or "USD"),
+            status=str(payload.get("status") or ""),
+            raw=dict(payload),
+        )
+
+    def _parse_position(self, payload: dict[str, Any]) -> BrokerPositionSnapshot:
+        return BrokerPositionSnapshot(
+            symbol=str(payload.get("symbol") or ""),
+            qty=abs(_safe_int(payload.get("qty"), 0)),
+            market_price=_safe_float(payload.get("current_price"), 0.0),
+            avg_entry_price=_safe_float(payload.get("avg_entry_price"), 0.0),
+            side=str(payload.get("side") or "long"),
+            unrealized_pnl=_safe_float(payload.get("unrealized_pl"), 0.0),
+            raw=dict(payload),
+        )
+
+    def _parse_order(self, payload: dict[str, Any]) -> BrokerOrderResult:
+        return BrokerOrderResult(
+            order_id=str(payload.get("id") or ""),
+            symbol=str(payload.get("symbol") or ""),
+            action=str(payload.get("side") or ""),
+            qty=abs(_safe_int(payload.get("qty"), 0)),
+            status=str(payload.get("status") or ""),
+            submitted_at=_parse_timestamp(payload.get("submitted_at")),
+            filled_at=_parse_timestamp(payload.get("filled_at")),
+            filled_qty=abs(_safe_int(payload.get("filled_qty"), 0)),
+            filled_avg_price=(
+                _safe_float(payload.get("filled_avg_price"), 0.0)
+                if payload.get("filled_avg_price") not in (None, "")
+                else None
+            ),
+            raw=dict(payload),
+        )
+
+    def get_account(self) -> BrokerAccountSnapshot:
+        payload = self._request("GET", "/v2/account")
+        return self._parse_account(dict(payload or {}))
+
+    def list_positions(self) -> list[BrokerPositionSnapshot]:
+        payload = self._request("GET", "/v2/positions")
+        return [
+            self._parse_position(dict(item or {}))
+            for item in list(payload or [])
+            if dict(item or {}).get("symbol")
+        ]
+
+    def submit_market_order(
+        self,
+        *,
+        symbol: str,
+        action: str,
+        qty: int,
+    ) -> BrokerOrderResult:
+        payload = self._request(
+            "POST",
+            "/v2/orders",
+            payload={
+                "symbol": symbol,
+                "qty": str(int(qty)),
+                "side": str(action).strip().lower(),
+                "type": "market",
+                "time_in_force": "day",
+            },
+        )
+        return self._parse_order(dict(payload or {}))
+
+    def get_order(self, order_id: str) -> BrokerOrderResult:
+        payload = self._request("GET", f"/v2/orders/{order_id}")
+        return self._parse_order(dict(payload or {}))
+
+    def wait_for_order(
+        self,
+        order_id: str,
+        *,
+        poll_interval: float | None = None,
+        timeout: float | None = None,
+    ) -> BrokerOrderResult:
+        interval = self.poll_interval if poll_interval is None else float(poll_interval)
+        deadline = time.monotonic() + (
+            self.order_timeout if timeout is None else float(timeout)
+        )
+        latest = self.get_order(order_id)
+        while latest.status not in ALPACA_TERMINAL_ORDER_STATUSES:
+            if time.monotonic() >= deadline:
+                return latest
+            time.sleep(max(interval, 0.0))
+            latest = self.get_order(order_id)
+        return latest

--- a/quanttradeai/brokers/base.py
+++ b/quanttradeai/brokers/base.py
@@ -1,0 +1,141 @@
+"""Broker abstractions used by real-time agent execution backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _serialize_timestamp(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+@dataclass(frozen=True)
+class BrokerAccountSnapshot:
+    account_id: str
+    cash: float
+    equity: float
+    buying_power: float
+    currency: str = "USD"
+    status: str = ""
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "account_id": self.account_id,
+            "cash": self.cash,
+            "equity": self.equity,
+            "buying_power": self.buying_power,
+            "currency": self.currency,
+            "status": self.status,
+        }
+
+
+@dataclass(frozen=True)
+class BrokerPositionSnapshot:
+    symbol: str
+    qty: int
+    market_price: float
+    avg_entry_price: float
+    side: str = "long"
+    unrealized_pnl: float = 0.0
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "qty": self.qty,
+            "market_price": self.market_price,
+            "avg_entry_price": self.avg_entry_price,
+            "side": self.side,
+            "unrealized_pnl": self.unrealized_pnl,
+        }
+
+
+@dataclass(frozen=True)
+class BrokerOrderResult:
+    order_id: str
+    symbol: str
+    action: str
+    qty: int
+    status: str
+    submitted_at: datetime | None = None
+    filled_at: datetime | None = None
+    filled_qty: int = 0
+    filled_avg_price: float | None = None
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "order_id": self.order_id,
+            "symbol": self.symbol,
+            "action": self.action,
+            "qty": self.qty,
+            "status": self.status,
+            "submitted_at": _serialize_timestamp(self.submitted_at),
+            "filled_at": _serialize_timestamp(self.filled_at),
+            "filled_qty": self.filled_qty,
+            "filled_avg_price": self.filled_avg_price,
+        }
+
+
+class BrokerError(RuntimeError):
+    """Raised when a broker request or state sync fails."""
+
+
+class BrokerCredentialsError(BrokerError):
+    """Raised when required broker credentials are missing."""
+
+
+class BrokerClient(ABC):
+    """Provider-agnostic broker interface."""
+
+    provider: str = "unknown"
+
+    @abstractmethod
+    def get_account(self) -> BrokerAccountSnapshot:
+        """Return the latest broker account snapshot."""
+
+    @abstractmethod
+    def list_positions(self) -> list[BrokerPositionSnapshot]:
+        """Return the latest open positions."""
+
+    @abstractmethod
+    def submit_market_order(
+        self,
+        *,
+        symbol: str,
+        action: str,
+        qty: int,
+    ) -> BrokerOrderResult:
+        """Submit a market order and return the broker's immediate response."""
+
+    @abstractmethod
+    def get_order(self, order_id: str) -> BrokerOrderResult:
+        """Fetch a broker order by id."""
+
+    @abstractmethod
+    def wait_for_order(
+        self,
+        order_id: str,
+        *,
+        poll_interval: float | None = None,
+        timeout: float | None = None,
+    ) -> BrokerOrderResult:
+        """Poll until the order reaches a terminal state or times out."""

--- a/quanttradeai/brokers/runtime.py
+++ b/quanttradeai/brokers/runtime.py
@@ -1,0 +1,199 @@
+"""Shared broker-backed execution helpers for real-time agent engines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from quanttradeai.trading.portfolio import PortfolioManager
+from quanttradeai.trading.position_manager import PositionManager
+
+from .alpaca import AlpacaBrokerClient
+from .base import (
+    BrokerAccountSnapshot,
+    BrokerClient,
+    BrokerError,
+    BrokerOrderResult,
+    BrokerPositionSnapshot,
+)
+
+
+def resolve_execution_backend(agent_config: dict[str, Any]) -> str:
+    execution_cfg = dict(agent_config.get("execution") or {})
+    return str(execution_cfg.get("backend") or "simulated").strip().lower()
+
+
+def create_broker_client_for_agent(
+    agent_config: dict[str, Any],
+    *,
+    mode: str,
+) -> BrokerClient | None:
+    backend = resolve_execution_backend(agent_config)
+    if backend == "simulated":
+        return None
+    if backend == "alpaca":
+        return AlpacaBrokerClient(mode=mode)
+    raise ValueError(f"Unsupported execution backend: {backend}")
+
+
+def _execution_status_from_order(status: str) -> str:
+    normalized = str(status or "").strip().lower()
+    if normalized == "filled":
+        return "executed"
+    if normalized == "partially_filled":
+        return "partial_fill"
+    if normalized in {"canceled", "expired", "done_for_day"}:
+        return "canceled"
+    if normalized == "rejected":
+        return "rejected"
+    return normalized or "submitted"
+
+
+@dataclass
+class BrokerExecutionRuntime:
+    """Keep local execution state in sync with broker truth."""
+
+    broker_client: BrokerClient
+    portfolio: PortfolioManager
+    position_manager: PositionManager | None
+    stop_loss_pct: float
+    provider: str | None = None
+    start_account: dict[str, Any] | None = field(default=None, init=False)
+    end_account: dict[str, Any] | None = field(default=None, init=False)
+    start_positions: list[dict[str, Any]] | None = field(default=None, init=False)
+    end_positions: list[dict[str, Any]] | None = field(default=None, init=False)
+    starting_equity: float | None = field(default=None, init=False)
+
+    def __post_init__(self) -> None:
+        if self.provider is None:
+            self.provider = getattr(self.broker_client, "provider", "unknown")
+
+    def _serialized_positions(
+        self,
+        positions: list[BrokerPositionSnapshot],
+    ) -> list[dict[str, Any]]:
+        return [position.to_dict() for position in positions]
+
+    def _apply_snapshots(
+        self,
+        *,
+        account: BrokerAccountSnapshot,
+        positions: list[BrokerPositionSnapshot],
+    ) -> None:
+        portfolio_positions: dict[str, dict[str, Any]] = {}
+        realtime_positions: dict[str, dict[str, Any]] = {}
+        for position in positions:
+            side = str(position.side or "long").strip().lower()
+            if side not in {"long", ""} and position.qty > 0:
+                raise BrokerError(
+                    f"Unsupported broker position for {position.symbol}: QuantTradeAI Alpaca execution only supports long/flat portfolios."
+                )
+            if position.qty <= 0:
+                continue
+            portfolio_positions[position.symbol] = {
+                "qty": position.qty,
+                "price": position.market_price,
+                "entry_price": position.avg_entry_price,
+                "stop_loss_pct": self.stop_loss_pct,
+            }
+            realtime_positions[position.symbol] = {
+                "qty": position.qty,
+                "avg_price": position.avg_entry_price,
+                "market_price": position.market_price,
+            }
+
+        if self.starting_equity is None:
+            self.starting_equity = account.equity
+
+        self.portfolio.replace_state(
+            cash=account.cash,
+            positions=portfolio_positions,
+            initial_capital=self.starting_equity,
+        )
+        if self.position_manager is not None:
+            self.position_manager.replace_state(
+                cash=account.cash,
+                positions=realtime_positions,
+            )
+
+    def sync_from_broker(
+        self,
+        *,
+        mark: str | None = None,
+    ) -> tuple[BrokerAccountSnapshot, list[BrokerPositionSnapshot]]:
+        account = self.broker_client.get_account()
+        positions = self.broker_client.list_positions()
+        self._apply_snapshots(account=account, positions=positions)
+        if mark == "start":
+            self.start_account = account.to_dict()
+            self.start_positions = self._serialized_positions(positions)
+        elif mark == "end":
+            self.end_account = account.to_dict()
+            self.end_positions = self._serialized_positions(positions)
+        return account, positions
+
+    def start_session(self) -> None:
+        self.sync_from_broker(mark="start")
+
+    def finish_session(self) -> None:
+        self.sync_from_broker(mark="end")
+
+    def execute_action(
+        self,
+        *,
+        symbol: str,
+        action: str,
+        price: float,
+        timestamp: datetime,
+        extra: dict[str, Any] | None = None,
+    ) -> tuple[str, dict[str, Any] | None]:
+        normalized_action = str(action or "").strip().lower()
+        current_position = dict(self.portfolio.positions.get(symbol) or {})
+        current_qty = int(current_position.get("qty", 0))
+
+        if normalized_action == "buy":
+            if current_qty > 0:
+                return "already_long", None
+            qty = self.portfolio.estimate_open_position_qty(
+                price,
+                stop_loss_pct=self.stop_loss_pct,
+            )
+            if qty <= 0:
+                return "blocked", None
+        elif normalized_action == "sell":
+            if current_qty <= 0:
+                return "no_position", None
+            qty = current_qty
+        else:
+            return "hold", None
+
+        initial_order = self.broker_client.submit_market_order(
+            symbol=symbol,
+            action=normalized_action,
+            qty=qty,
+        )
+        order = self.broker_client.wait_for_order(initial_order.order_id)
+        self.sync_from_broker()
+
+        payload = {
+            "action": normalized_action,
+            "symbol": symbol,
+            "qty": qty,
+            "price": (
+                order.filled_avg_price
+                if order.filled_avg_price is not None
+                else float(price)
+            ),
+            "timestamp": timestamp,
+            "status": order.status,
+            "order_id": order.order_id,
+            "filled_qty": order.filled_qty,
+            "filled_avg_price": order.filled_avg_price,
+            "submitted_at": order.submitted_at,
+            "filled_at": order.filled_at,
+            "broker_provider": self.provider,
+        }
+        if extra:
+            payload.update(extra)
+        return _execution_status_from_order(order.status), payload

--- a/quanttradeai/brokers/runtime.py
+++ b/quanttradeai/brokers/runtime.py
@@ -75,6 +75,44 @@ class BrokerExecutionRuntime:
     ) -> list[dict[str, Any]]:
         return [position.to_dict() for position in positions]
 
+    def _record_filled_trade(
+        self,
+        *,
+        action: str,
+        current_position: dict[str, Any],
+        order: BrokerOrderResult,
+        fallback_timestamp: datetime,
+    ) -> None:
+        filled_qty = max(int(order.filled_qty or 0), 0)
+        if filled_qty <= 0:
+            return
+
+        filled_avg_price = order.filled_avg_price
+        if filled_avg_price is None:
+            return
+
+        fill_timestamp = order.filled_at or fallback_timestamp
+        notional = filled_qty * filled_avg_price
+        risk_manager = getattr(self.portfolio, "risk_manager", None)
+        if risk_manager is not None:
+            risk_manager.record_trade(notional, fill_timestamp)
+
+        if action != "sell":
+            return
+
+        position_qty = max(int(current_position.get("qty", 0)), 0)
+        if position_qty <= 0:
+            return
+
+        closed_qty = min(filled_qty, position_qty)
+        entry_price = float(
+            current_position.get(
+                "entry_price",
+                current_position.get("price", filled_avg_price),
+            )
+        )
+        self.portfolio.realized_pnl += closed_qty * (filled_avg_price - entry_price)
+
     def _apply_snapshots(
         self,
         *,
@@ -110,6 +148,7 @@ class BrokerExecutionRuntime:
             cash=account.cash,
             positions=portfolio_positions,
             initial_capital=self.starting_equity,
+            realized_pnl=self.portfolio.realized_pnl,
         )
         if self.position_manager is not None:
             self.position_manager.replace_state(
@@ -174,6 +213,12 @@ class BrokerExecutionRuntime:
             qty=qty,
         )
         order = self.broker_client.wait_for_order(initial_order.order_id)
+        self._record_filled_trade(
+            action=normalized_action,
+            current_position=current_position,
+            order=order,
+            fallback_timestamp=timestamp,
+        )
         self.sync_from_broker()
 
         payload = {

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -201,6 +201,7 @@ PROJECT_TEMPLATES = {
                 "name": "breakout_gpt",
                 "kind": "llm",
                 "mode": "paper",
+                "execution": {"backend": "simulated"},
                 "llm": {
                     "provider": "openai",
                     "model": "gpt-5.3",
@@ -308,6 +309,7 @@ PROJECT_TEMPLATES = {
                 "name": "hybrid_swing_agent",
                 "kind": "hybrid",
                 "mode": "paper",
+                "execution": {"backend": "simulated"},
                 "model_signal_sources": [
                     {
                         "name": "aapl_daily_classifier",
@@ -411,6 +413,7 @@ PROJECT_TEMPLATES = {
                 "name": "paper_momentum",
                 "kind": "model",
                 "mode": "paper",
+                "execution": {"backend": "simulated"},
                 "model": {"path": "models/promoted/aapl_daily_classifier"},
                 "context": {
                     "features": ["rsi_14"],
@@ -495,6 +498,7 @@ PROJECT_TEMPLATES = {
                 "name": "rsi_reversion",
                 "kind": "rule",
                 "mode": "paper",
+                "execution": {"backend": "simulated"},
                 "rule": {
                     "preset": "rsi_threshold",
                     "feature": "rsi_14",

--- a/quanttradeai/deployment.py
+++ b/quanttradeai/deployment.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import yaml
 
+from quanttradeai.brokers import resolve_execution_backend
 from quanttradeai.streaming.env_vars import provider_env_var_prefix
 from quanttradeai.utils.config_validator import validate_project_config
 from quanttradeai.utils.project_config import (
@@ -149,6 +150,8 @@ def _render_bundle_readme(
     agent_name: str,
     agent_kind: str,
     mode: str,
+    execution_backend: str,
+    broker_provider: str | None,
     service_name: str,
     next_command: str,
     env_vars: list[tuple[str, str]],
@@ -162,6 +165,7 @@ def _render_bundle_readme(
         "## Mode",
         "",
         f"- `mode: {mode}`",
+        f"- `execution.backend: {execution_backend}`",
         "",
         "## Files",
         "",
@@ -181,6 +185,15 @@ def _render_bundle_readme(
         "",
         "The compose service mounts project `data/`, `runs/`, and `reports/` read-write so runtime artifacts stay on the host.",
     ]
+
+    if execution_backend == "alpaca" and broker_provider:
+        lines.extend(
+            [
+                "",
+                "This bundle uses broker-backed execution.",
+                f"In `{mode}` mode it will submit real `{broker_provider}` market orders instead of simulated local fills.",
+            ]
+        )
 
     if safety_requirements:
         lines.extend(
@@ -461,6 +474,17 @@ def deploy_project_agent(
 
     service_name = _slugify(f"{agent_name}-{resolved_mode}")
     safety_requirements = _deployment_safety_requirements(resolved_mode)
+    execution_backend = resolve_execution_backend(agent_config)
+    broker_provider = (
+        str(
+            ((deployment_project.get("data") or {}).get("streaming") or {}).get(
+                "provider"
+            )
+            or ""
+        ).strip()
+        if execution_backend == "alpaca"
+        else None
+    )
     env_vars = _required_env_vars(
         agent_config=agent_config,
         project_config=deployment_project,
@@ -538,6 +562,8 @@ def deploy_project_agent(
             agent_name=agent_name,
             agent_kind=str(agent_config.get("kind") or ""),
             mode=resolved_mode,
+            execution_backend=execution_backend,
+            broker_provider=broker_provider,
             service_name=service_name,
             next_command=next_command,
             env_vars=env_vars,
@@ -552,6 +578,8 @@ def deploy_project_agent(
         "agent_kind": agent_config.get("kind"),
         "target": resolved_target,
         "mode": resolved_mode,
+        "execution_backend": execution_backend,
+        "broker_provider": broker_provider,
         "service_name": service_name,
         "project_root": project_root.as_posix(),
         "source_config": config_path.as_posix(),

--- a/quanttradeai/streaming/live_trading.py
+++ b/quanttradeai/streaming/live_trading.py
@@ -14,11 +14,12 @@ import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import pandas as pd
 import yaml
 
+from quanttradeai.brokers import BrokerExecutionRuntime
 from quanttradeai.data.loader import DataLoader
 from quanttradeai.data.processor import DataProcessor
 from quanttradeai.models.classifier import MomentumClassifier
@@ -111,6 +112,8 @@ class LiveTradingEngine:
     data_processor: DataProcessor | None = None
     model: MomentumClassifier | None = None
     bootstrap_history_frames: Dict[str, pd.DataFrame] | None = None
+    execution_backend: str = "simulated"
+    broker_runtime: BrokerExecutionRuntime | None = None
     _history: Dict[str, pd.DataFrame] = field(default_factory=dict, init=False)
     _consumer: asyncio.Task | None = field(default=None, init=False)
     execution_log: list[dict] = field(default_factory=list, init=False)
@@ -145,6 +148,12 @@ class LiveTradingEngine:
                     self.position_manager.bind_gateway(self.gateway, symbols)
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning("failed_binding_position_manager", error=str(exc))
+
+    @property
+    def broker_provider(self) -> str | None:
+        if self.broker_runtime is None:
+            return None
+        return self.broker_runtime.provider
 
     @property
     def health_monitor(self):
@@ -377,10 +386,45 @@ class LiveTradingEngine:
         price: float,
         signal: int,
         timestamp: pd.Timestamp,
-    ) -> None:
+    ) -> dict[str, Any]:
+        had_position = symbol in self.portfolio.positions
+        position_before = 1 if had_position else 0
+        execution_status = "hold"
+        execution_payload: dict[str, Any] | None = None
+
+        if self.broker_runtime is not None:
+            action = _signal_to_action(signal)
+            if action in {"buy", "sell"}:
+                execution_status, execution_payload = (
+                    self.broker_runtime.execute_action(
+                        symbol=symbol,
+                        action=action,
+                        price=price,
+                        timestamp=timestamp.to_pydatetime(),
+                        extra={"signal": signal},
+                    )
+                )
+                if execution_payload is not None:
+                    self._record_execution(execution_payload)
+            position_after = 1 if symbol in self.portfolio.positions else 0
+            return {
+                "execution_status": execution_status,
+                "execution": execution_payload,
+                "position_before": position_before,
+                "position_after": position_after,
+                "target_position": position_after,
+            }
+
         if signal > 0:
             if symbol in self.portfolio.positions:
-                return
+                execution_status = "already_long"
+                return {
+                    "execution_status": execution_status,
+                    "execution": None,
+                    "position_before": position_before,
+                    "position_after": position_before,
+                    "target_position": position_before,
+                }
             qty = self.portfolio.open_position(
                 symbol, price, stop_loss_pct=self.stop_loss_pct
             )
@@ -393,16 +437,18 @@ class LiveTradingEngine:
                         timestamp=timestamp.to_pydatetime(),
                     )
                     self._sync_position_manager()
-                self._record_execution(
-                    {
-                        "action": "buy",
-                        "symbol": symbol,
-                        "qty": qty,
-                        "price": price,
-                        "timestamp": timestamp,
-                        "signal": signal,
-                    }
-                )
+                execution_payload = {
+                    "action": "buy",
+                    "symbol": symbol,
+                    "qty": qty,
+                    "price": price,
+                    "timestamp": timestamp,
+                    "signal": signal,
+                }
+                self._record_execution(execution_payload)
+                execution_status = "executed"
+            else:
+                execution_status = "blocked"
         elif signal < 0 and symbol in self.portfolio.positions:
             qty = self.portfolio.close_position(symbol, price)
             if qty > 0:
@@ -413,16 +459,29 @@ class LiveTradingEngine:
                         timestamp=timestamp.to_pydatetime(),
                     )
                     self._sync_position_manager()
-                self._record_execution(
-                    {
-                        "action": "sell",
-                        "symbol": symbol,
-                        "qty": qty,
-                        "price": price,
-                        "timestamp": timestamp,
-                        "signal": signal,
-                    }
-                )
+                execution_payload = {
+                    "action": "sell",
+                    "symbol": symbol,
+                    "qty": qty,
+                    "price": price,
+                    "timestamp": timestamp,
+                    "signal": signal,
+                }
+                self._record_execution(execution_payload)
+                execution_status = "executed"
+            else:
+                execution_status = "blocked"
+        elif signal < 0:
+            execution_status = "no_position"
+
+        position_after = 1 if symbol in self.portfolio.positions else 0
+        return {
+            "execution_status": execution_status,
+            "execution": execution_payload,
+            "position_before": position_before,
+            "position_after": position_after,
+            "target_position": position_after,
+        }
 
     async def _consume_buffer(self) -> None:
         while True:
@@ -460,6 +519,7 @@ class LiveTradingEngine:
                 signal = self._predict_signal(features)
                 if signal is None:
                     continue
+                execution_result = self._handle_signal(symbol, price, signal, timestamp)
                 self.decision_log.append(
                     {
                         "symbol": symbol,
@@ -467,9 +527,9 @@ class LiveTradingEngine:
                         "signal": int(signal),
                         "action": _signal_to_action(int(signal)),
                         "source": "model",
+                        **execution_result,
                     }
                 )
-                self._handle_signal(symbol, price, signal, timestamp)
                 self._mark_to_market(symbol, price, timestamp)
             except Exception as exc:  # pragma: no cover - runtime guard
                 logger.error("live_pipeline_error", error=str(exc))
@@ -494,6 +554,8 @@ class LiveTradingEngine:
     async def start(self) -> None:
         """Start streaming and inference concurrently."""
 
+        if self.broker_runtime is not None:
+            self.broker_runtime.start_session()
         self.bootstrap_history()
         self._consumer = asyncio.create_task(self._consume_buffer())
         completed_via_signal = False
@@ -518,3 +580,5 @@ class LiveTradingEngine:
                 self._consumer.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await self._consumer
+            if self.broker_runtime is not None:
+                self.broker_runtime.finish_session()

--- a/quanttradeai/trading/portfolio.py
+++ b/quanttradeai/trading/portfolio.py
@@ -86,17 +86,17 @@ class PortfolioManager:
             p["qty"] * p["price"] * p["stop_loss_pct"] for p in self.positions.values()
         )
 
-    def open_position(
-        self, symbol: str, price: float, stop_loss_pct: float | None = None
+    def estimate_open_position_qty(
+        self,
+        price: float,
+        stop_loss_pct: float | None = None,
+        *,
+        check_risk: bool = True,
     ) -> int:
-        """Open a new position and return the quantity allocated."""
-        if symbol in self.positions:
-            raise ValueError(f"Position for {symbol} already exists")
-
-        if self.risk_manager is not None:
+        """Return the quantity that would be allocated for a new position."""
+        if check_risk and self.risk_manager is not None:
             self.risk_manager.update(self.portfolio_value, datetime.now(UTC))
             if self.risk_manager.should_emergency_liquidate():
-                self.close_all_positions()
                 return 0
             if self.risk_manager.should_halt_trading():
                 return 0
@@ -123,9 +123,32 @@ class PortfolioManager:
 
         qty = int(qty * multiplier)
         qty = min(qty, int(self.cash // price))
+        return max(qty, 0)
+
+    def open_position(
+        self, symbol: str, price: float, stop_loss_pct: float | None = None
+    ) -> int:
+        """Open a new position and return the quantity allocated."""
+        if symbol in self.positions:
+            raise ValueError(f"Position for {symbol} already exists")
+
+        if self.risk_manager is not None:
+            self.risk_manager.update(self.portfolio_value, datetime.now(UTC))
+            if self.risk_manager.should_emergency_liquidate():
+                self.close_all_positions()
+                return 0
+            if self.risk_manager.should_halt_trading():
+                return 0
+
+        qty = self.estimate_open_position_qty(
+            price,
+            stop_loss_pct=stop_loss_pct,
+            check_risk=False,
+        )
         if qty <= 0:
             return 0
 
+        stop_loss = stop_loss_pct if stop_loss_pct and stop_loss_pct > 0 else 0.0
         notional = qty * price
         self.cash -= notional
         self.positions[symbol] = {
@@ -137,6 +160,34 @@ class PortfolioManager:
         if self.risk_manager is not None:
             self.risk_manager.record_trade(notional, datetime.now(UTC))
         return qty
+
+    def replace_state(
+        self,
+        *,
+        cash: float,
+        positions: Dict[str, dict],
+        initial_capital: float | None = None,
+        realized_pnl: float | None = None,
+    ) -> None:
+        """Overwrite the tracked portfolio state from an external source."""
+
+        self.cash = float(cash)
+        self.positions = {
+            str(symbol): {
+                "qty": int(position.get("qty", 0)),
+                "price": float(position.get("price", 0.0)),
+                "entry_price": float(
+                    position.get("entry_price", position.get("price", 0.0))
+                ),
+                "stop_loss_pct": float(position.get("stop_loss_pct", 0.0)),
+            }
+            for symbol, position in positions.items()
+            if int(position.get("qty", 0)) > 0
+        }
+        if initial_capital is not None:
+            self.initial_capital = float(initial_capital)
+        if realized_pnl is not None:
+            self.realized_pnl = float(realized_pnl)
 
     def close_position(self, symbol: str, price: float) -> int:
         """Close an existing position and return quantity closed."""

--- a/quanttradeai/trading/position_manager.py
+++ b/quanttradeai/trading/position_manager.py
@@ -291,3 +291,25 @@ class PositionManager:
             total_impact = sum(e.impact_cost for e in self._executions)
             trades = len(self._executions)
         return {"trades": trades, "total_impact_cost": total_impact}
+
+    def replace_state(
+        self, *, cash: float, positions: Dict[str, Dict[str, Any]]
+    ) -> None:
+        """Overwrite in-memory positions from an external broker/account snapshot."""
+
+        with self._lock:
+            self.cash = float(cash)
+            self._positions = {}
+            for symbol, payload in positions.items():
+                qty = int(payload.get("qty", 0))
+                if qty <= 0:
+                    continue
+                self._positions[str(symbol)] = Position(
+                    qty=qty,
+                    avg_price=float(
+                        payload.get("avg_price", payload.get("market_price", 0.0))
+                    ),
+                    market_price=float(
+                        payload.get("market_price", payload.get("avg_price", 0.0))
+                    ),
+                )

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -772,6 +772,10 @@ class ProjectAgentContextConfig(BaseModel):
     notes: bool | ProjectAgentNotesContext = False
 
 
+class ProjectAgentExecutionConfig(BaseModel):
+    backend: Literal["simulated", "alpaca"] = "simulated"
+
+
 class ProjectAgentConfig(BaseModel):
     name: str
     kind: Literal["rule", "model", "llm", "hybrid"]
@@ -779,6 +783,9 @@ class ProjectAgentConfig(BaseModel):
     rule: Optional[ProjectAgentRuleConfig] = None
     llm: Optional[ProjectAgentLLMConfig] = None
     model: Optional[ProjectAgentModelConfig] = None
+    execution: ProjectAgentExecutionConfig = Field(
+        default_factory=ProjectAgentExecutionConfig
+    )
     context: ProjectAgentContextConfig = Field(
         default_factory=ProjectAgentContextConfig
     )

--- a/quanttradeai/utils/config_validator.py
+++ b/quanttradeai/utils/config_validator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -203,6 +204,11 @@ def _validate_agent_project_sections(
     for agent in resolved.get("agents") or []:
         agent_name = agent.get("name", "<unknown>")
         agent_kind = agent.get("kind")
+        agent_mode = str(agent.get("mode") or "").strip().lower()
+        execution_cfg = dict(agent.get("execution") or {})
+        execution_backend = (
+            str(execution_cfg.get("backend") or "simulated").strip().lower()
+        )
         context_cfg = dict(agent.get("context") or {})
         llm_cfg = agent.get("llm") or {}
         model_cfg = agent.get("model") or {}
@@ -215,12 +221,44 @@ def _validate_agent_project_sections(
                 errors.append(
                     f"Agent '{agent_name}' prompt file does not exist: {prompt_path}"
                 )
-        if agent.get("mode") == "paper" and not data_streaming_cfg.get(
-            "enabled", False
-        ):
+        if agent_mode == "paper" and not data_streaming_cfg.get("enabled", False):
             errors.append(
                 f"Agent '{agent_name}' is configured for paper mode but data.streaming.enabled is not true."
             )
+
+        if execution_backend == "alpaca":
+            if agent_mode not in {"paper", "live"}:
+                errors.append(
+                    f"Agent '{agent_name}' execution.backend=alpaca is only supported for agents configured with mode=paper or mode=live."
+                )
+            if not data_streaming_cfg.get("enabled", False):
+                errors.append(
+                    f"Agent '{agent_name}' execution.backend=alpaca requires data.streaming.enabled to be true."
+                )
+            if (
+                str(data_streaming_cfg.get("provider") or "").strip().lower()
+                != "alpaca"
+            ):
+                errors.append(
+                    f"Agent '{agent_name}' execution.backend=alpaca requires data.streaming.provider=alpaca."
+                )
+            replay_enabled = bool(
+                dict(data_streaming_cfg.get("replay") or {}).get("enabled", False)
+            )
+            if agent_mode == "paper" and replay_enabled:
+                errors.append(
+                    f"Agent '{agent_name}' execution.backend=alpaca does not support replay-backed paper mode."
+                )
+            missing_credentials = [
+                env_var
+                for env_var in ("ALPACA_API_KEY", "ALPACA_API_SECRET")
+                if not str(os.environ.get(env_var) or "").strip()
+            ]
+            if missing_credentials:
+                warnings.append(
+                    f"Agent '{agent_name}' execution.backend=alpaca is configured but the following environment variables are not set in the current environment: "
+                    + ", ".join(missing_credentials)
+                )
 
         if agent_kind == "model":
             model_path_raw = str(model_cfg.get("path", "")).strip()

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,6 @@
 # QuantTradeAI Roadmap
 
-Last updated: 2026-04-12
+Last updated: 2026-04-17
 
 This document is the product source of truth for QuantTradeAI.
 It is written for both human contributors and coding agents.
@@ -155,6 +155,8 @@ agents:
   - name: "breakout_gpt"
     kind: "llm"
     mode: "paper"
+    execution:
+      backend: "simulated"
     llm:
       provider: "openai"
       model: "gpt-5.3"
@@ -177,6 +179,8 @@ agents:
   - name: "hybrid_swing_agent"
     kind: "hybrid"
     mode: "paper"
+    execution:
+      backend: "simulated"
     model_signal_sources:
       - name: "aapl_daily_classifier"
         path: "models/promoted/aapl_daily_classifier"
@@ -203,6 +207,7 @@ An agent should be configurable through YAML with:
 
 - Strategy kind: `rule`, `model`, `llm`, or `hybrid`.
 - Execution mode: `backtest`, `paper`, or `live`.
+- Execution backend: simulated by default, broker-backed when explicitly enabled.
 - LLM provider/model settings when applicable.
 - Prompt template file or inline prompt.
 - Tool list.
@@ -333,6 +338,7 @@ Status on 2026-04-17:
 - `quanttradeai agent run --agent <name> -c config/project.yaml --mode backtest|paper` is implemented for `model` agents.
 - `quanttradeai agent run --agent <name> -c config/project.yaml --mode backtest|paper` is implemented for `rule` agents.
 - `quanttradeai agent run --agent <name> -c config/project.yaml --mode live` is implemented for `rule`, `model`, `llm`, and `hybrid` agents.
+- `agents[].execution.backend: alpaca` is implemented for happy-path paper/live runs, with broker-backed Alpaca market orders, broker state reconciliation, and broker snapshot artifacts under each run directory.
 - Agent templates now write the referenced prompt markdown assets.
 - Agent backtest runs now persist resolved config, runtime YAML snapshots, metrics, equity curve, ledger, decisions, sampled prompt/response payloads where applicable, and standardized run metadata under `runs/agent/backtest/...`.
 - Project-defined paper runs now support deterministic OHLCV replay through `data.streaming.replay`, resolving the replay window from replay dates, then test dates, then data dates.
@@ -346,7 +352,7 @@ Status on 2026-04-17:
 - `quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml` is implemented for successful agent backtest-to-paper promotion.
 - `quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live <agent_name>` is implemented for successful paper-to-live promotion with an explicit safety acknowledgement.
 - Top-level `risk` and `position_manager` are now the canonical live safety/runtime sections in `config/project.yaml`.
-- `quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` now generates a real-time paper-agent deployment bundle with compose, Dockerfile, env placeholders, resolved config, and a deployment manifest. Replay is disabled in the emitted bundle config.
+- `quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` now generates paper and live deployment bundles with compose, Dockerfile, env placeholders, resolved config, and a deployment manifest. Paper bundles still disable replay in the emitted config, and Alpaca-backed agents are called out explicitly in the generated bundle README and manifest.
 - Replaced legacy paths have been removed from the primary CLI surface: `train`, `backtest-model`, `live-trade`, `validate-config`, and the `--legacy-config-dir` import flags are gone. `fetch-data`, `evaluate`, and standalone `backtest` remain as utility commands outside the primary product workflow.
 
 ### Stage 2: Multi-Agent Lab
@@ -459,7 +465,7 @@ quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode 
 ```
 
 Current implementation note:
-`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`, including `agent run --all --mode paper`. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`. `deploy --target docker-compose` still generates real-time paper bundles only.
+`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`, including `agent run --all --mode paper`. Agents can also opt into `execution.backend: alpaca` for happy-path real-time paper/live broker submission with broker-synced account and position snapshots. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`. `deploy --target docker-compose` supports both simulated and Alpaca-backed paper/live agent bundles.
 
 ### Hybrid track
 

--- a/tests/agents/test_paper.py
+++ b/tests/agents/test_paper.py
@@ -7,6 +7,12 @@ import numpy as np
 import pandas as pd
 import yaml
 
+from quanttradeai.brokers.base import (
+    BrokerAccountSnapshot,
+    BrokerOrderResult,
+    BrokerPositionSnapshot,
+)
+from quanttradeai.brokers.runtime import BrokerExecutionRuntime
 from quanttradeai.agents.paper import (
     PaperAgentEngine,
     _build_paper_runtime_model_config,
@@ -72,6 +78,96 @@ class FakeSignalRuntime:
 
     def predict(self, features_frame: pd.DataFrame) -> int:
         return self.signal
+
+
+class FakeBrokerClient:
+    provider = "alpaca"
+
+    def __init__(self, starting_cash: float = 100000.0) -> None:
+        self.cash = starting_cash
+        self.qty = 0
+        self.market_price = 0.0
+        self.avg_entry_price = 0.0
+        self.next_order_id = 1
+        self.last_order = None
+
+    def get_account(self) -> BrokerAccountSnapshot:
+        equity = self.cash + (self.qty * self.market_price)
+        return BrokerAccountSnapshot(
+            account_id="acct-paper",
+            cash=self.cash,
+            equity=equity,
+            buying_power=self.cash,
+        )
+
+    def list_positions(self) -> list[BrokerPositionSnapshot]:
+        if self.qty <= 0:
+            return []
+        return [
+            BrokerPositionSnapshot(
+                symbol="AAPL",
+                qty=self.qty,
+                market_price=self.market_price,
+                avg_entry_price=self.avg_entry_price,
+            )
+        ]
+
+    def submit_market_order(
+        self,
+        *,
+        symbol: str,
+        action: str,
+        qty: int,
+    ) -> BrokerOrderResult:
+        order_id = f"ord-{self.next_order_id}"
+        self.next_order_id += 1
+        self.last_order = {
+            "order_id": order_id,
+            "symbol": symbol,
+            "action": action,
+            "qty": qty,
+        }
+        return BrokerOrderResult(
+            order_id=order_id,
+            symbol=symbol,
+            action=action,
+            qty=qty,
+            status="new",
+        )
+
+    def get_order(self, order_id: str) -> BrokerOrderResult:
+        raise AssertionError("FakeBrokerClient.get_order should not be called directly")
+
+    def wait_for_order(
+        self,
+        order_id: str,
+        *,
+        poll_interval: float | None = None,
+        timeout: float | None = None,
+    ) -> BrokerOrderResult:
+        assert self.last_order is not None
+        qty = int(self.last_order["qty"])
+        action = str(self.last_order["action"])
+        fill_price = 121.0 if action == "buy" else 123.0
+        if action == "buy":
+            self.cash -= qty * fill_price
+            self.qty += qty
+            self.avg_entry_price = fill_price
+            self.market_price = fill_price
+        else:
+            self.cash += qty * fill_price
+            self.qty = 0
+            self.avg_entry_price = 0.0
+            self.market_price = fill_price
+        return BrokerOrderResult(
+            order_id=order_id,
+            symbol=str(self.last_order["symbol"]),
+            action=action,
+            qty=qty,
+            status="filled",
+            filled_qty=qty,
+            filled_avg_price=fill_price,
+        )
 
 
 def _completion_from_actions(actions: list[str]):
@@ -527,3 +623,51 @@ def test_paper_engine_replay_waits_for_completion_signal(
 
     assert len(engine.decision_log) == 6
     assert len(engine.execution_log) == 0
+
+
+def test_paper_engine_broker_runtime_records_broker_metadata(
+    tmp_path: Path, monkeypatch
+):
+    engine = _build_engine(
+        tmp_path,
+        monkeypatch,
+        gateway_messages=[
+            {
+                "symbol": "AAPL",
+                "price": 121.0,
+                "volume": 10,
+                "timestamp": "2024-09-17T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 123.0,
+                "volume": 12,
+                "timestamp": "2024-09-18T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 124.0,
+                "volume": 14,
+                "timestamp": "2024-09-19T00:00:00Z",
+            },
+        ],
+        completion=_completion_from_actions(["buy", "sell"]),
+    )
+    broker_client = FakeBrokerClient()
+    engine.execution_backend = "alpaca"
+    engine.broker_runtime = BrokerExecutionRuntime(
+        broker_client=broker_client,
+        portfolio=engine.portfolio,
+        position_manager=engine.position_manager,
+        stop_loss_pct=engine.stop_loss_pct,
+    )
+
+    asyncio.run(engine.start())
+
+    assert [entry["action"] for entry in engine.execution_log] == ["buy", "sell"]
+    assert engine.execution_log[0]["order_id"] == "ord-1"
+    assert engine.execution_log[0]["status"] == "filled"
+    assert engine.execution_log[0]["broker_provider"] == "alpaca"
+    assert engine.decision_log[0]["execution_status"] == "executed"
+    assert engine.broker_runtime.start_account is not None
+    assert engine.broker_runtime.end_account is not None

--- a/tests/brokers/test_alpaca.py
+++ b/tests/brokers/test_alpaca.py
@@ -1,0 +1,169 @@
+import json
+
+import pytest
+
+from quanttradeai.brokers.alpaca import AlpacaBrokerClient
+from quanttradeai.brokers.base import BrokerOrderResult
+
+
+class _FakeHTTPResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return None
+
+
+def test_alpaca_get_account_and_positions_parse_payloads(monkeypatch):
+    responses = iter(
+        [
+            {
+                "id": "acct-123",
+                "cash": "1000.50",
+                "equity": "1020.25",
+                "buying_power": "2500.00",
+                "currency": "USD",
+                "status": "ACTIVE",
+            },
+            [
+                {
+                    "symbol": "AAPL",
+                    "qty": "3",
+                    "side": "long",
+                    "current_price": "201.5",
+                    "avg_entry_price": "199.0",
+                    "unrealized_pl": "7.5",
+                }
+            ],
+        ]
+    )
+
+    def _fake_urlopen(req, timeout):
+        return _FakeHTTPResponse(next(responses))
+
+    monkeypatch.setattr("quanttradeai.brokers.alpaca.request.urlopen", _fake_urlopen)
+    client = AlpacaBrokerClient(api_key="key", api_secret="secret")
+
+    account = client.get_account()
+    positions = client.list_positions()
+
+    assert account.account_id == "acct-123"
+    assert account.cash == pytest.approx(1000.50)
+    assert account.equity == pytest.approx(1020.25)
+    assert positions[0].symbol == "AAPL"
+    assert positions[0].qty == 3
+    assert positions[0].market_price == pytest.approx(201.5)
+    assert positions[0].avg_entry_price == pytest.approx(199.0)
+
+
+def test_alpaca_submit_market_order_builds_expected_payload(monkeypatch):
+    captured = {}
+
+    def _fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.header_items())
+        captured["payload"] = json.loads(req.data.decode("utf-8"))
+        return _FakeHTTPResponse(
+            {
+                "id": "ord-1",
+                "symbol": "AAPL",
+                "side": "buy",
+                "qty": "5",
+                "status": "new",
+                "filled_qty": "0",
+            }
+        )
+
+    monkeypatch.setattr("quanttradeai.brokers.alpaca.request.urlopen", _fake_urlopen)
+    client = AlpacaBrokerClient(api_key="key", api_secret="secret", mode="paper")
+
+    order = client.submit_market_order(symbol="AAPL", action="buy", qty=5)
+
+    assert captured["url"].endswith("/v2/orders")
+    assert captured["method"] == "POST"
+    assert captured["payload"] == {
+        "symbol": "AAPL",
+        "qty": "5",
+        "side": "buy",
+        "type": "market",
+        "time_in_force": "day",
+    }
+    assert order.order_id == "ord-1"
+    assert order.status == "new"
+
+
+def test_alpaca_wait_for_order_polls_until_filled(monkeypatch):
+    client = AlpacaBrokerClient(
+        api_key="key",
+        api_secret="secret",
+        poll_interval=0.0,
+        order_timeout=1.0,
+    )
+    responses = iter(
+        [
+            BrokerOrderResult(
+                order_id="ord-1",
+                symbol="AAPL",
+                action="buy",
+                qty=5,
+                status="new",
+            ),
+            BrokerOrderResult(
+                order_id="ord-1",
+                symbol="AAPL",
+                action="buy",
+                qty=5,
+                status="partially_filled",
+                filled_qty=2,
+                filled_avg_price=101.0,
+            ),
+            BrokerOrderResult(
+                order_id="ord-1",
+                symbol="AAPL",
+                action="buy",
+                qty=5,
+                status="filled",
+                filled_qty=5,
+                filled_avg_price=101.5,
+            ),
+        ]
+    )
+    monkeypatch.setattr(client, "get_order", lambda order_id: next(responses))
+
+    result = client.wait_for_order("ord-1", poll_interval=0.0, timeout=0.1)
+
+    assert result.status == "filled"
+    assert result.filled_qty == 5
+    assert result.filled_avg_price == pytest.approx(101.5)
+
+
+@pytest.mark.parametrize("status", ["canceled", "rejected"])
+def test_alpaca_wait_for_order_returns_terminal_failure_status(monkeypatch, status):
+    client = AlpacaBrokerClient(
+        api_key="key",
+        api_secret="secret",
+        poll_interval=0.0,
+        order_timeout=1.0,
+    )
+    monkeypatch.setattr(
+        client,
+        "get_order",
+        lambda order_id: BrokerOrderResult(
+            order_id=order_id,
+            symbol="AAPL",
+            action="sell",
+            qty=5,
+            status=status,
+        ),
+    )
+
+    result = client.wait_for_order("ord-2", poll_interval=0.0, timeout=0.1)
+
+    assert result.status == status

--- a/tests/brokers/test_runtime.py
+++ b/tests/brokers/test_runtime.py
@@ -1,0 +1,163 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from quanttradeai.brokers.base import (
+    BrokerAccountSnapshot,
+    BrokerOrderResult,
+    BrokerPositionSnapshot,
+)
+from quanttradeai.brokers.runtime import BrokerExecutionRuntime
+from quanttradeai.trading.portfolio import PortfolioManager
+
+
+class _RiskManagerSpy:
+    def __init__(self) -> None:
+        self.recorded: list[tuple[float, datetime]] = []
+
+    def update(self, portfolio_value: float, timestamp: datetime) -> None:
+        return None
+
+    def record_trade(self, notional: float, timestamp: datetime) -> None:
+        self.recorded.append((notional, timestamp))
+
+    def should_emergency_liquidate(self) -> bool:
+        return False
+
+    def should_halt_trading(self) -> bool:
+        return False
+
+    def get_position_size_multiplier(self) -> float:
+        return 1.0
+
+
+class _FakeBrokerClient:
+    provider = "alpaca"
+
+    def __init__(self, starting_cash: float = 1000.0) -> None:
+        self.cash = starting_cash
+        self.qty = 0
+        self.market_price = 0.0
+        self.avg_entry_price = 0.0
+        self.next_order_id = 1
+        self.last_order: dict[str, object] | None = None
+
+    def get_account(self) -> BrokerAccountSnapshot:
+        equity = self.cash + (self.qty * self.market_price)
+        return BrokerAccountSnapshot(
+            account_id="acct-runtime",
+            cash=self.cash,
+            equity=equity,
+            buying_power=self.cash,
+        )
+
+    def list_positions(self) -> list[BrokerPositionSnapshot]:
+        if self.qty <= 0:
+            return []
+        return [
+            BrokerPositionSnapshot(
+                symbol="AAPL",
+                qty=self.qty,
+                market_price=self.market_price,
+                avg_entry_price=self.avg_entry_price,
+            )
+        ]
+
+    def submit_market_order(
+        self,
+        *,
+        symbol: str,
+        action: str,
+        qty: int,
+    ) -> BrokerOrderResult:
+        order_id = f"ord-{self.next_order_id}"
+        self.next_order_id += 1
+        self.last_order = {
+            "order_id": order_id,
+            "symbol": symbol,
+            "action": action,
+            "qty": qty,
+        }
+        return BrokerOrderResult(
+            order_id=order_id,
+            symbol=symbol,
+            action=action,
+            qty=qty,
+            status="new",
+        )
+
+    def get_order(self, order_id: str) -> BrokerOrderResult:
+        raise AssertionError("Orders are resolved via wait_for_order in this test")
+
+    def wait_for_order(
+        self,
+        order_id: str,
+        *,
+        poll_interval: float | None = None,
+        timeout: float | None = None,
+    ) -> BrokerOrderResult:
+        assert self.last_order is not None
+        qty = int(self.last_order["qty"])
+        action = str(self.last_order["action"])
+        fill_price = 10.0 if action == "buy" else 11.0
+        filled_at = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+        if action == "buy":
+            self.cash -= qty * fill_price
+            self.qty += qty
+            self.avg_entry_price = fill_price
+            self.market_price = fill_price
+        else:
+            self.cash += qty * fill_price
+            self.qty = 0
+            self.avg_entry_price = 0.0
+            self.market_price = fill_price
+        return BrokerOrderResult(
+            order_id=order_id,
+            symbol=str(self.last_order["symbol"]),
+            action=action,
+            qty=qty,
+            status="filled",
+            filled_qty=qty,
+            filled_avg_price=fill_price,
+            filled_at=filled_at,
+        )
+
+
+def test_broker_runtime_records_fill_notional_and_realized_pnl():
+    risk_manager = _RiskManagerSpy()
+    portfolio = PortfolioManager(capital=1000.0, risk_manager=risk_manager)
+    runtime = BrokerExecutionRuntime(
+        broker_client=_FakeBrokerClient(),
+        portfolio=portfolio,
+        position_manager=None,
+        stop_loss_pct=0.02,
+    )
+    runtime.start_session()
+
+    _, buy_payload = runtime.execute_action(
+        symbol="AAPL",
+        action="buy",
+        price=10.0,
+        timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    _, sell_payload = runtime.execute_action(
+        symbol="AAPL",
+        action="sell",
+        price=11.0,
+        timestamp=datetime(2024, 1, 1, 13, 0, tzinfo=UTC),
+    )
+    runtime.sync_from_broker()
+
+    assert buy_payload is not None
+    assert sell_payload is not None
+    assert len(risk_manager.recorded) == 2
+    assert risk_manager.recorded[0][0] == pytest.approx(
+        buy_payload["filled_qty"] * buy_payload["filled_avg_price"]
+    )
+    assert risk_manager.recorded[1][0] == pytest.approx(
+        sell_payload["filled_qty"] * sell_payload["filled_avg_price"]
+    )
+    assert portfolio.realized_pnl == pytest.approx(
+        sell_payload["filled_qty"]
+        * (sell_payload["filled_avg_price"] - buy_payload["filled_avg_price"])
+    )

--- a/tests/integration/test_agent_cli.py
+++ b/tests/integration/test_agent_cli.py
@@ -10,6 +10,11 @@ import pandas as pd
 import yaml
 from typer.testing import CliRunner
 
+from quanttradeai.brokers.base import (
+    BrokerAccountSnapshot,
+    BrokerOrderResult,
+    BrokerPositionSnapshot,
+)
 from quanttradeai.cli import app
 
 
@@ -426,6 +431,30 @@ class FakePaperPortfolio:
             position["qty"] * position["price"] for position in self.positions.values()
         )
 
+    def replace_state(
+        self,
+        *,
+        cash: float,
+        positions: dict,
+        initial_capital: float | None = None,
+        realized_pnl: float | None = None,
+    ) -> None:
+        self.cash = float(cash)
+        self.positions = dict(positions)
+        if initial_capital is not None:
+            self.initial_capital = float(initial_capital)
+        if realized_pnl is not None:
+            self.realized_pnl = float(realized_pnl)
+
+    def estimate_open_position_qty(
+        self,
+        price: float,
+        stop_loss_pct: float | None = None,
+        *,
+        check_risk: bool = True,
+    ) -> int:
+        return max(int(self.cash // price), 0)
+
 
 class FakePaperEngine:
     def __init__(self, **kwargs):
@@ -518,6 +547,96 @@ class FakeStreamingGateway:
     async def _start(self) -> None:
         for message in self.messages:
             await self.buffer.put(message)
+
+
+class FakeBrokerClient:
+    provider = "alpaca"
+
+    def __init__(self, starting_cash: float = 100000.0) -> None:
+        self.cash = starting_cash
+        self.qty = 0
+        self.market_price = 0.0
+        self.avg_entry_price = 0.0
+        self.next_order_id = 1
+        self.last_order = None
+
+    def get_account(self) -> BrokerAccountSnapshot:
+        equity = self.cash + (self.qty * self.market_price)
+        return BrokerAccountSnapshot(
+            account_id="acct-integration",
+            cash=self.cash,
+            equity=equity,
+            buying_power=self.cash,
+        )
+
+    def list_positions(self) -> list[BrokerPositionSnapshot]:
+        if self.qty <= 0:
+            return []
+        return [
+            BrokerPositionSnapshot(
+                symbol="AAPL",
+                qty=self.qty,
+                market_price=self.market_price,
+                avg_entry_price=self.avg_entry_price,
+            )
+        ]
+
+    def submit_market_order(
+        self,
+        *,
+        symbol: str,
+        action: str,
+        qty: int,
+    ) -> BrokerOrderResult:
+        order_id = f"ord-{self.next_order_id}"
+        self.next_order_id += 1
+        self.last_order = {
+            "order_id": order_id,
+            "symbol": symbol,
+            "action": action,
+            "qty": qty,
+        }
+        return BrokerOrderResult(
+            order_id=order_id,
+            symbol=symbol,
+            action=action,
+            qty=qty,
+            status="new",
+        )
+
+    def get_order(self, order_id: str) -> BrokerOrderResult:
+        raise AssertionError("FakeBrokerClient.get_order should not be called directly")
+
+    def wait_for_order(
+        self,
+        order_id: str,
+        *,
+        poll_interval: float | None = None,
+        timeout: float | None = None,
+    ) -> BrokerOrderResult:
+        assert self.last_order is not None
+        qty = int(self.last_order["qty"])
+        action = str(self.last_order["action"])
+        fill_price = 121.0 if action == "buy" else 123.0
+        if action == "buy":
+            self.cash -= qty * fill_price
+            self.qty += qty
+            self.avg_entry_price = fill_price
+            self.market_price = fill_price
+        else:
+            self.cash += qty * fill_price
+            self.qty = 0
+            self.avg_entry_price = 0.0
+            self.market_price = fill_price
+        return BrokerOrderResult(
+            order_id=order_id,
+            symbol=str(self.last_order["symbol"]),
+            action=action,
+            qty=qty,
+            status="filled",
+            filled_qty=qty,
+            filled_avg_price=fill_price,
+        )
 
 
 def test_hybrid_agent_run_includes_model_signals(tmp_path: Path, monkeypatch):
@@ -952,6 +1071,110 @@ def test_model_agent_live_run_writes_live_artifacts_and_risk_metrics(
     assert metrics_payload["risk_status"]["status"] == "ok"
 
 
+def test_model_agent_live_run_with_alpaca_backend_writes_broker_artifacts(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    _stub_prometheus_client(monkeypatch)
+    _stub_live_trading_module(monkeypatch)
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "model-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["agents"][0]["mode"] = "live"
+    config_payload["agents"][0]["execution"] = {"backend": "alpaca"}
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    class FakeBrokerAwareLiveEngine(FakeLiveEngine):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.position_manager = None
+
+        @property
+        def broker_provider(self):
+            runtime = getattr(self, "broker_runtime", None)
+            return runtime.provider if runtime is not None else None
+
+        async def start(self) -> None:
+            self.decision_log = []
+            self.execution_log = []
+            if getattr(self, "broker_runtime", None) is not None:
+                self.broker_runtime.start_session()
+                execution_status, execution_payload = self.broker_runtime.execute_action(
+                    symbol="AAPL",
+                    action="buy",
+                    price=100.0,
+                    timestamp=pd.Timestamp("2024-01-01T00:00:00Z").to_pydatetime(),
+                    extra={"signal": 1},
+                )
+                self.execution_log = [execution_payload]
+                self.decision_log = [
+                    {
+                        "symbol": "AAPL",
+                        "timestamp": pd.Timestamp("2024-01-01T00:00:00Z"),
+                        "signal": 1,
+                        "action": "buy",
+                        "source": "model",
+                        "execution_status": execution_status,
+                        "execution": execution_payload,
+                        "target_position": 1,
+                    }
+                ]
+                self.broker_runtime.finish_session()
+            else:
+                await super().start()
+
+    with (
+        patch(
+            "quanttradeai.agents.model_agent.LiveTradingEngine",
+            side_effect=lambda **kwargs: FakeBrokerAwareLiveEngine(**kwargs),
+        ),
+        patch(
+            "quanttradeai.agents.model_agent.create_broker_client_for_agent",
+            return_value=FakeBrokerClient(),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--agent",
+                "paper_momentum",
+                "--config",
+                str(config_path),
+                "--mode",
+                "live",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    run_dir = Path(payload["run_dir"])
+    assert payload["execution_backend"] == "alpaca"
+    assert payload["broker_provider"] == "alpaca"
+    assert (run_dir / "broker_account_start.json").is_file()
+    assert (run_dir / "broker_account_end.json").is_file()
+
+    execution_lines = [
+        json.loads(line)
+        for line in (run_dir / "executions.jsonl")
+        .read_text(encoding="utf-8")
+        .strip()
+        .splitlines()
+    ]
+    assert execution_lines[0]["order_id"] == "ord-1"
+    assert execution_lines[0]["status"] == "filled"
+
+
 def test_llm_agent_paper_run_writes_standardized_artifacts(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
@@ -1354,6 +1577,114 @@ def test_rule_agent_paper_run_writes_metrics_and_execution_log(
     metrics_payload = json.loads((run_dir / "metrics.json").read_text("utf-8"))
     assert metrics_payload["decision_count"] == 2
     assert metrics_payload["execution_count"] == 2
+
+
+def test_rule_agent_paper_run_with_alpaca_backend_writes_broker_artifacts(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    _stub_streaming_gateway_module(monkeypatch)
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    config_path = Path("config/project.yaml")
+    config_payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config_payload["data"]["start_date"] = "2024-01-01"
+    config_payload["data"]["end_date"] = "2024-02-09"
+    config_payload["data"]["test_start"] = "2024-02-01"
+    config_payload["data"]["test_end"] = "2024-02-09"
+    config_payload["data"]["streaming"]["replay"]["enabled"] = False
+    config_payload["agents"][0]["execution"] = {"backend": "alpaca"}
+    config_payload["agents"][0]["rule"]["buy_below"] = 50.0
+    config_payload["agents"][0]["rule"]["sell_above"] = 60.0
+    config_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    gateway = FakeStreamingGateway(
+        [
+            {
+                "symbol": "AAPL",
+                "price": 121.0,
+                "volume": 10,
+                "timestamp": "2024-02-10T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 123.0,
+                "volume": 12,
+                "timestamp": "2024-02-11T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 124.0,
+                "volume": 14,
+                "timestamp": "2024-02-12T00:00:00Z",
+            },
+        ]
+    )
+
+    with (
+        patch(
+            "quanttradeai.agents.paper.StreamingGateway",
+            return_value=gateway,
+        ),
+        patch(
+            "quanttradeai.agents.paper.DataLoader.fetch_data",
+            return_value={"AAPL": _mock_history()},
+        ),
+        patch(
+            "quanttradeai.agents.paper.DataProcessor.generate_features",
+            _rule_paper_features,
+        ),
+        patch(
+            "quanttradeai.agents.paper.create_broker_client_for_agent",
+            return_value=FakeBrokerClient(),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--agent",
+                "rsi_reversion",
+                "--config",
+                str(config_path),
+                "--mode",
+                "paper",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    run_dir = Path(payload["run_dir"])
+    assert payload["execution_backend"] == "alpaca"
+    assert payload["broker_provider"] == "alpaca"
+    assert (run_dir / "broker_account_start.json").is_file()
+    assert (run_dir / "broker_account_end.json").is_file()
+    assert (run_dir / "broker_positions_start.json").is_file()
+    assert (run_dir / "broker_positions_end.json").is_file()
+
+    execution_lines = [
+        json.loads(line)
+        for line in (run_dir / "executions.jsonl")
+        .read_text(encoding="utf-8")
+        .strip()
+        .splitlines()
+    ]
+    assert execution_lines[0]["order_id"] == "ord-1"
+    assert execution_lines[0]["status"] == "filled"
+    assert execution_lines[0]["filled_qty"] > 0
+
+    metrics_payload = json.loads((run_dir / "metrics.json").read_text("utf-8"))
+    assert metrics_payload["execution_backend"] == "alpaca"
+    assert metrics_payload["broker_provider"] == "alpaca"
 
 
 def test_rule_agent_paper_run_uses_replay_without_realtime_streaming(

--- a/tests/integration/test_deploy_cli.py
+++ b/tests/integration/test_deploy_cli.py
@@ -162,6 +162,34 @@ def test_rule_agent_live_deploy_uses_config_default_mode_and_preserves_project_c
     assert resolved_project["data"]["streaming"]["replay"]["enabled"] is True
 
 
+def test_deploy_readme_and_manifest_call_out_alpaca_backed_execution(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "rule-agent")
+    payload = _read_yaml(config_path)
+    payload["data"]["streaming"]["replay"]["enabled"] = False
+    payload["agents"][0]["execution"] = {"backend": "alpaca"}
+    _write_yaml(config_path, payload)
+
+    result = _deploy_agent(
+        agent_name="rsi_reversion",
+        config_path=config_path,
+        output_dir="deployments/rule-broker",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    deploy_payload = json.loads(result.stdout)
+    output_dir = Path(deploy_payload["output_dir"])
+    _compose_text, _env_example, readme, manifest, _resolved_project = _load_deploy_bundle(
+        output_dir
+    )
+
+    assert manifest["execution_backend"] == "alpaca"
+    assert manifest["broker_provider"] == "alpaca"
+    assert "broker-backed execution" in readme
+    assert "submit real `alpaca` market orders" in readme
+
+
 @pytest.mark.parametrize(
     ("template", "agent_name", "expect_openai_env", "expect_prompt_mount", "expect_models_mount"),
     [

--- a/tests/streaming/test_live_trading.py
+++ b/tests/streaming/test_live_trading.py
@@ -5,6 +5,12 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 
+from quanttradeai.brokers.base import (
+    BrokerAccountSnapshot,
+    BrokerOrderResult,
+    BrokerPositionSnapshot,
+)
+from quanttradeai.brokers.runtime import BrokerExecutionRuntime
 from quanttradeai.streaming.replay import ReplayGateway
 from quanttradeai.streaming.live_trading import LiveTradingEngine
 from quanttradeai.streaming.monitoring.health_monitor import StreamingHealthMonitor
@@ -74,6 +80,97 @@ class DummyPreprocessor:
         for column in self.feature_columns:
             out[column] = out[column].astype(float)
         return out
+
+
+class FakeBrokerClient:
+    provider = "alpaca"
+
+    def __init__(self, starting_cash: float = 1000.0) -> None:
+        self.cash = starting_cash
+        self.qty = 0
+        self.market_price = 0.0
+        self.avg_entry_price = 0.0
+        self.next_order_id = 1
+        self.last_order = None
+
+    def get_account(self) -> BrokerAccountSnapshot:
+        equity = self.cash + (self.qty * self.market_price)
+        return BrokerAccountSnapshot(
+            account_id="acct-1",
+            cash=self.cash,
+            equity=equity,
+            buying_power=self.cash,
+        )
+
+    def list_positions(self) -> list[BrokerPositionSnapshot]:
+        if self.qty <= 0:
+            return []
+        return [
+            BrokerPositionSnapshot(
+                symbol="AAPL",
+                qty=self.qty,
+                market_price=self.market_price,
+                avg_entry_price=self.avg_entry_price,
+                side="long",
+            )
+        ]
+
+    def submit_market_order(
+        self,
+        *,
+        symbol: str,
+        action: str,
+        qty: int,
+    ) -> BrokerOrderResult:
+        order_id = f"ord-{self.next_order_id}"
+        self.next_order_id += 1
+        self.last_order = {
+            "order_id": order_id,
+            "symbol": symbol,
+            "action": action,
+            "qty": qty,
+        }
+        return BrokerOrderResult(
+            order_id=order_id,
+            symbol=symbol,
+            action=action,
+            qty=qty,
+            status="new",
+        )
+
+    def get_order(self, order_id: str) -> BrokerOrderResult:
+        raise AssertionError("FakeBrokerClient.get_order should not be called directly")
+
+    def wait_for_order(
+        self,
+        order_id: str,
+        *,
+        poll_interval: float | None = None,
+        timeout: float | None = None,
+    ) -> BrokerOrderResult:
+        assert self.last_order is not None
+        qty = int(self.last_order["qty"])
+        action = str(self.last_order["action"])
+        fill_price = 10.0 if action == "buy" else 11.0
+        if action == "buy":
+            self.cash -= qty * fill_price
+            self.qty += qty
+            self.avg_entry_price = fill_price
+            self.market_price = fill_price
+        else:
+            self.cash += qty * fill_price
+            self.qty = 0
+            self.market_price = fill_price
+            self.avg_entry_price = 0.0
+        return BrokerOrderResult(
+            order_id=order_id,
+            symbol=str(self.last_order["symbol"]),
+            action=action,
+            qty=qty,
+            status="filled",
+            filled_qty=qty,
+            filled_avg_price=fill_price,
+        )
 
 
 @pytest.mark.asyncio
@@ -592,3 +689,60 @@ async def test_live_trading_engine_replay_waits_for_completion_signal():
 
     assert len(engine.decision_log) == 6
     assert len(engine.execution_log) == 1
+
+
+@pytest.mark.asyncio
+async def test_live_trading_engine_broker_runtime_syncs_and_records_broker_orders():
+    gateway = ScriptedGateway(
+        [
+            {
+                "symbol": "AAPL",
+                "price": 10.0,
+                "Open": 10.0,
+                "High": 10.0,
+                "Low": 10.0,
+                "Close": 10.0,
+                "Volume": 100,
+                "timestamp": "2024-01-01T00:00:00Z",
+            },
+            {
+                "symbol": "AAPL",
+                "price": 11.0,
+                "Open": 11.0,
+                "High": 11.0,
+                "Low": 11.0,
+                "Close": 11.0,
+                "Volume": 100,
+                "timestamp": "2024-01-01T00:01:00Z",
+            },
+        ]
+    )
+    engine = LiveTradingEngine(
+        model_config="config/model_config.yaml",
+        model_path="unused",
+        gateway=gateway,
+        data_processor=DummyProcessor(),
+        model=DummyModel(outputs=[1, -1]),
+        min_history_for_features=1,
+        history_window=8,
+        risk_config=None,
+        position_manager_config=None,
+        execution_backend="alpaca",
+    )
+    broker_client = FakeBrokerClient(starting_cash=1000.0)
+    engine.broker_runtime = BrokerExecutionRuntime(
+        broker_client=broker_client,
+        portfolio=engine.portfolio,
+        position_manager=engine.position_manager,
+        stop_loss_pct=engine.stop_loss_pct,
+    )
+
+    await engine.start()
+
+    assert [entry["action"] for entry in engine.execution_log] == ["buy", "sell"]
+    assert engine.execution_log[0]["order_id"] == "ord-1"
+    assert engine.execution_log[0]["status"] == "filled"
+    assert engine.execution_log[0]["filled_qty"] > 0
+    assert engine.broker_runtime.start_account is not None
+    assert engine.broker_runtime.end_account is not None
+    assert engine.portfolio.cash == pytest.approx(broker_client.cash)

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -878,6 +878,100 @@ def test_validate_fails_when_live_agent_streaming_is_disabled(
     assert "data.streaming.enabled must be true" in result.stderr.lower()
 
 
+def test_validate_defaults_agent_execution_backend_to_simulated(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    init_result = runner.invoke(
+        app,
+        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+    )
+    assert init_result.exit_code == 0, init_result.stdout
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    resolved = yaml.safe_load(
+        Path(payload["artifacts"]["resolved_config"]).read_text(encoding="utf-8")
+    )
+    assert resolved["agents"][0]["execution"]["backend"] == "simulated"
+
+
+def test_validate_fails_when_alpaca_execution_uses_replay_paper(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["rule-agent"], sort_keys=False)
+    )
+    config_payload["agents"][0]["execution"] = {"backend": "alpaca"}
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert "does not support replay-backed paper mode" in result.stderr.lower()
+
+
+def test_validate_fails_when_alpaca_execution_uses_non_alpaca_provider(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["rule-agent"], sort_keys=False)
+    )
+    config_payload["agents"][0]["execution"] = {"backend": "alpaca"}
+    config_payload["data"]["streaming"]["provider"] = "polygon"
+    config_payload["data"]["streaming"]["replay"]["enabled"] = False
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 1
+    assert "requires data.streaming.provider=alpaca" in result.stderr.lower()
+
+
+def test_validate_warns_when_alpaca_execution_credentials_are_missing(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_API_SECRET", raising=False)
+    cfg_path = Path("config/project.yaml")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["rule-agent"], sort_keys=False)
+    )
+    config_payload["agents"][0]["execution"] = {"backend": "alpaca"}
+    config_payload["data"]["streaming"]["replay"]["enabled"] = False
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "ALPACA_API_KEY" in f"{result.stdout}\n{result.stderr}"
+    assert "ALPACA_API_SECRET" in f"{result.stdout}\n{result.stderr}"
+
+
 def test_validate_fails_when_live_agent_missing_top_level_risk(
     tmp_path: Path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- add Alpaca-backed broker execution for project-defined paper and live agents
- validate and document the new execution.backend happy-path workflow and deployment behavior
- add broker/runtime/integration coverage plus a pytest recursion guard for local temp artifacts

## Validation
- make lint.format.test
