### PR TITLE
feat: add local deployment bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 | Run a hybrid agent | `init --template hybrid` -> `research run` -> `promote --run research/<run_id>` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Model signals plus LLM reasoning in one project, with research outputs promoted into a stable path before the agent is promoted through environments |
 | Run every project agent together | `agent run --all --mode backtest|paper --max-concurrency 4` | A local multi-agent batch that preserves normal child runs plus batch-level manifests and scoreboards |
 | Sweep one agent across parameter variants | `agent run --sweep rsi_threshold_grid --mode backtest --max-concurrency 4` | A local sweep batch that expands one agent into many backtest variants, preserves normal child runs, and ranks them with the same scoreboard flow |
-| Generate a Docker Compose deployment bundle | `deploy --agent <name> --target docker-compose --mode paper|live` | A Docker Compose bundle for a promoted paper or live agent with compose, Dockerfile, env placeholders, and resolved config |
+| Generate a QuantTradeAI deployment bundle | `deploy --agent <name> --target local|docker-compose --mode paper|live` | A local runner or Docker Compose bundle for a promoted paper or live agent with env placeholders and resolved config |
 
 ## How It Fits Together
 
@@ -80,6 +80,7 @@ QuantTradeAI is one framework with two connected tracks:
 | `agent run --all --mode backtest` from `project.yaml` | Supported |
 | `agent run --all --mode paper` from `project.yaml` | Supported |
 | `agent run --sweep <name> --mode backtest` from `project.yaml` | Supported |
+| `deploy --target local` for paper or live agents | Supported |
 | `deploy --target docker-compose` for paper or live agents | Supported |
 ## Install In 2 Minutes
 
@@ -287,23 +288,26 @@ Sweep child runs are intentionally not promotable. Copy the winning parameters i
 
 ### Deploy A Paper Or Live Agent
 
-Use this if you want a generated Docker Compose bundle for a project-defined paper or live agent.
+Use this if you want a generated local runner or Docker Compose bundle for a project-defined paper or live agent.
 
 ```bash
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local --mode live
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose --mode live
 ```
 
 This writes a deployment bundle under `reports/deployments/<agent>/<timestamp>/` with:
 
-- `docker-compose.yml`
-- `Dockerfile`
+- `run.py` for local bundles, or `docker-compose.yml` and `Dockerfile` for Docker Compose bundles
 - `.env.example`
 - `README.md`
 - `resolved_project_config.yaml`
 - `deployment_manifest.json`
 
 Paper bundles always disable replay in the emitted resolved project config and expect real-time streaming credentials. Local replay-backed paper runs stay unchanged in your source `config/project.yaml`.
+
+Local bundles run `python <bundle>/run.py` from your project environment. The runner uses the bundle's resolved config, loads an optional `.env` file next to `run.py`, and writes runtime artifacts back under the project `runs/` and `reports/` directories.
 
 If the target agent uses `execution.backend: alpaca`, the generated bundle README and manifest call out that the service will submit real Alpaca paper/live market orders instead of simulated local fills.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,10 +50,11 @@ poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.
 ### Agent Deployment
 
 ```bash
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
 ```
 
-Deployment bundles are generated from `config/project.yaml`. Paper bundles disable replay in the emitted deployment config and expect valid real-time provider settings.
+Deployment bundles are generated from `config/project.yaml`. Use `--target local` for a Python runner bundle or `--target docker-compose` for a Compose bundle. Paper bundles disable replay in the emitted deployment config and expect valid real-time provider settings.
 
 ## Important Boundaries
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,13 +73,14 @@ poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yam
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode live
 ```
 
-### Generate A Docker Compose Bundle
+### Generate A Deployment Bundle
 
 ```bash
+poetry run quanttradeai deploy --agent paper_momentum -c config/project.yaml --target local
 poetry run quanttradeai deploy --agent paper_momentum -c config/project.yaml --target docker-compose
 ```
 
-Generated deployment bundles are still real-time paper deployments. QuantTradeAI disables replay in the emitted `resolved_project_config.yaml` and requires the normal provider and websocket settings to be present in the source project config.
+Generated local and Docker Compose deployment bundles are still real-time paper deployments. QuantTradeAI disables replay in the emitted `resolved_project_config.yaml` and requires the normal provider and websocket settings to be present in the source project config.
 
 Paper and live runs write standardized artifacts under `runs/agent/paper/...` and `runs/agent/live/...`, including:
 
@@ -122,7 +123,7 @@ poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.y
 
 The hybrid template already points `model_signal_sources` at `models/promoted/aapl_daily_classifier`, so the happy path does not require editing timestamped experiment directories by hand.
 
-Deployment bundles for project-defined paper agents are written under `reports/deployments/<agent>/<timestamp>/`.
+Deployment bundles for project-defined paper agents are written under `reports/deployments/<agent>/<timestamp>/`. Use `--target local` for a Python runner bundle or `--target docker-compose` for a Compose bundle.
 
 ## Workflow 4: Multi-Agent Batches
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -61,8 +61,9 @@ poetry run quanttradeai agent run --all -c config/project.yaml --mode paper --ma
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest --max-concurrency 4
 
-# Generate a Docker Compose bundle for the paper agent
+# Generate deployment bundles for the paper agent
 # Generated bundles disable replay and expect real-time streaming settings
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
 
 # Lower-level utility commands that still exist
@@ -106,7 +107,14 @@ Canonical agent paper artifacts:
 - `runs/agent/paper/<timestamp>_<agent>/prompt_samples.json` for `llm` and `hybrid`
 - `runs/agent/paper/<timestamp>_<agent>/replay_manifest.json` when replay is enabled
 
-Canonical deployment bundle artifacts:
+Canonical local deployment bundle artifacts:
+- `reports/deployments/<agent>/<timestamp>/run.py`
+- `reports/deployments/<agent>/<timestamp>/.env.example`
+- `reports/deployments/<agent>/<timestamp>/README.md`
+- `reports/deployments/<agent>/<timestamp>/resolved_project_config.yaml`
+- `reports/deployments/<agent>/<timestamp>/deployment_manifest.json`
+
+Canonical Docker Compose deployment bundle artifacts:
 - `reports/deployments/<agent>/<timestamp>/docker-compose.yml`
 - `reports/deployments/<agent>/<timestamp>/Dockerfile`
 - `reports/deployments/<agent>/<timestamp>/.env.example`

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -1170,7 +1170,7 @@ def cmd_deploy(
     mode: Optional[str] = typer.Option(
         None,
         "--mode",
-        help="Deployment mode. Defaults to deployment.mode from project config; docker-compose supports paper and live.",
+        help="Deployment mode. Defaults to deployment.mode from project config; local and docker-compose support paper and live.",
     ),
     output: Optional[str] = typer.Option(
         None,

--- a/quanttradeai/deployment.py
+++ b/quanttradeai/deployment.py
@@ -8,6 +8,7 @@ import os
 import re
 import tempfile
 from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -31,9 +32,26 @@ DEFAULT_LLM_API_KEY_ENV_VARS = {
     "anthropic": "ANTHROPIC_API_KEY",
     "huggingface": "HUGGINGFACE_API_KEY",
 }
-SUPPORTED_DEPLOY_TARGETS = {"docker-compose"}
+SUPPORTED_DEPLOY_TARGETS = {"docker-compose", "local"}
 SUPPORTED_DEPLOY_MODES = {"paper", "live"}
 SUPPORTED_AGENT_KINDS = {"rule", "model", "llm", "hybrid"}
+
+
+@dataclass
+class PreparedDeployment:
+    config_path: Path
+    project_root: Path
+    output_path: Path
+    project_config: dict[str, Any]
+    warnings: list[str]
+    target: str
+    mode: str
+    agent_config: dict[str, Any]
+    service_name: str
+    safety_requirements: list[str]
+    execution_backend: str
+    broker_provider: str | None
+    env_vars: list[tuple[str, str]]
 
 
 def _slugify(value: str) -> str:
@@ -108,10 +126,10 @@ def _compose_environment(env_vars: list[tuple[str, str]]) -> dict[str, str]:
     return {name: f"${{{name}:-}}" for name, _ in env_vars}
 
 
-def _render_env_example(env_vars: list[tuple[str, str]]) -> str:
+def _render_env_example(env_vars: list[tuple[str, str]], *, target_label: str) -> str:
     lines = [
-        "# QuantTradeAI docker-compose deployment environment",
-        "# Fill the values needed by this deployment bundle before running docker compose.",
+        f"# QuantTradeAI {target_label} deployment environment",
+        "# Fill the values needed by this deployment bundle before running it.",
         "",
     ]
     if not env_vars:
@@ -218,6 +236,142 @@ def _render_bundle_readme(
     return "\n".join(lines) + "\n"
 
 
+def _render_local_runner_script(
+    *,
+    agent_name: str,
+    mode: str,
+    project_root: Path,
+) -> str:
+    project_root_literal = json.dumps(project_root.as_posix())
+    agent_name_literal = json.dumps(agent_name)
+    mode_literal = json.dumps(mode)
+    return f'''"""Run a QuantTradeAI agent from this local deployment bundle."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+BUNDLE_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = Path({project_root_literal})
+CONFIG_PATH = BUNDLE_DIR / "resolved_project_config.yaml"
+AGENT_NAME = {agent_name_literal}
+MODE = {mode_literal}
+
+
+def _strip_simple_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {{"'", '"'}}:
+        return value[1:-1]
+    return value
+
+
+def _load_env_file(path: Path) -> None:
+    if not path.is_file():
+        return
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = _strip_simple_quotes(value.strip())
+        if not key or not value:
+            continue
+        os.environ.setdefault(key, value)
+
+
+def main() -> int:
+    _load_env_file(BUNDLE_DIR / ".env")
+    command = [
+        sys.executable,
+        "-m",
+        "quanttradeai.cli",
+        "agent",
+        "run",
+        "--agent",
+        AGENT_NAME,
+        "-c",
+        str(CONFIG_PATH),
+        "--mode",
+        MODE,
+    ]
+    return subprocess.call(command, cwd=str(PROJECT_ROOT))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def _render_local_bundle_readme(
+    *,
+    agent_name: str,
+    agent_kind: str,
+    mode: str,
+    execution_backend: str,
+    broker_provider: str | None,
+    next_command: str,
+    env_vars: list[tuple[str, str]],
+    safety_requirements: list[str],
+) -> str:
+    lines = [
+        "# QuantTradeAI Local Deployment Bundle",
+        "",
+        f"This bundle runs the `{agent_name}` `{agent_kind}` agent in `{mode}` mode on the local machine.",
+        "",
+        "## Mode",
+        "",
+        f"- `mode: {mode}`",
+        f"- `execution.backend: {execution_backend}`",
+        "",
+        "## Files",
+        "",
+        "- `run.py`: starts the agent with the resolved project config in this bundle.",
+        "- `.env.example`: provider environment variables inferred from the project config.",
+        "- `resolved_project_config.yaml`: exact project config snapshot used for deployment generation.",
+        "- `deployment_manifest.json`: machine-readable summary of the generated bundle.",
+        "",
+        "## Run",
+        "",
+        "From the project environment:",
+        "",
+        "```bash",
+        next_command,
+        "```",
+        "",
+        "The runner executes from the original project root so `data/`, `runs/`, and `reports/` stay in the project.",
+    ]
+
+    if execution_backend == "alpaca" and broker_provider:
+        lines.extend(
+            [
+                "",
+                "This bundle uses broker-backed execution.",
+                f"In `{mode}` mode it will submit real `{broker_provider}` market orders instead of simulated local fills.",
+            ]
+        )
+
+    if safety_requirements:
+        lines.extend(["", "## Safety Requirements", ""])
+        lines.extend([f"- {requirement}" for requirement in safety_requirements])
+
+    if env_vars:
+        lines.extend(
+            [
+                "",
+                "## Environment",
+                "",
+                "Create a `.env` file next to `run.py` with the variables listed in `.env.example`, or export them before starting the runner.",
+            ]
+        )
+
+    return "\n".join(lines) + "\n"
+
+
 def _copy_resolved_project_config(
     *,
     config_path: Path | str,
@@ -253,6 +407,60 @@ def _disable_replay_for_deployment(project_config: dict[str, Any]) -> dict[str, 
         streaming_cfg["replay"] = replay_cfg
         deployment_project.setdefault("data", {})["streaming"] = streaming_cfg
     return deployment_project
+
+
+def _absolute_project_path(config_path: Path, candidate: Any) -> str:
+    if candidate is None:
+        return ""
+    candidate_text = str(candidate).strip()
+    if not candidate_text:
+        return candidate_text
+    return resolve_project_path(config_path, candidate_text).resolve().as_posix()
+
+
+def _absolutize_local_project_paths(
+    *,
+    project_config: dict[str, Any],
+    config_path: Path,
+) -> dict[str, Any]:
+    """Make bundle config asset paths independent from the bundle location."""
+
+    local_project = copy.deepcopy(project_config)
+    for agent in local_project.get("agents") or []:
+        if not isinstance(agent, dict):
+            continue
+
+        llm_cfg = agent.get("llm")
+        if isinstance(llm_cfg, dict) and llm_cfg.get("prompt_file"):
+            llm_cfg["prompt_file"] = _absolute_project_path(
+                config_path, llm_cfg["prompt_file"]
+            )
+
+        model_cfg = agent.get("model")
+        if isinstance(model_cfg, dict) and model_cfg.get("path"):
+            model_cfg["path"] = _absolute_project_path(config_path, model_cfg["path"])
+
+        for source in agent.get("model_signal_sources") or []:
+            if isinstance(source, dict) and source.get("path"):
+                source["path"] = _absolute_project_path(config_path, source["path"])
+
+        context_cfg = agent.get("context")
+        if not isinstance(context_cfg, dict):
+            continue
+
+        notes_cfg = context_cfg.get("notes")
+        agent_name = str(agent.get("name") or "agent").strip() or "agent"
+        if notes_cfg is True:
+            context_cfg["notes"] = {
+                "enabled": True,
+                "file": _absolute_project_path(config_path, f"notes/{agent_name}.md"),
+            }
+        elif isinstance(notes_cfg, dict) and notes_cfg.get("enabled", True):
+            notes_cfg["file"] = _absolute_project_path(
+                config_path, notes_cfg.get("file") or f"notes/{agent_name}.md"
+            )
+
+    return local_project
 
 
 def _deployment_safety_requirements(mode: str) -> list[str]:
@@ -384,17 +592,15 @@ def _required_mounts(
     return deduped
 
 
-def deploy_project_agent(
+def _prepare_deployment(
     *,
     agent_name: str,
-    config_path: Path | str = "config/project.yaml",
-    target: str | None = None,
-    mode: str | None = None,
-    output_dir: Path | str | None = None,
-    force: bool = False,
-) -> dict[str, Any]:
-    """Generate a docker-compose deployment bundle for a project-defined agent."""
-
+    config_path: Path | str,
+    target: str | None,
+    mode: str | None,
+    output_dir: Path | str | None,
+    force: bool,
+) -> PreparedDeployment:
     config_path = Path(config_path).resolve()
     project_root = infer_project_root(config_path)
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
@@ -420,6 +626,7 @@ def deploy_project_agent(
             config_path=config_path,
             destination=temp_resolved_project_path,
         )
+
     deployment_cfg = dict((resolved_project.get("deployment") or {}))
     resolved_target = str(target or deployment_cfg.get("target") or "docker-compose")
     resolved_target = resolved_target.strip().lower()
@@ -448,6 +655,12 @@ def deploy_project_agent(
                 "Paper deployment bundles always use real-time streaming; replay was disabled in the generated bundle."
             )
 
+    if resolved_target == "local":
+        deployment_project = _absolutize_local_project_paths(
+            project_config=deployment_project,
+            config_path=config_path,
+        )
+
     agent_config = _resolve_agent_config(
         project_config=deployment_project,
         agent_name=agent_name,
@@ -472,8 +685,6 @@ def deploy_project_agent(
         compile_live_risk_runtime_config(deployment_project)
         compile_live_position_manager_runtime_config(deployment_project)
 
-    service_name = _slugify(f"{agent_name}-{resolved_mode}")
-    safety_requirements = _deployment_safety_requirements(resolved_mode)
     execution_backend = resolve_execution_backend(agent_config)
     broker_provider = (
         str(
@@ -485,14 +696,37 @@ def deploy_project_agent(
         if execution_backend == "alpaca"
         else None
     )
-    env_vars = _required_env_vars(
-        agent_config=agent_config,
-        project_config=deployment_project,
-    )
-    mounts = _required_mounts(
-        project_root=project_root,
+
+    return PreparedDeployment(
         config_path=config_path,
+        project_root=project_root,
+        output_path=output_path,
+        project_config=deployment_project,
+        warnings=warnings,
+        target=resolved_target,
+        mode=resolved_mode,
         agent_config=agent_config,
+        service_name=_slugify(f"{agent_name}-{resolved_mode}"),
+        safety_requirements=_deployment_safety_requirements(resolved_mode),
+        execution_backend=execution_backend,
+        broker_provider=broker_provider,
+        env_vars=_required_env_vars(
+            agent_config=agent_config,
+            project_config=deployment_project,
+        ),
+    )
+
+
+def _write_docker_compose_bundle(
+    prepared: PreparedDeployment,
+    *,
+    agent_name: str,
+) -> dict[str, Any]:
+    output_path = prepared.output_path
+    mounts = _required_mounts(
+        project_root=prepared.project_root,
+        config_path=prepared.config_path,
+        agent_config=prepared.agent_config,
         output_dir=output_path,
     )
 
@@ -505,14 +739,14 @@ def deploy_project_agent(
         "-c",
         "config/project.yaml",
         "--mode",
-        resolved_mode,
+        prepared.mode,
     ]
 
-    build_context = _relative_posix(project_root, output_path)
-    dockerfile_rel = _relative_posix(output_path / "Dockerfile", project_root)
+    build_context = _relative_posix(prepared.project_root, output_path)
+    dockerfile_rel = _relative_posix(output_path / "Dockerfile", prepared.project_root)
     compose_payload = {
         "services": {
-            service_name: {
+            prepared.service_name: {
                 "build": {
                     "context": build_context,
                     "dockerfile": dockerfile_rel,
@@ -520,7 +754,7 @@ def deploy_project_agent(
                 "working_dir": "/app",
                 "command": compose_command,
                 "restart": "unless-stopped",
-                "environment": _compose_environment(env_vars),
+                "environment": _compose_environment(prepared.env_vars),
                 "volumes": [
                     (
                         f"{_relative_posix(Path(mount['host']), output_path)}:"
@@ -537,7 +771,7 @@ def deploy_project_agent(
 
     resolved_project_path = output_path / "resolved_project_config.yaml"
     resolved_project_path.write_text(
-        yaml.safe_dump(deployment_project, sort_keys=False),
+        yaml.safe_dump(prepared.project_config, sort_keys=False),
         encoding="utf-8",
     )
 
@@ -551,41 +785,49 @@ def deploy_project_agent(
     )
 
     env_example_path = output_path / ".env.example"
-    env_example_path.write_text(_render_env_example(env_vars), encoding="utf-8")
-
-    next_command = (
-        f"docker compose -f {compose_path.as_posix()} up --build {service_name}"
+    env_example_path.write_text(
+        _render_env_example(prepared.env_vars, target_label="docker-compose"),
+        encoding="utf-8",
     )
+
+    next_command = f"docker compose -f {compose_path.as_posix()} up --build {prepared.service_name}"
     bundle_readme_path = output_path / "README.md"
     bundle_readme_path.write_text(
         _render_bundle_readme(
             agent_name=agent_name,
-            agent_kind=str(agent_config.get("kind") or ""),
-            mode=resolved_mode,
-            execution_backend=execution_backend,
-            broker_provider=broker_provider,
-            service_name=service_name,
+            agent_kind=str(prepared.agent_config.get("kind") or ""),
+            mode=prepared.mode,
+            execution_backend=prepared.execution_backend,
+            broker_provider=prepared.broker_provider,
+            service_name=prepared.service_name,
             next_command=next_command,
-            env_vars=env_vars,
-            safety_requirements=safety_requirements,
+            env_vars=prepared.env_vars,
+            safety_requirements=prepared.safety_requirements,
         ),
         encoding="utf-8",
     )
 
+    artifacts = {
+        "compose": compose_path.as_posix(),
+        "dockerfile": dockerfile_path.as_posix(),
+        "env_example": env_example_path.as_posix(),
+        "readme": bundle_readme_path.as_posix(),
+        "resolved_project_config": resolved_project_path.as_posix(),
+    }
     manifest = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "agent_name": agent_name,
-        "agent_kind": agent_config.get("kind"),
-        "target": resolved_target,
-        "mode": resolved_mode,
-        "execution_backend": execution_backend,
-        "broker_provider": broker_provider,
-        "service_name": service_name,
-        "project_root": project_root.as_posix(),
-        "source_config": config_path.as_posix(),
+        "agent_kind": prepared.agent_config.get("kind"),
+        "target": prepared.target,
+        "mode": prepared.mode,
+        "execution_backend": prepared.execution_backend,
+        "broker_provider": prepared.broker_provider,
+        "service_name": prepared.service_name,
+        "project_root": prepared.project_root.as_posix(),
+        "source_config": prepared.config_path.as_posix(),
         "command": compose_command,
-        "safety_requirements": safety_requirements,
-        "environment_variables": [name for name, _ in env_vars],
+        "safety_requirements": prepared.safety_requirements,
+        "environment_variables": [name for name, _ in prepared.env_vars],
         "volumes": [
             {
                 "host": _path_to_posix(Path(mount["host"])),
@@ -594,17 +836,117 @@ def deploy_project_agent(
             }
             for mount in mounts
         ],
-        "artifacts": {
-            "compose": compose_path.as_posix(),
-            "dockerfile": dockerfile_path.as_posix(),
-            "env_example": env_example_path.as_posix(),
-            "readme": bundle_readme_path.as_posix(),
-            "resolved_project_config": resolved_project_path.as_posix(),
-        },
-        "warnings": warnings,
+        "artifacts": artifacts,
+        "warnings": prepared.warnings,
         "next_command": next_command,
     }
-    manifest_path = output_path / "deployment_manifest.json"
+    return _write_manifest_and_result(
+        prepared=prepared,
+        manifest=manifest,
+        artifacts=artifacts,
+        next_command=next_command,
+    )
+
+
+def _write_local_bundle(
+    prepared: PreparedDeployment,
+    *,
+    agent_name: str,
+) -> dict[str, Any]:
+    output_path = prepared.output_path
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    resolved_project_path = output_path / "resolved_project_config.yaml"
+    resolved_project_path.write_text(
+        yaml.safe_dump(prepared.project_config, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    runner_path = output_path / "run.py"
+    runner_path.write_text(
+        _render_local_runner_script(
+            agent_name=agent_name,
+            mode=prepared.mode,
+            project_root=prepared.project_root,
+        ),
+        encoding="utf-8",
+    )
+
+    env_example_path = output_path / ".env.example"
+    env_example_path.write_text(
+        _render_env_example(prepared.env_vars, target_label="local"),
+        encoding="utf-8",
+    )
+
+    next_command = f"python {runner_path.as_posix()}"
+    bundle_readme_path = output_path / "README.md"
+    bundle_readme_path.write_text(
+        _render_local_bundle_readme(
+            agent_name=agent_name,
+            agent_kind=str(prepared.agent_config.get("kind") or ""),
+            mode=prepared.mode,
+            execution_backend=prepared.execution_backend,
+            broker_provider=prepared.broker_provider,
+            next_command=next_command,
+            env_vars=prepared.env_vars,
+            safety_requirements=prepared.safety_requirements,
+        ),
+        encoding="utf-8",
+    )
+
+    artifacts = {
+        "runner": runner_path.as_posix(),
+        "env_example": env_example_path.as_posix(),
+        "readme": bundle_readme_path.as_posix(),
+        "resolved_project_config": resolved_project_path.as_posix(),
+    }
+    manifest = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "agent_name": agent_name,
+        "agent_kind": prepared.agent_config.get("kind"),
+        "target": prepared.target,
+        "mode": prepared.mode,
+        "execution_backend": prepared.execution_backend,
+        "broker_provider": prepared.broker_provider,
+        "service_name": prepared.service_name,
+        "project_root": prepared.project_root.as_posix(),
+        "source_config": prepared.config_path.as_posix(),
+        "command": ["python", runner_path.as_posix()],
+        "agent_command": [
+            "python",
+            "-m",
+            "quanttradeai.cli",
+            "agent",
+            "run",
+            "--agent",
+            agent_name,
+            "-c",
+            resolved_project_path.as_posix(),
+            "--mode",
+            prepared.mode,
+        ],
+        "safety_requirements": prepared.safety_requirements,
+        "environment_variables": [name for name, _ in prepared.env_vars],
+        "artifacts": artifacts,
+        "warnings": prepared.warnings,
+        "next_command": next_command,
+    }
+    return _write_manifest_and_result(
+        prepared=prepared,
+        manifest=manifest,
+        artifacts=artifacts,
+        next_command=next_command,
+    )
+
+
+def _write_manifest_and_result(
+    *,
+    prepared: PreparedDeployment,
+    manifest: dict[str, Any],
+    artifacts: dict[str, str],
+    next_command: str,
+) -> dict[str, Any]:
+    manifest_path = prepared.output_path / "deployment_manifest.json"
     manifest_path.write_text(
         json.dumps(manifest, indent=2, default=_json_default),
         encoding="utf-8",
@@ -612,14 +954,45 @@ def deploy_project_agent(
 
     return {
         "status": "success",
-        "agent_name": agent_name,
-        "target": resolved_target,
-        "mode": resolved_mode,
-        "output_dir": output_path.as_posix(),
+        "agent_name": manifest["agent_name"],
+        "target": prepared.target,
+        "mode": prepared.mode,
+        "output_dir": prepared.output_path.as_posix(),
         "artifacts": {
-            **manifest["artifacts"],
+            **artifacts,
             "manifest": manifest_path.as_posix(),
         },
-        "warnings": warnings,
+        "warnings": prepared.warnings,
         "next_command": next_command,
     }
+
+
+def deploy_project_agent(
+    *,
+    agent_name: str,
+    config_path: Path | str = "config/project.yaml",
+    target: str | None = None,
+    mode: str | None = None,
+    output_dir: Path | str | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Generate a deployment bundle for a project-defined agent."""
+
+    prepared = _prepare_deployment(
+        agent_name=agent_name,
+        config_path=config_path,
+        target=target,
+        mode=mode,
+        output_dir=output_dir,
+        force=force,
+    )
+
+    if prepared.target == "docker-compose":
+        return _write_docker_compose_bundle(prepared, agent_name=agent_name)
+    if prepared.target == "local":
+        return _write_local_bundle(prepared, agent_name=agent_name)
+
+    supported = ", ".join(sorted(SUPPORTED_DEPLOY_TARGETS))
+    raise ValueError(
+        f"Unsupported deployment target '{prepared.target}'. Supported targets: {supported}."
+    )

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,6 @@
 # QuantTradeAI Roadmap
 
-Last updated: 2026-04-17
+Last updated: 2026-04-22
 
 This document is the product source of truth for QuantTradeAI.
 It is written for both human contributors and coding agents.
@@ -352,7 +352,7 @@ Status on 2026-04-17:
 - `quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml` is implemented for successful agent backtest-to-paper promotion.
 - `quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live <agent_name>` is implemented for successful paper-to-live promotion with an explicit safety acknowledgement.
 - Top-level `risk` and `position_manager` are now the canonical live safety/runtime sections in `config/project.yaml`.
-- `quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` now generates paper and live deployment bundles with compose, Dockerfile, env placeholders, resolved config, and a deployment manifest. Paper bundles still disable replay in the emitted config, and Alpaca-backed agents are called out explicitly in the generated bundle README and manifest.
+- `quanttradeai deploy --agent <name> -c config/project.yaml --target local|docker-compose` now generates paper and live deployment bundles with env placeholders, resolved config, and a deployment manifest. Local bundles include a Python runner, Docker Compose bundles include compose and Dockerfile assets, paper bundles still disable replay in the emitted config, and Alpaca-backed agents are called out explicitly in the generated bundle README and manifest. Managed runner deployment remains future work.
 - Replaced legacy paths have been removed from the primary CLI surface: `train`, `backtest-model`, `live-trade`, `validate-config`, and the `--legacy-config-dir` import flags are gone. `fetch-data`, `evaluate`, and standalone `backtest` remain as utility commands outside the primary product workflow.
 
 ### Stage 2: Multi-Agent Lab
@@ -460,12 +460,13 @@ quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode paper
 quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live paper_momentum
 quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode live
+quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
 quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
 quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest
 ```
 
 Current implementation note:
-`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`, including `agent run --all --mode paper`. Agents can also opt into `execution.backend: alpaca` for happy-path real-time paper/live broker submission with broker-synced account and position snapshots. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`. `deploy --target docker-compose` supports both simulated and Alpaca-backed paper/live agent bundles.
+`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`, including `agent run --all --mode paper`. Agents can also opt into `execution.backend: alpaca` for happy-path real-time paper/live broker submission with broker-synced account and position snapshots. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`. `deploy --target local` and `deploy --target docker-compose` support both simulated and Alpaca-backed paper/live agent bundles.
 
 ### Hybrid track
 

--- a/tests/integration/test_deploy_cli.py
+++ b/tests/integration/test_deploy_cli.py
@@ -74,6 +74,17 @@ def _load_deploy_bundle(output_dir: Path) -> tuple[str, str, str, dict, dict]:
     return compose_text, env_example, readme, manifest, resolved_project
 
 
+def _load_local_deploy_bundle(output_dir: Path) -> tuple[str, str, str, dict, dict]:
+    runner_text = (output_dir / "run.py").read_text(encoding="utf-8")
+    env_example = (output_dir / ".env.example").read_text(encoding="utf-8")
+    readme = (output_dir / "README.md").read_text(encoding="utf-8")
+    manifest = json.loads(
+        (output_dir / "deployment_manifest.json").read_text(encoding="utf-8")
+    )
+    resolved_project = _read_yaml(output_dir / "resolved_project_config.yaml")
+    return runner_text, env_example, readme, manifest, resolved_project
+
+
 def test_rule_agent_deploy_writes_paper_bundle_and_preserves_project_config(
     tmp_path: Path, monkeypatch
 ):
@@ -119,6 +130,81 @@ def test_rule_agent_deploy_writes_paper_bundle_and_preserves_project_config(
     assert resolved_project["data"]["streaming"]["replay"]["enabled"] is False
 
 
+def test_rule_agent_local_deploy_writes_paper_bundle_and_preserves_project_config(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "rule-agent")
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name="rsi_reversion",
+        config_path=config_path,
+        output_dir="deployments/rule-local",
+        extra_args=["--target", "local"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    output_dir = Path(payload["output_dir"])
+    runner_text, env_example, readme, manifest, resolved_project = (
+        _load_local_deploy_bundle(output_dir)
+    )
+
+    assert payload["status"] == "success"
+    assert payload["target"] == "local"
+    assert payload["mode"] == "paper"
+    assert payload["next_command"] == f"python {(output_dir / 'run.py').as_posix()}"
+    assert payload["artifacts"]["runner"].endswith("/run.py")
+    assert "compose" not in payload["artifacts"]
+    assert "dockerfile" not in payload["artifacts"]
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert (output_dir / "run.py").is_file()
+    assert not (output_dir / "docker-compose.yml").exists()
+    assert not (output_dir / "Dockerfile").exists()
+    assert "quanttradeai.cli" in runner_text
+    assert "resolved_project_config.yaml" in runner_text
+    assert "ALPACA_API_KEY" in env_example
+    assert "ALPACA_API_SECRET" in env_example
+    assert "docker compose" not in readme.lower()
+    assert "local machine" in readme
+    assert manifest["agent_name"] == "rsi_reversion"
+    assert manifest["mode"] == "paper"
+    assert manifest["target"] == "local"
+    assert manifest["command"] == ["python", (output_dir / "run.py").as_posix()]
+    assert manifest["safety_requirements"] == []
+    assert "volumes" not in manifest
+    assert resolved_project["data"]["streaming"]["replay"]["enabled"] is False
+
+
+def test_local_deploy_can_use_project_config_default_target(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "rule-agent")
+    payload = _read_yaml(config_path)
+    payload["deployment"]["target"] = "local"
+    _write_yaml(config_path, payload)
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name="rsi_reversion",
+        config_path=config_path,
+        output_dir="deployments/rule-local-default",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    deploy_payload = json.loads(result.stdout)
+    output_dir = Path(deploy_payload["output_dir"])
+    _runner_text, _env_example, _readme, manifest, _resolved_project = (
+        _load_local_deploy_bundle(output_dir)
+    )
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert deploy_payload["target"] == "local"
+    assert manifest["target"] == "local"
+    assert (output_dir / "run.py").is_file()
+    assert not (output_dir / "docker-compose.yml").exists()
+
+
 def test_rule_agent_live_deploy_uses_config_default_mode_and_preserves_project_config(
     tmp_path: Path, monkeypatch
 ):
@@ -162,6 +248,50 @@ def test_rule_agent_live_deploy_uses_config_default_mode_and_preserves_project_c
     assert resolved_project["data"]["streaming"]["replay"]["enabled"] is True
 
 
+def test_hybrid_agent_local_live_deploy_absolutizes_prompt_and_model_paths(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "hybrid")
+    _configure_live_deploy(config_path, deployment_mode="paper")
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name="hybrid_swing_agent",
+        config_path=config_path,
+        output_dir="deployments/hybrid-local-live",
+        extra_args=["--target", "local", "--mode", "live"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    output_dir = Path(payload["output_dir"])
+    runner_text, env_example, readme, manifest, resolved_project = (
+        _load_local_deploy_bundle(output_dir)
+    )
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert payload["status"] == "success"
+    assert payload["target"] == "local"
+    assert payload["mode"] == "live"
+    assert manifest["agent_name"] == "hybrid_swing_agent"
+    assert manifest["mode"] == "live"
+    assert manifest["target"] == "local"
+    assert manifest["safety_requirements"]
+    assert "OPENAI_API_KEY" in env_example
+    assert "ALPACA_API_KEY" in env_example
+    assert "quanttradeai.cli" in runner_text
+    assert "in `live` mode" in readme
+    assert "Safety Requirements" in readme
+    agent_config = resolved_project["agents"][0]
+    assert Path(agent_config["llm"]["prompt_file"]).is_absolute()
+    assert Path(agent_config["model_signal_sources"][0]["path"]).is_absolute()
+    assert not (output_dir / "docker-compose.yml").exists()
+    assert not any(
+        "replay was disabled in the generated bundle" in warning.lower()
+        for warning in payload["warnings"]
+    )
+
+
 def test_deploy_readme_and_manifest_call_out_alpaca_backed_execution(
     tmp_path: Path, monkeypatch
 ):
@@ -180,8 +310,8 @@ def test_deploy_readme_and_manifest_call_out_alpaca_backed_execution(
     assert result.exit_code == 0, result.stdout
     deploy_payload = json.loads(result.stdout)
     output_dir = Path(deploy_payload["output_dir"])
-    _compose_text, _env_example, readme, manifest, _resolved_project = _load_deploy_bundle(
-        output_dir
+    _compose_text, _env_example, readme, manifest, _resolved_project = (
+        _load_deploy_bundle(output_dir)
     )
 
     assert manifest["execution_backend"] == "alpaca"
@@ -191,7 +321,13 @@ def test_deploy_readme_and_manifest_call_out_alpaca_backed_execution(
 
 
 @pytest.mark.parametrize(
-    ("template", "agent_name", "expect_openai_env", "expect_prompt_mount", "expect_models_mount"),
+    (
+        "template",
+        "agent_name",
+        "expect_openai_env",
+        "expect_prompt_mount",
+        "expect_models_mount",
+    ),
     [
         ("llm-agent", "breakout_gpt", True, True, False),
         ("model-agent", "paper_momentum", False, False, True),
@@ -221,8 +357,8 @@ def test_live_deploy_supports_llm_model_and_hybrid_agents(
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
     output_dir = Path(payload["output_dir"])
-    compose_text, env_example, readme, manifest, _resolved_project = _load_deploy_bundle(
-        output_dir
+    compose_text, env_example, readme, manifest, _resolved_project = (
+        _load_deploy_bundle(output_dir)
     )
 
     assert config_path.read_text(encoding="utf-8") == original_config
@@ -264,8 +400,8 @@ def test_deploy_normalizes_streaming_provider_env_var_prefix(
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
     output_dir = Path(payload["output_dir"])
-    _compose_text, env_example, _readme, _manifest, _resolved_project = _load_deploy_bundle(
-        output_dir
+    _compose_text, env_example, _readme, _manifest, _resolved_project = (
+        _load_deploy_bundle(output_dir)
     )
 
     assert "FOO_BAR_API_KEY" in env_example
@@ -287,8 +423,8 @@ def test_deploy_disables_replay_in_generated_paper_bundle_and_warns(
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
     output_dir = Path(payload["output_dir"])
-    _compose_text, _env_example, _readme, _manifest, resolved_project = _load_deploy_bundle(
-        output_dir
+    _compose_text, _env_example, _readme, _manifest, resolved_project = (
+        _load_deploy_bundle(output_dir)
     )
 
     assert config_path.read_text(encoding="utf-8") != ""
@@ -319,9 +455,7 @@ def test_deploy_rejects_replay_only_project_without_realtime_streaming_fields(
     assert "data.streaming.provider must be configured" in combined_output
 
 
-def test_live_deploy_requires_agent_to_be_configured_live(
-    tmp_path: Path, monkeypatch
-):
+def test_live_deploy_requires_agent_to_be_configured_live(tmp_path: Path, monkeypatch):
     config_path = _init_template(tmp_path, monkeypatch, "llm-agent")
     original_config = config_path.read_text(encoding="utf-8")
 
@@ -336,6 +470,26 @@ def test_live_deploy_requires_agent_to_be_configured_live(
     combined_output = f"{result.stdout}\n{result.stderr}"
     assert "must be configured with mode=live" in combined_output
     assert config_path.read_text(encoding="utf-8") == original_config
+
+
+def test_local_live_deploy_requires_agent_to_be_configured_live(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "llm-agent")
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name="breakout_gpt",
+        config_path=config_path,
+        output_dir="deployments/local-live-not-configured",
+        extra_args=["--target", "local", "--mode", "live"],
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert "must be configured with mode=live" in combined_output
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert not Path("deployments/local-live-not-configured").exists()
 
 
 @pytest.mark.parametrize(
@@ -406,6 +560,41 @@ def test_live_deploy_requires_top_level_live_safety_sections(
     assert config_path.read_text(encoding="utf-8") == original_config
 
 
+@pytest.mark.parametrize(
+    ("field_name", "expected_error"),
+    [
+        ("risk", "risk is required when an agent is configured with mode=live."),
+        (
+            "position_manager",
+            "position_manager is required when an agent is configured with mode=live.",
+        ),
+    ],
+)
+def test_local_live_deploy_requires_top_level_live_safety_sections(
+    tmp_path: Path,
+    monkeypatch,
+    field_name: str,
+    expected_error: str,
+):
+    config_path = _init_template(tmp_path, monkeypatch, "rule-agent")
+    payload = _configure_live_deploy(config_path)
+    payload.pop(field_name)
+    _write_yaml(config_path, payload)
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name="rsi_reversion",
+        config_path=config_path,
+        output_dir=f"deployments/local-live-missing-{field_name}",
+        extra_args=["--target", "local", "--mode", "live"],
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert expected_error in combined_output
+    assert config_path.read_text(encoding="utf-8") == original_config
+
+
 def test_deploy_failure_cases(
     tmp_path: Path,
     monkeypatch,
@@ -464,6 +653,9 @@ def test_deploy_failure_cases(
         assert result.exit_code == 1
         combined_output = f"{result.stdout}\n{result.stderr}"
         assert expected_error in combined_output
+        if expected_error == "Unsupported deployment target":
+            assert "docker-compose" in combined_output
+            assert "local" in combined_output
         assert config_path.read_text(encoding="utf-8") == original_config
         if requested_output == existing_output:
             assert (requested_output / "stale.txt").is_file()


### PR DESCRIPTION
## Summary

- Add `quanttradeai deploy --target local` for paper and live project agents.
- Generate local runner bundles with `run.py`, `.env.example`, `README.md`, `resolved_project_config.yaml`, and `deployment_manifest.json`.
- Preserve existing Docker Compose deployment behavior while sharing validation and safety checks.
- Update deployment tests, README, docs, CLI help, and roadmap to cover local and Docker Compose deployment targets.

## Validation

- `make lint.format.test`
- Pre-commit hooks during commit: format, lint, test

## Notes

Local paper bundles keep the existing deployment behavior of disabling replay in the emitted resolved config and requiring real-time streaming settings. Live bundles keep the existing live safety gates.