### PR TITLE
feat: add live multi-agent batch runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 | Run a trained model as an agent | `init --template model-agent` -> `validate` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | One YAML-defined model agent wired to a stable `models/promoted/...` path that can be backtested, promoted, paper-run, and live-run |
 | Run an LLM agent | `init --template llm-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Prompt-driven agent logic using project config across all three modes |
 | Run a hybrid agent | `init --template hybrid` -> `research run` -> `promote --run research/<run_id>` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Model signals plus LLM reasoning in one project, with research outputs promoted into a stable path before the agent is promoted through environments |
-| Run every project agent together | `agent run --all --mode backtest|paper --max-concurrency 4` | A local multi-agent batch that preserves normal child runs plus batch-level manifests and scoreboards |
+| Run every project agent together | `agent run --all --mode backtest|paper|live --max-concurrency 4` | A local multi-agent batch that preserves normal child runs plus batch-level manifests and scoreboards |
 | Sweep one agent across parameter variants | `agent run --sweep rsi_threshold_grid --mode backtest --max-concurrency 4` | A local sweep batch that expands one agent into many backtest variants, preserves normal child runs, and ranks them with the same scoreboard flow |
 | Generate a QuantTradeAI deployment bundle | `deploy --agent <name> --target local|docker-compose --mode paper|live` | A local runner or Docker Compose bundle for a promoted paper or live agent with env placeholders and resolved config |
 
@@ -79,6 +79,7 @@ QuantTradeAI is one framework with two connected tracks:
 | Agent paper-to-live promotion with acknowledgement | Supported |
 | `agent run --all --mode backtest` from `project.yaml` | Supported |
 | `agent run --all --mode paper` from `project.yaml` | Supported |
+| `agent run --all --mode live` from `project.yaml` with acknowledgement | Supported |
 | `agent run --sweep <name> --mode backtest` from `project.yaml` | Supported |
 | `deploy --target local` for paper or live agents | Supported |
 | `deploy --target docker-compose` for paper or live agents | Supported |
@@ -248,16 +249,19 @@ poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper --max-concurrency 4
+poetry run quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>
 ```
 
-This writes batch artifacts under `runs/agent/batches/<timestamp>_<project>_backtest/` or `runs/agent/batches/<timestamp>_<project>_paper/`:
+Live batches require every agent in `config/project.yaml` to already have `mode: live` and require `--acknowledge-live` to exactly match `project.name`.
+
+This writes batch artifacts under `runs/agent/batches/<timestamp>_<project>_<mode>/`:
 
 - `batch_manifest.json`
 - `results.json`
 - `scoreboard.json`
 - `scoreboard.txt`
 
-Each child agent still writes its normal run under `runs/agent/backtest/...` or `runs/agent/paper/...`, so `quanttradeai runs list --scoreboard` continues to work for ranking and `quanttradeai runs list --compare ...` can inspect shortlisted runs in detail. Backtest batches rank by `net_sharpe`; paper batches rank by `total_pnl`.
+Each child agent still writes its normal run under `runs/agent/backtest/...`, `runs/agent/paper/...`, or `runs/agent/live/...`, so `quanttradeai runs list --scoreboard` continues to work for ranking and `quanttradeai runs list --compare ...` can inspect shortlisted runs in detail. Backtest batches rank by `net_sharpe`; paper and live batches rank by `total_pnl`.
 
 ### Sweep One Agent
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ poetry run quanttradeai init --template llm-agent -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
+poetry run quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>
 
 # Lower-level utility commands that still exist
 poetry run quanttradeai fetch-data -c config/model_config.yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,16 @@ poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
 ```
 
+### Multi-Agent Runs
+
+```bash
+poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest
+poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
+poetry run quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>
+```
+
+Live batches require every configured agent to already have `mode: live` and require the acknowledgement value to match `project.name`.
+
 ### Agent Deployment
 
 ```bash

--- a/docs/configuration/live-runtime-files.md
+++ b/docs/configuration/live-runtime-files.md
@@ -73,7 +73,7 @@ LLM and hybrid live runs also write `prompt_samples.json`.
 - `scoreboard.json`
 - `scoreboard.txt`
 
-Child runs keep their normal per-run runtime YAML snapshots inside their own run directories.
+Child runs keep their normal per-run runtime YAML snapshots inside their own run directories. Live batches require `--acknowledge-live <project.name>` and preserve normal child runs under `runs/agent/live/...`.
 
 ## Deployment Bundles
 

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -8,7 +8,7 @@ It drives:
 - `quanttradeai validate`
 - `quanttradeai research run`
 - `quanttradeai agent run` for project-defined agents in `backtest`, `paper`, and `live`
-- `quanttradeai agent run --all` for multi-agent batches in `backtest` and `paper`
+- `quanttradeai agent run --all` for multi-agent batches in `backtest`, `paper`, and `live`
 - `quanttradeai agent run --sweep <name>` for backtest-only parameter sweeps
 - `quanttradeai promote` for research-model promotion plus agent backtest-to-paper and paper-to-live promotion
 - `quanttradeai deploy` for docker-compose paper and live agent bundles
@@ -84,16 +84,18 @@ poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.y
 
 The default hybrid template already points `model_signal_sources` at `models/promoted/aapl_daily_classifier`, so the happy path does not require editing timestamped experiment directories.
 
-### Multi-Agent Paper Batches
+### Multi-Agent Batches
 
 ```bash
+poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper --max-concurrency 4
+poetry run quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>
 ```
 
-Multi-agent paper batches preserve the normal child runs under `runs/agent/paper/...` and write batch artifacts under `runs/agent/batches/<timestamp>_<project>_paper/`.
+Multi-agent batches preserve the normal child runs under `runs/agent/backtest/...`, `runs/agent/paper/...`, or `runs/agent/live/...` and write batch artifacts under `runs/agent/batches/<timestamp>_<project>_<mode>/`.
 
-Paper batches rank the batch scoreboard by `total_pnl`.
+Backtest batches rank by `net_sharpe`. Paper and live batches rank by `total_pnl`. Live batches require every configured agent to already have `mode: live` and require `--acknowledge-live` to match `project.name`.
 
 ### Backtest Sweeps
 
@@ -763,6 +765,14 @@ When replay is enabled, the run directory also includes `replay_manifest.json`, 
 Writes a batch directory under `runs/agent/batches/<timestamp>_<project>_paper/` and one normal child paper run under `runs/agent/paper/...` for each enumerated agent.
 
 Batch scoreboards for paper mode sort by `total_pnl`.
+
+### `quanttradeai agent run --all --mode live`
+
+Writes a batch directory under `runs/agent/batches/<timestamp>_<project>_live/` and one normal child live run under `runs/agent/live/...` for each enumerated agent.
+
+Live batches require `--acknowledge-live <project.name>`, reject `--skip-validation`, and fail fast unless every configured agent already has `mode: live`.
+
+Batch scoreboards for live mode sort by `total_pnl`.
 
 ### `quanttradeai agent run --mode live`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -134,14 +134,15 @@ poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper --max-concurrency 4
+poetry run quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>
 ```
 
 This workflow:
 
 - validates the project before enumeration
-- runs every configured agent through the existing backtest or paper path
-- preserves the normal child runs under `runs/agent/backtest/...` or `runs/agent/paper/...`
-- adds batch-level artifacts under `runs/agent/batches/<timestamp>_<project>_backtest/` or `runs/agent/batches/<timestamp>_<project>_paper/`
+- runs every configured agent through the existing backtest, paper, or live path
+- preserves the normal child runs under `runs/agent/backtest/...`, `runs/agent/paper/...`, or `runs/agent/live/...`
+- adds batch-level artifacts under `runs/agent/batches/<timestamp>_<project>_<mode>/`
 
 Batch artifacts include:
 
@@ -150,7 +151,7 @@ Batch artifacts include:
 - `scoreboard.json`
 - `scoreboard.txt`
 
-Backtest batches rank by `net_sharpe`. Paper batches rank by `total_pnl`. Live still runs one agent at a time.
+Backtest batches rank by `net_sharpe`. Paper and live batches rank by `total_pnl`. Live batches require every configured agent to already have `mode: live` and require `--acknowledge-live` to match `project.name`.
 
 ## Standalone Utility Commands
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -56,6 +56,8 @@ poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest -
 # Replay-backed paper batch across every configured project agent
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper --max-concurrency 4
+# Acknowledged live batch across every live-configured project agent
+poetry run quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>
 
 # Backtest one sweep of agent parameter variants
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest

--- a/quanttradeai/agents/batch.py
+++ b/quanttradeai/agents/batch.py
@@ -14,6 +14,9 @@ import yaml
 
 from quanttradeai.utils.config_validator import validate_project_config
 from quanttradeai.utils.project_config import (
+    compile_live_position_manager_runtime_config,
+    compile_live_risk_runtime_config,
+    compile_live_streaming_runtime_config,
     compile_paper_streaming_runtime_config,
     load_project_config,
 )
@@ -27,10 +30,11 @@ from quanttradeai.utils.sweeps import expand_agent_backtest_sweep, sweep_summary
 from .runner import run_project_agent
 
 
-SUPPORTED_BATCH_MODES = {"backtest", "paper"}
+SUPPORTED_BATCH_MODES = {"backtest", "paper", "live"}
 BATCH_SCOREBOARD_SORT_FIELDS = {
     "backtest": "net_sharpe",
     "paper": "total_pnl",
+    "live": "total_pnl",
 }
 
 
@@ -171,7 +175,7 @@ def _sort_result_entries(
     scoreboard_order: list[str],
     mode: str,
 ) -> list[dict[str, Any]]:
-    if mode != "paper":
+    if mode not in {"paper", "live"}:
         return entries
 
     order_index = {run_id: index for index, run_id in enumerate(scoreboard_order)}
@@ -256,9 +260,11 @@ def run_agent_batch(
     skip_validation: bool = False,
     max_concurrency: int = 1,
     sweep_name: str | None = None,
+    acknowledge_live_project_name: str | None = None,
 ) -> dict[str, Any]:
     """Run every configured agent or sweep variant through a supported batch path."""
 
+    mode = mode.strip().lower()
     if max_concurrency < 1:
         raise ValueError("--max-concurrency must be at least 1.")
     if mode not in SUPPORTED_BATCH_MODES:
@@ -266,6 +272,10 @@ def run_agent_batch(
         raise ValueError(
             f"Unsupported batch mode '{mode}'. Supported modes: {supported}."
         )
+    if acknowledge_live_project_name is not None and mode != "live":
+        raise ValueError("--acknowledge-live is only supported with --all --mode live.")
+    if mode == "live" and skip_validation:
+        raise ValueError("--skip-validation is not supported for live agent batches.")
     if sweep_name is not None and mode != "backtest":
         raise ValueError("--sweep currently supports only --mode backtest.")
 
@@ -275,6 +285,10 @@ def run_agent_batch(
     project_name = (loaded_project.raw.get("project") or {}).get("name") or Path(
         original_project_path
     ).stem
+    if mode == "live" and acknowledge_live_project_name != str(project_name):
+        raise ValueError(
+            f"Running all live agents requires --acknowledge-live {project_name}."
+        )
     batch_name = (
         f"{timestamp}_{_slugify(project_name)}_{_slugify(sweep_name)}_{mode}"
         if sweep_name
@@ -297,6 +311,25 @@ def run_agent_batch(
     if mode == "paper":
         # Fail fast for project-wide paper prerequisites before launching child runs.
         compile_paper_streaming_runtime_config(resolved_project)
+    elif mode == "live":
+        agents = [dict(agent) for agent in resolved_project.get("agents") or []]
+        if not agents:
+            raise ValueError("Project config defines no agents to run with --all.")
+        non_live_agents = [
+            f"{agent.get('name') or '<unnamed>'}({agent.get('mode') or '<blank>'})"
+            for agent in agents
+            if str(agent.get("mode") or "").strip().lower() != "live"
+        ]
+        if non_live_agents:
+            raise ValueError(
+                "All agents must be configured with mode=live before running "
+                "--all --mode live. Non-live agents: " + ", ".join(non_live_agents)
+            )
+
+        # Fail fast for project-wide live prerequisites before launching child runs.
+        compile_live_streaming_runtime_config(resolved_project)
+        compile_live_risk_runtime_config(resolved_project)
+        compile_live_position_manager_runtime_config(resolved_project)
 
     if sweep_name:
         sweep_payload, agent_specs = _build_sweep_specs(
@@ -403,6 +436,8 @@ def run_agent_batch(
             "error": item.get("error"),
             "parameters": item.get("parameters"),
             "paper_source": item["summary"].get("paper_source"),
+            "execution_backend": item["summary"].get("execution_backend"),
+            "broker_provider": item["summary"].get("broker_provider"),
             "run_timestamp": item["run_timestamp"],
             "run_id": item["summary"].get("run_id"),
             "run_dir": item["summary"].get("run_dir"),
@@ -492,6 +527,8 @@ def run_agent_batch(
                     "configured_mode",
                     "status",
                     "paper_source",
+                    "execution_backend",
+                    "broker_provider",
                     "run_timestamp",
                     "run_id",
                     "run_dir",

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -1214,7 +1214,7 @@ def cmd_agent_run(
     run_all: bool = typer.Option(
         False,
         "--all",
-        help="Run every project-defined agent. Supports backtest and paper modes in this release.",
+        help="Run every project-defined agent. Supports backtest, paper, and live modes.",
     ),
     sweep: Optional[str] = typer.Option(
         None,
@@ -1240,6 +1240,11 @@ def cmd_agent_run(
         min=1,
         help="Maximum concurrent child runs when using --all or --sweep.",
     ),
+    acknowledge_live: Optional[str] = typer.Option(
+        None,
+        "--acknowledge-live",
+        help="Required for --all --mode live. Must exactly match project.name.",
+    ),
 ):
     """Run a first-class project agent in backtest, paper, or live mode."""
 
@@ -1251,16 +1256,19 @@ def cmd_agent_run(
         raise typer.BadParameter("Choose exactly one of --agent, --all, or --sweep.")
 
     try:
+        normalized_mode = mode.strip().lower()
+        if acknowledge_live is not None and not (run_all and normalized_mode == "live"):
+            raise ValueError(
+                "--acknowledge-live is only supported with --all --mode live."
+            )
+
         if run_all:
-            if mode == "live":
-                raise ValueError(
-                    "--all currently supports only --mode backtest or --mode paper."
-                )
             batch_result = run_agent_batch(
                 project_config_path=config,
-                mode=mode,
+                mode=normalized_mode,
                 skip_validation=skip_validation,
                 max_concurrency=max_concurrency,
+                acknowledge_live_project_name=acknowledge_live,
             )
             typer.echo(f"Agent batch completed: {batch_result['run_dir']}")
             typer.echo(json.dumps(batch_result, indent=2))
@@ -1269,11 +1277,11 @@ def cmd_agent_run(
             return
 
         if sweep:
-            if mode != "backtest":
+            if normalized_mode != "backtest":
                 raise ValueError("--sweep currently supports only --mode backtest.")
             batch_result = run_agent_batch(
                 project_config_path=config,
-                mode=mode,
+                mode=normalized_mode,
                 skip_validation=skip_validation,
                 max_concurrency=max_concurrency,
                 sweep_name=sweep,
@@ -1288,7 +1296,7 @@ def cmd_agent_run(
         summary, warnings = run_project_agent(
             project_config_path=config,
             agent_name=agent,
-            mode=mode,
+            mode=normalized_mode,
             skip_validation=skip_validation,
         )
         for warning in warnings:

--- a/roadmap.md
+++ b/roadmap.md
@@ -367,7 +367,7 @@ Status on 2026-04-17:
 - `quanttradeai agent run --all -c config/project.yaml --mode backtest` is implemented for local multi-agent backtest batches, with bounded concurrency, preserved child runs, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 - `quanttradeai agent run --all -c config/project.yaml --mode paper` is implemented for local multi-agent paper batches, reusing the existing replay-backed paper path, preserving child runs under `runs/agent/paper/...`, and writing batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 - `quanttradeai agent run --sweep <name> -c config/project.yaml --mode backtest` is implemented for backtest-only parameter sweeps defined under `sweeps:` in `config/project.yaml`, with deterministic variant expansion, preserved child runs, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
-- Live multi-agent orchestration remains future Stage 2 work.
+- `quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>` is implemented for local multi-agent live batches, requiring an explicit project-name acknowledgement, live-mode agent configs, live runtime prerequisites, preserved child runs under `runs/agent/live/...`, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 
 Deliverables:
 

--- a/tests/integration/test_agent_batch_cli.py
+++ b/tests/integration/test_agent_batch_cli.py
@@ -57,6 +57,18 @@ def _seed_agent_assets(tmp_path: Path) -> Path:
     return config_path
 
 
+def _set_all_agents_live(config_path: Path) -> dict:
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    payload["project"]["name"] = "multi_agent_lab"
+    for agent in payload["agents"]:
+        agent["mode"] = "live"
+    config_path.write_text(
+        yaml.safe_dump(payload, sort_keys=False),
+        encoding="utf-8",
+    )
+    return payload
+
+
 def _seed_sweep_assets(tmp_path: Path) -> Path:
     config_path = tmp_path / "config" / "project.yaml"
 
@@ -137,11 +149,14 @@ def test_agent_run_rejects_mixing_agent_and_sweep(tmp_path: Path, monkeypatch):
     assert "--sweep" in combined
 
 
-def test_agent_run_all_rejects_live_mode(tmp_path: Path, monkeypatch):
+def test_agent_run_all_live_requires_matching_project_acknowledgement(
+    tmp_path: Path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     config_path = _seed_agent_assets(tmp_path)
+    _set_all_agents_live(config_path)
 
-    result = runner.invoke(
+    missing = runner.invoke(
         app,
         [
             "agent",
@@ -154,9 +169,114 @@ def test_agent_run_all_rejects_live_mode(tmp_path: Path, monkeypatch):
         ],
     )
 
+    assert missing.exit_code == 1
+    missing_output = f"{missing.stdout}\n{missing.stderr}"
+    assert "requires --acknowledge-live multi_agent_lab" in missing_output
+
+    wrong = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--all",
+            "--config",
+            str(config_path),
+            "--mode",
+            "live",
+            "--acknowledge-live",
+            "wrong_project",
+        ],
+    )
+
+    assert wrong.exit_code == 1
+    wrong_output = f"{wrong.stdout}\n{wrong.stderr}"
+    assert "requires --acknowledge-live multi_agent_lab" in wrong_output
+
+
+def test_agent_run_rejects_acknowledge_live_outside_all_live(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--agent",
+            "rsi_reversion",
+            "--config",
+            str(config_path),
+            "--mode",
+            "paper",
+            "--acknowledge-live",
+            "multi_agent_lab",
+        ],
+    )
+
     assert result.exit_code == 1
     combined = f"{result.stdout}\n{result.stderr}"
-    assert "--all currently supports only --mode backtest or --mode paper" in combined
+    assert "--acknowledge-live is only supported with --all --mode live" in combined
+
+
+def test_agent_run_all_live_rejects_skip_validation(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+    _set_all_agents_live(config_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--all",
+            "--config",
+            str(config_path),
+            "--mode",
+            "live",
+            "--acknowledge-live",
+            "multi_agent_lab",
+            "--skip-validation",
+        ],
+    )
+
+    assert result.exit_code == 1
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert "--skip-validation is not supported for live agent batches" in combined
+
+
+def test_agent_run_all_live_requires_every_agent_configured_live(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+    payload = _set_all_agents_live(config_path)
+    payload["agents"][1]["mode"] = "paper"
+    config_path.write_text(
+        yaml.safe_dump(payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--all",
+            "--config",
+            str(config_path),
+            "--mode",
+            "live",
+            "--acknowledge-live",
+            "multi_agent_lab",
+        ],
+    )
+
+    assert result.exit_code == 1
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert "All agents must be configured with mode=live" in combined
+    assert "paper_momentum(paper)" in combined
 
 
 def test_agent_run_sweep_rejects_non_backtest_modes(tmp_path: Path, monkeypatch):
@@ -570,6 +690,283 @@ def test_agent_run_all_paper_preserves_child_failures_and_logs(
     assert failed_entry["status"] == "failed"
     assert failed_entry["warnings"] == ["child warning"]
     assert failed_entry["run_id"].startswith("agent/paper/")
+    assert Path(failed_entry["stderr_log"]).read_text("utf-8")
+    successful_names = {
+        item["agent_name"] for item in payload["results"] if item["status"] == "success"
+    }
+    assert successful_names == {"breakout_gpt", "paper_momentum", "rsi_reversion"}
+
+
+def test_agent_run_all_live_writes_batch_artifacts_and_sorts_by_total_pnl(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+    _set_all_agents_live(config_path)
+
+    def _fake_run_project_agent(
+        *,
+        project_config_path: str,
+        agent_name: str,
+        mode: str,
+        skip_validation: bool,
+        project_config_override: dict | None = None,
+        run_timestamp: str | None = None,
+    ):
+        assert mode == "live"
+        assert skip_validation is False
+        assert run_timestamp is not None
+        assert Path(project_config_path).resolve() == config_path.resolve()
+        assert project_config_override is None
+        run_dir = (
+            Path("runs") / "agent" / "live" / f"{run_timestamp}_{agent_name.lower()}"
+        )
+        run_dir.mkdir(parents=True, exist_ok=True)
+        pnl_by_agent = {
+            "rsi_reversion": 80.0,
+            "paper_momentum": 120.0,
+            "breakout_gpt": 240.0,
+            "hybrid_swing_agent": 170.0,
+        }
+        backend_by_agent = {
+            "rsi_reversion": "simulated",
+            "paper_momentum": "alpaca",
+            "breakout_gpt": "simulated",
+            "hybrid_swing_agent": "simulated",
+        }
+        metrics_path = run_dir / "metrics.json"
+        metrics_path.write_text(
+            json.dumps(
+                {
+                    "status": "available",
+                    "total_pnl": pnl_by_agent[agent_name],
+                    "portfolio_value": 100000.0 + pnl_by_agent[agent_name],
+                    "execution_count": int(pnl_by_agent[agent_name] / 10.0),
+                    "decision_count": int(pnl_by_agent[agent_name] / 5.0),
+                    "risk_status": "ok",
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        summary = {
+            "run_id": f"agent/live/{run_dir.name}",
+            "run_type": "agent",
+            "mode": "live",
+            "name": agent_name,
+            "status": "success",
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "symbols": ["AAPL"],
+            "warnings": [],
+            "artifacts": {"metrics": str(metrics_path)},
+            "execution_backend": backend_by_agent[agent_name],
+            "broker_provider": (
+                "alpaca" if backend_by_agent[agent_name] == "alpaca" else None
+            ),
+            "run_dir": str(run_dir),
+        }
+        (run_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2),
+            encoding="utf-8",
+        )
+        return summary, []
+
+    with patch(
+        "quanttradeai.agents.batch.run_project_agent",
+        side_effect=_fake_run_project_agent,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--all",
+                "--config",
+                str(config_path),
+                "--mode",
+                "live",
+                "--acknowledge-live",
+                "multi_agent_lab",
+                "--max-concurrency",
+                "2",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    batch_dir = Path(payload["run_dir"])
+
+    assert payload["status"] == "success"
+    assert payload["mode"] == "live"
+    assert batch_dir.name.endswith("_live")
+    assert (batch_dir / "batch_manifest.json").is_file()
+    assert (batch_dir / "results.json").is_file()
+    assert (batch_dir / "scoreboard.json").is_file()
+    assert (batch_dir / "scoreboard.txt").is_file()
+
+    results_payload = json.loads((batch_dir / "results.json").read_text("utf-8"))
+    assert results_payload["mode"] == "live"
+    assert results_payload["scoreboard_sort_by"] == "total_pnl"
+    assert [item["agent_name"] for item in results_payload["results"]] == [
+        "breakout_gpt",
+        "hybrid_swing_agent",
+        "paper_momentum",
+        "rsi_reversion",
+    ]
+    assert all(
+        item["run_id"].startswith("agent/live/") for item in results_payload["results"]
+    )
+    assert all(
+        Path(item["run_dir"]).parts[:3] == ("runs", "agent", "live")
+        for item in results_payload["results"]
+    )
+    paper_momentum = next(
+        item
+        for item in results_payload["results"]
+        if item["agent_name"] == "paper_momentum"
+    )
+    assert paper_momentum["execution_backend"] == "alpaca"
+    assert paper_momentum["broker_provider"] == "alpaca"
+
+    manifest = json.loads((batch_dir / "batch_manifest.json").read_text("utf-8"))
+    manifest_paper_momentum = next(
+        item for item in manifest["agents"] if item["agent_name"] == "paper_momentum"
+    )
+    assert manifest_paper_momentum["execution_backend"] == "alpaca"
+    assert manifest_paper_momentum["broker_provider"] == "alpaca"
+
+    scoreboard_payload = json.loads((batch_dir / "scoreboard.json").read_text("utf-8"))
+    assert scoreboard_payload["sort_by"] == "total_pnl"
+    assert [record["name"] for record in scoreboard_payload["records"]] == [
+        "breakout_gpt",
+        "hybrid_swing_agent",
+        "paper_momentum",
+        "rsi_reversion",
+    ]
+    scoreboard_text = (batch_dir / "scoreboard.txt").read_text("utf-8")
+    assert "TOTAL_PNL" in scoreboard_text
+    assert "RISK" in scoreboard_text
+
+
+def test_agent_run_all_live_preserves_child_failures_and_logs(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = _seed_agent_assets(tmp_path)
+    _set_all_agents_live(config_path)
+
+    def _fake_run_project_agent(
+        *,
+        project_config_path: str,
+        agent_name: str,
+        mode: str,
+        skip_validation: bool,
+        project_config_override: dict | None = None,
+        run_timestamp: str | None = None,
+    ):
+        assert mode == "live"
+        assert run_timestamp is not None
+        assert Path(project_config_path).resolve() == config_path.resolve()
+        assert project_config_override is None
+        run_dir = (
+            Path("runs") / "agent" / "live" / f"{run_timestamp}_{agent_name.lower()}"
+        )
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        if agent_name == "hybrid_swing_agent":
+            child_summary = {
+                "run_id": f"agent/live/{run_dir.name}",
+                "run_type": "agent",
+                "mode": "live",
+                "name": agent_name,
+                "status": "failed",
+                "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+                "symbols": ["AAPL"],
+                "warnings": ["child warning"],
+                "artifacts": {},
+                "run_dir": str(run_dir),
+                "error": "live child failed",
+            }
+            (run_dir / "summary.json").write_text(
+                json.dumps(child_summary, indent=2),
+                encoding="utf-8",
+            )
+            raise RuntimeError("simulated live failure")
+
+        pnl_by_agent = {
+            "rsi_reversion": 80.0,
+            "paper_momentum": 120.0,
+            "breakout_gpt": 240.0,
+        }
+        metrics_path = run_dir / "metrics.json"
+        metrics_path.write_text(
+            json.dumps(
+                {
+                    "total_pnl": pnl_by_agent[agent_name],
+                    "portfolio_value": 100000.0 + pnl_by_agent[agent_name],
+                    "execution_count": int(pnl_by_agent[agent_name] / 10.0),
+                    "decision_count": int(pnl_by_agent[agent_name] / 5.0),
+                    "risk_status": "ok",
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        summary = {
+            "run_id": f"agent/live/{run_dir.name}",
+            "run_type": "agent",
+            "mode": "live",
+            "name": agent_name,
+            "status": "success",
+            "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+            "symbols": ["AAPL"],
+            "warnings": [],
+            "artifacts": {"metrics": str(metrics_path)},
+            "execution_backend": "simulated",
+            "broker_provider": None,
+            "run_dir": str(run_dir),
+        }
+        (run_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2),
+            encoding="utf-8",
+        )
+        return summary, []
+
+    with patch(
+        "quanttradeai.agents.batch.run_project_agent",
+        side_effect=_fake_run_project_agent,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "run",
+                "--all",
+                "--config",
+                str(config_path),
+                "--mode",
+                "live",
+                "--acknowledge-live",
+                "multi_agent_lab",
+                "--max-concurrency",
+                "2",
+            ],
+        )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    assert payload["status"] == "failed"
+    assert payload["failure_count"] == 1
+    assert payload["success_count"] == 3
+
+    failed_entry = next(
+        item
+        for item in payload["results"]
+        if item["agent_name"] == "hybrid_swing_agent"
+    )
+    assert failed_entry["status"] == "failed"
+    assert failed_entry["warnings"] == ["child warning"]
+    assert failed_entry["run_id"].startswith("agent/live/")
     assert Path(failed_entry["stderr_log"]).read_text("utf-8")
     successful_names = {
         item["agent_name"] for item in payload["results"] if item["status"] == "success"


### PR DESCRIPTION
## Summary

- Add `quanttradeai agent run --all --mode live` with `--acknowledge-live <project.name>` as an explicit safety gate.
- Reuse existing individual live agent execution while adding batch-level preflight checks, manifests, results, and scoreboards.
- Surface live execution metadata such as `execution_backend` and `broker_provider` in batch results and manifests.
- Update roadmap and docs to include live multi-agent batches while preserving legacy utility command boundaries.

## Validation

- `make lint.format.test` passed: 359 tests passed.
- Commit hooks passed: format, lint, test.
- `git diff --cached --check` passed before commit.

## Notes

Live batches require every configured project agent to already have `mode: live`, reject `--skip-validation`, and require the acknowledgement value to exactly match `project.name`.