### PR TITLE
feat: apply sweep winners to project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,15 @@ sweeps:
 
 This writes batch artifacts under `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/` plus one normal child run per expanded variant under `runs/agent/backtest/...`.
 
-Sweep child runs are intentionally not promotable. Copy the winning parameters into `config/project.yaml`, rerun that agent normally, and then promote the non-sweep run.
+After reviewing `scoreboard.txt` or `quanttradeai runs list --scoreboard --sort-by net_sharpe`, apply the selected sweep child back to the base agent:
+
+```bash
+poetry run quanttradeai promote --run agent/backtest/<winning_sweep_child> -c config/project.yaml --apply-sweep
+poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<normal_run_id> -c config/project.yaml
+```
+
+Sweep child runs are intentionally not promoted directly; `--apply-sweep` updates the base agent parameters first, then the normal backtest-to-paper promotion flow continues.
 
 ### Deploy A Paper Or Live Agent
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -62,6 +62,9 @@ poetry run quanttradeai agent run --all -c config/project.yaml --mode live --ack
 # Backtest one sweep of agent parameter variants
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest --max-concurrency 4
+# Apply the selected sweep child to the base agent, then rerun normally
+poetry run quanttradeai promote --run agent/backtest/<winning_sweep_child> -c config/project.yaml --apply-sweep
+poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode backtest
 
 # Generate deployment bundles for the paper agent
 # Generated bundles disable replay and expect real-time streaming settings

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -1136,6 +1136,11 @@ def cmd_promote(
         "--acknowledge-live",
         help="Required for --to live. Must exactly match the agent name being promoted.",
     ),
+    apply_sweep: bool = typer.Option(
+        False,
+        "--apply-sweep",
+        help="Apply a successful sweep child run's parameters back to the base agent.",
+    ),
 ):
     """Promote a successful research or agent run in the canonical workflow."""
 
@@ -1148,6 +1153,7 @@ def cmd_promote(
             target_mode=target,
             dry_run=dry_run,
             acknowledge_live=acknowledge_live,
+            apply_sweep=apply_sweep,
         )
     except Exception as exc:
         typer.echo(f"Promotion failed: {exc}", err=True)

--- a/quanttradeai/utils/promotion.py
+++ b/quanttradeai/utils/promotion.py
@@ -18,6 +18,7 @@ from quanttradeai.utils.config_schemas import ProjectConfigSchema
 from quanttradeai.utils.project_config import extract_canonical_live_risk_config
 from quanttradeai.utils.project_paths import infer_project_root, resolve_project_path
 from quanttradeai.utils.run_records import RUNS_ROOT, discover_runs
+from quanttradeai.utils.sweeps import apply_agent_scalar_overrides
 
 
 def _normalize_run_id(value: str | Path) -> str:
@@ -122,6 +123,44 @@ def _validate_agent_promotable_run(
     return agent_name, required_source_mode
 
 
+def _validate_sweep_apply_run(
+    record: dict[str, Any],
+    summary: dict[str, Any],
+    *,
+    target_mode: str,
+    acknowledge_live: str | None,
+) -> tuple[str, str, dict[str, Any]]:
+    if target_mode != "paper":
+        raise ValueError("--apply-sweep does not support --to live.")
+    if acknowledge_live is not None:
+        raise ValueError(
+            "--acknowledge-live is only supported when promoting agent paper runs to live."
+        )
+
+    run_type = str(summary.get("run_type") or record.get("run_type") or "")
+    mode = str(summary.get("mode") or record.get("mode") or "")
+    status = str(summary.get("status") or record.get("status") or "")
+    if run_type != "agent" or mode != "backtest" or status != "success":
+        raise ValueError(
+            "Only successful agent backtest sweep child runs can be applied to project config."
+        )
+
+    sweep_metadata = summary.get("sweep")
+    if not isinstance(sweep_metadata, dict):
+        raise ValueError("--apply-sweep requires a sweep-generated agent backtest run.")
+
+    base_agent_name = str(sweep_metadata.get("base_agent_name") or "").strip()
+    if not base_agent_name:
+        raise ValueError("Sweep child run summary is missing sweep.base_agent_name.")
+
+    parameters = sweep_metadata.get("parameters")
+    if not isinstance(parameters, dict) or not parameters:
+        raise ValueError("Sweep child run summary is missing sweep.parameters.")
+
+    sweep_name = str(sweep_metadata.get("name") or "").strip() or "unnamed_sweep"
+    return sweep_name, base_agent_name, dict(parameters)
+
+
 def _validate_research_promotable_run(
     record: dict[str, Any],
     summary: dict[str, Any],
@@ -153,6 +192,56 @@ def _validate_research_promotable_run(
         raise ValueError("Promotable research run is missing a project name.")
 
     return project_name, "research"
+
+
+def _apply_sweep_parameters(
+    project_config: dict[str, Any],
+    *,
+    base_agent_name: str,
+    parameters: dict[str, Any],
+) -> tuple[dict[str, Any], bool]:
+    proposed = copy.deepcopy(project_config)
+    agents = proposed.get("agents")
+    if not isinstance(agents, list):
+        raise ValueError("Project config must include an agents list.")
+
+    target_index: int | None = None
+    target_agent: dict[str, Any] | None = None
+    for index, agent in enumerate(agents):
+        if isinstance(agent, dict) and agent.get("name") == base_agent_name:
+            target_index = index
+            target_agent = agent
+            break
+
+    if target_agent is None or target_index is None:
+        raise ValueError(f"Base agent '{base_agent_name}' not found in project config.")
+
+    updated_agent = apply_agent_scalar_overrides(target_agent, parameters)
+    updated_agent["name"] = base_agent_name
+    changed = updated_agent != target_agent
+    agents[target_index] = updated_agent
+    return proposed, changed
+
+
+def _validate_proposed_project_config(
+    *,
+    proposed_config: dict[str, Any],
+    config_path: Path,
+) -> None:
+    try:
+        ProjectConfigSchema(**proposed_config)
+    except ValidationError as exc:
+        raise ValueError(f"Proposed project config is invalid: {exc}") from exc
+
+    from quanttradeai.utils.config_validator import validate_project_config
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        validate_project_config(
+            config_path=config_path,
+            output_dir=temp_dir,
+            project_config_override=proposed_config,
+            timestamp_subdir=False,
+        )
 
 
 def _apply_paper_promotion(
@@ -198,6 +287,59 @@ def _apply_paper_promotion(
         raise ValueError(f"Promoted project config is invalid: {exc}") from exc
 
     return proposed, changed
+
+
+def _apply_sweep_child_run(
+    *,
+    record: dict[str, Any],
+    summary: dict[str, Any],
+    config_path: Path,
+    target_mode: str,
+    dry_run: bool,
+    acknowledge_live: str | None,
+) -> dict[str, Any]:
+    sweep_name, base_agent_name, parameters = _validate_sweep_apply_run(
+        record,
+        summary,
+        target_mode=target_mode,
+        acknowledge_live=acknowledge_live,
+    )
+    project_config = _load_yaml_mapping(config_path)
+    proposed_config, changed = _apply_sweep_parameters(
+        project_config,
+        base_agent_name=base_agent_name,
+        parameters=parameters,
+    )
+    _validate_proposed_project_config(
+        proposed_config=proposed_config,
+        config_path=config_path,
+    )
+
+    if changed and not dry_run:
+        config_path.write_text(
+            yaml.safe_dump(proposed_config, sort_keys=False),
+            encoding="utf-8",
+        )
+
+    config_path_display = config_path.as_posix()
+    next_command = (
+        f"quanttradeai agent run --agent {base_agent_name} "
+        f"-c {config_path_display} --mode backtest"
+    )
+    return {
+        "status": "success",
+        "operation": "apply_sweep",
+        "source_run_id": str(
+            record.get("run_id") or _normalize_run_id(summary.get("run_id") or "")
+        ),
+        "sweep_name": sweep_name,
+        "base_agent_name": base_agent_name,
+        "applied_parameters": parameters,
+        "changed": changed,
+        "dry_run": dry_run,
+        "config_path": config_path_display,
+        "next_command": next_command,
+    }
 
 
 def _apply_live_promotion(
@@ -550,6 +692,7 @@ def promote_run(
     target_mode: str = "paper",
     dry_run: bool = False,
     acknowledge_live: str | None = None,
+    apply_sweep: bool = False,
     runs_root: Path | str = RUNS_ROOT,
 ) -> dict[str, Any]:
     """Promote a successful research or agent run through the canonical workflow."""
@@ -563,6 +706,16 @@ def promote_run(
     summary = _load_json(summary_path)
     run_type = str(summary.get("run_type") or record.get("run_type") or "")
     project_config_path = Path(config_path)
+
+    if apply_sweep:
+        return _apply_sweep_child_run(
+            record=record,
+            summary=summary,
+            config_path=project_config_path,
+            target_mode=target_mode,
+            dry_run=dry_run,
+            acknowledge_live=acknowledge_live,
+        )
 
     if run_type == "research":
         _validate_research_promotable_run(

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,6 @@
 # QuantTradeAI Roadmap
 
-Last updated: 2026-04-22
+Last updated: 2026-04-25
 
 This document is the product source of truth for QuantTradeAI.
 It is written for both human contributors and coding agents.
@@ -368,6 +368,7 @@ Status on 2026-04-17:
 - `quanttradeai agent run --all -c config/project.yaml --mode paper` is implemented for local multi-agent paper batches, reusing the existing replay-backed paper path, preserving child runs under `runs/agent/paper/...`, and writing batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 - `quanttradeai agent run --sweep <name> -c config/project.yaml --mode backtest` is implemented for backtest-only parameter sweeps defined under `sweeps:` in `config/project.yaml`, with deterministic variant expansion, preserved child runs, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 - `quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>` is implemented for local multi-agent live batches, requiring an explicit project-name acknowledgement, live-mode agent configs, live runtime prerequisites, preserved child runs under `runs/agent/live/...`, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
+- `quanttradeai promote --run agent/backtest/<winning_sweep_child> -c config/project.yaml --apply-sweep` is implemented to apply a sweep winner's scalar parameters back to the base agent before rerunning and promoting the normal backtest.
 
 Deliverables:
 
@@ -466,7 +467,7 @@ quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode 
 ```
 
 Current implementation note:
-`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`, including `agent run --all --mode paper`. Agents can also opt into `execution.backend: alpaca` for happy-path real-time paper/live broker submission with broker-synced account and position snapshots. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`. `deploy --target local` and `deploy --target docker-compose` support both simulated and Alpaca-backed paper/live agent bundles.
+`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`, including `agent run --all --mode paper`; live batches are available through `agent run --all --mode live --acknowledge-live <project_name>`. Agents can also opt into `execution.backend: alpaca` for happy-path real-time paper/live broker submission with broker-synced account and position snapshots. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`, and winning sweep child runs can be applied back to the base agent with `promote --apply-sweep` before rerunning a normal backtest. `deploy --target local` and `deploy --target docker-compose` support both simulated and Alpaca-backed paper/live agent bundles.
 
 ### Hybrid track
 

--- a/tests/integration/test_promote_cli.py
+++ b/tests/integration/test_promote_cli.py
@@ -47,6 +47,26 @@ def _write_research_project_config(path: Path) -> dict:
     return payload
 
 
+def _write_rule_sweep_project_config(path: Path) -> dict:
+    payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["rule-agent"], sort_keys=False)
+    )
+    payload["sweeps"] = [
+        {
+            "name": "rsi_threshold_grid",
+            "kind": "agent_backtest",
+            "agent": "rsi_reversion",
+            "parameters": [
+                {"path": "rule.buy_below", "values": [25.0, 30.0]},
+                {"path": "rule.sell_above", "values": [70.0, 75.0]},
+            ],
+        }
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return payload
+
+
 def _write_run_summary(
     *,
     run_id: str = "agent/backtest/20260101_010000_breakout_gpt",
@@ -83,6 +103,43 @@ def _write_run_summary(
         json.dumps(summary, indent=2),
         encoding="utf-8",
     )
+    return run_dir
+
+
+def _write_sweep_child_summary(
+    *,
+    run_id: str = "agent/backtest/20260101_010000_rsi_sweep_variant",
+    status: str = "success",
+    mode: str = "backtest",
+    include_sweep: bool = True,
+    base_agent_name: str = "rsi_reversion",
+    parameters: dict | None = None,
+) -> Path:
+    run_dir = _write_run_summary(
+        run_id=run_id,
+        mode=mode,
+        status=status,
+        agent_name=(
+            f"{base_agent_name}__rsi_threshold_grid__buy_below-25_0__sell_above-75_0"
+        ),
+    )
+    summary_path = run_dir / "summary.json"
+    summary_payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    if include_sweep:
+        summary_payload["sweep"] = {
+            "name": "rsi_threshold_grid",
+            "base_agent_name": base_agent_name,
+            "parameters": (
+                parameters
+                if parameters is not None
+                else {
+                    "rule.buy_below": 25.0,
+                    "rule.sell_above": 75.0,
+                }
+            ),
+            "promotable": False,
+        }
+    summary_path.write_text(json.dumps(summary_payload, indent=2), encoding="utf-8")
     return run_dir
 
 
@@ -330,6 +387,216 @@ def test_promote_rejects_sweep_generated_backtest_run(
     assert "cannot be promoted directly" in combined_output
     assert "copy the winning parameters" in combined_output.lower()
     assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_promote_apply_sweep_updates_base_agent_parameters(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_rule_sweep_project_config(config_path)
+    run_id = "agent/backtest/20260101_010000_rsi_sweep_variant"
+    _write_sweep_child_summary(run_id=run_id)
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "--run",
+            run_id,
+            "--config",
+            str(config_path),
+            "--apply-sweep",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    updated = _load_project_config(config_path)
+    base_agent = updated["agents"][0]
+
+    assert payload == {
+        "status": "success",
+        "operation": "apply_sweep",
+        "source_run_id": run_id,
+        "sweep_name": "rsi_threshold_grid",
+        "base_agent_name": "rsi_reversion",
+        "applied_parameters": {
+            "rule.buy_below": 25.0,
+            "rule.sell_above": 75.0,
+        },
+        "changed": True,
+        "dry_run": False,
+        "config_path": "config/project.yaml",
+        "next_command": (
+            "quanttradeai agent run --agent rsi_reversion "
+            "-c config/project.yaml --mode backtest"
+        ),
+    }
+    assert base_agent["name"] == "rsi_reversion"
+    assert base_agent["kind"] == "rule"
+    assert base_agent["mode"] == "paper"
+    assert base_agent["rule"]["buy_below"] == 25.0
+    assert base_agent["rule"]["sell_above"] == 75.0
+    assert updated["sweeps"][0]["name"] == "rsi_threshold_grid"
+
+
+def test_promote_apply_sweep_dry_run_does_not_write_project_yaml(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+    _write_rule_sweep_project_config(config_path)
+    original = config_path.read_text(encoding="utf-8")
+    run_id = "agent/backtest/20260101_010000_rsi_sweep_variant"
+    _write_sweep_child_summary(run_id=run_id)
+
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "--run",
+            run_id,
+            "--config",
+            str(config_path),
+            "--apply-sweep",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["operation"] == "apply_sweep"
+    assert payload["changed"] is True
+    assert payload["dry_run"] is True
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_promote_apply_sweep_rejects_invalid_inputs_without_mutating_config(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = Path("config/project.yaml")
+
+    cases = [
+        (
+            "non_sweep",
+            lambda: _write_run_summary(
+                run_id="agent/backtest/20260101_010000_rsi_reversion",
+                mode="backtest",
+                agent_name="rsi_reversion",
+            ),
+            [
+                "promote",
+                "--run",
+                "agent/backtest/20260101_010000_rsi_reversion",
+                "--config",
+                str(config_path),
+                "--apply-sweep",
+            ],
+            "--apply-sweep requires a sweep-generated agent backtest run",
+        ),
+        (
+            "failed_sweep",
+            lambda: _write_sweep_child_summary(
+                run_id="agent/backtest/20260101_020000_failed_sweep",
+                status="failed",
+            ),
+            [
+                "promote",
+                "--run",
+                "agent/backtest/20260101_020000_failed_sweep",
+                "--config",
+                str(config_path),
+                "--apply-sweep",
+            ],
+            "Only successful agent backtest sweep child runs",
+        ),
+        (
+            "paper_sweep",
+            lambda: _write_sweep_child_summary(
+                run_id="agent/paper/20260101_030000_paper_sweep",
+                mode="paper",
+            ),
+            [
+                "promote",
+                "--run",
+                "agent/paper/20260101_030000_paper_sweep",
+                "--config",
+                str(config_path),
+                "--apply-sweep",
+            ],
+            "Only successful agent backtest sweep child runs",
+        ),
+        (
+            "missing_base_agent",
+            lambda: _write_sweep_child_summary(
+                run_id="agent/backtest/20260101_040000_missing_base",
+                base_agent_name="missing_agent",
+            ),
+            [
+                "promote",
+                "--run",
+                "agent/backtest/20260101_040000_missing_base",
+                "--config",
+                str(config_path),
+                "--apply-sweep",
+            ],
+            "Base agent 'missing_agent' not found",
+        ),
+        (
+            "invalid_parameter_path",
+            lambda: _write_sweep_child_summary(
+                run_id="agent/backtest/20260101_050000_invalid_path",
+                parameters={"rule.unknown": 25.0},
+            ),
+            [
+                "promote",
+                "--run",
+                "agent/backtest/20260101_050000_invalid_path",
+                "--config",
+                str(config_path),
+                "--apply-sweep",
+            ],
+            "must resolve to an existing scalar leaf",
+        ),
+        (
+            "live_target",
+            lambda: _write_sweep_child_summary(
+                run_id="agent/backtest/20260101_060000_live_target"
+            ),
+            [
+                "promote",
+                "--run",
+                "agent/backtest/20260101_060000_live_target",
+                "--config",
+                str(config_path),
+                "--apply-sweep",
+                "--to",
+                "live",
+            ],
+            "--apply-sweep does not support --to live",
+        ),
+    ]
+
+    for case_name, seed_run, command, expected_error in cases:
+        if Path("runs").exists():
+            import shutil
+
+            shutil.rmtree("runs")
+        _write_rule_sweep_project_config(config_path)
+        original = config_path.read_text(encoding="utf-8")
+        seed_run()
+
+        result = runner.invoke(app, command)
+
+        assert result.exit_code == 1, case_name
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        assert expected_error in combined_output
+        assert config_path.read_text(encoding="utf-8") == original
 
 
 def test_promote_research_run_copies_models_to_promoted_paths(


### PR DESCRIPTION
## Summary
- Add `quanttradeai promote --apply-sweep` to apply a successful sweep child run's scalar parameters back to the base agent in `config/project.yaml`.
- Preserve direct sweep-child promotion rejection unless the explicit apply flow is used.
- Update README, quick reference, and roadmap with the new sweep winner workflow.

## Verification
- `make lint.format.test`
- pre-commit hook: format, lint, test