### PR TITLE
Add Render managed worker deployment

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -1,345 +1,81 @@
-# QuantTradeAI - LLM Agent Guide
+# QuantTradeAI Agent Guide
 
-## Project Overview
+QuantTradeAI is built around one canonical project file: `config/project.yaml`.
+AI coding agents should treat that file as the source of truth for research,
+agent runs, promotion, and deployment.
 
-QuantTradeAI is a comprehensive machine learning framework for quantitative trading strategies. The codebase implements momentum trading using ensemble models (Logistic Regression, Random Forest, XGBoost) with advanced feature engineering and backtesting capabilities.
+## Primary Workflow
 
-## Core Architecture
-
-### Key Components
-- **Data Layer**: `quanttradeai/data/` - Data fetching, caching, validation
-- **Feature Engineering**: `quanttradeai/features/` - Technical indicators, custom features
-- **ML Models**: `quanttradeai/models/` - Ensemble classifiers, hyperparameter optimization
-- **Backtesting**: `quanttradeai/backtest/` - Trade simulation, performance metrics
-- **Risk Management**: `quanttradeai/trading/` - Stop-loss, position sizing
-- **Utilities**: `quanttradeai/utils/` - Metrics, visualization, configuration
-
-### Data Flow
-1. Fetch OHLCV data (YFinance/AlphaVantage)
-2. Generate technical indicators (SMA, EMA, RSI, MACD, etc.)
-3. Create custom features (momentum score, volatility breakout)
-4. Generate trading labels (forward returns)
-5. Train ensemble models with hyperparameter optimization
-6. Backtest with risk management
-7. Evaluate performance metrics
-
-## Development Guidelines
-
-### Code Quality Standards
-- **Testing**: All new code MUST have unit tests
-- **Formatting**: Use Black for code formatting
-- **Linting**: Use flake8 for code quality
-- **Type Hints**: Include type annotations for all functions
-
-### Pre-commit Requirements
-```bash
-# Run all quality checks
-make format   # Black formatting
-make lint     # flake8 linting
-make test     # pytest testing
-```
-
-### Dependency Management
-- **CRITICAL**: Use Poetry CLI for ALL dependency changes
-- **NEVER** manually edit `pyproject.toml` dependencies
-- **ALWAYS** use: `poetry add package-name` or `poetry add --group dev package-name`
-- **REMOVE** dependencies with: `poetry remove package-name`
-
-### Testing Requirements
-- Unit tests for all new functions/classes
-- Integration tests for data pipelines
-- Performance tests for critical paths
-- Test coverage > 80%
-
-## Key Technologies
-
-### Core Dependencies
-- **Python 3.11+** - Main language
-- **Poetry** - Dependency management
-- **pandas/numpy** - Data manipulation
-- **scikit-learn** - ML algorithms
-- **XGBoost** - Gradient boosting
-- **Optuna** - Hyperparameter optimization
-- **yfinance** - Market data
-- **pandas-ta** - Technical indicators
-
-### Configuration
-- **YAML** - Configuration files
-- **Pydantic** - Configuration validation
-- **joblib** - Model persistence
-
-## API Structure
-
-### Data Loading
-```python
-from quanttradeai import DataLoader, DataProcessor
-
-# Initialize components
-loader = DataLoader("config/model_config.yaml")
-processor = DataProcessor("config/features_config.yaml")
-
-# Fetch and process data
-data_dict = loader.fetch_data()
-df_processed = processor.process_data(df)
-df_labeled = processor.generate_labels(df_processed)
-```
-
-### Model Training
-```python
-from quanttradeai import MomentumClassifier
-
-# Initialize and train
-classifier = MomentumClassifier("config/model_config.yaml")
-X, y = classifier.prepare_data(df_labeled)
-classifier.train(X, y)
-```
-
-### Evaluation & Splitting
-- CLI training performs time‑aware splits using `data.test_start` and optional `data.test_end` in `config/model_config.yaml`. If unset, the last `training.test_size` fraction is used chronologically (no shuffle).
-- Hyperparameter tuning uses `TimeSeriesSplit(n_splits=training.cv_folds)` to prevent look‑ahead bias during CV.
-
-### Backtesting
-```python
-from quanttradeai import simulate_trades, compute_metrics
-
-# Simulate trades
-df_trades = simulate_trades(df_labeled)
-metrics = compute_metrics(df_trades)
-```
-
-## Configuration Files
-
-### Model Configuration (`config/model_config.yaml`)
-- Data parameters (symbols, date ranges, caching)
-- Model hyperparameters (LR, RF, XGBoost)
-- Training settings (test size, CV folds)
-- Trading parameters (position sizing, risk)
-
-### Feature Configuration (`config/features_config.yaml`)
-- Technical indicator parameters
-- Feature preprocessing settings
-- Feature selection methods
-- Pipeline steps
-
-## Error Handling Patterns
-
-### Data Validation
-```python
-# Validate data quality
-is_valid = loader.validate_data(data_dict)
-if not is_valid:
-    raise ValueError("Data validation failed")
-```
-
-### Model Training
-```python
-try:
-    classifier.train(X, y)
-except ValueError as e:
-    logger.error(f"Training error: {e}")
-    # Check data shapes and class distribution
-```
-
-### Configuration Validation
-```python
-from quanttradeai.utils.config_schemas import ModelConfigSchema
-ModelConfigSchema(**config)  # Validates configuration
-```
-
-## Performance Considerations
-
-### Memory Management
-- Use smaller data types for large datasets
-- Process data in batches for memory efficiency
-- Cache intermediate results appropriately
-
-### Computational Optimization
-- Vectorized operations over loops
-- Parallel processing for multiple assets
-- GPU acceleration for model training (future)
-
-## Testing Patterns
-
-### Unit Tests
-```python
-def test_data_loader():
-    loader = DataLoader("config/model_config.yaml")
-    data = loader.fetch_data()
-    assert len(data) > 0
-    assert all(isinstance(df, pd.DataFrame) for df in data.values())
-```
-
-### Integration Tests
-```python
-def test_complete_pipeline():
-    # Test end-to-end workflow
-    loader = DataLoader()
-    processor = DataProcessor()
-    classifier = MomentumClassifier()
-    
-    data = loader.fetch_data()
-    df = processor.process_data(data['AAPL'])
-    df_labeled = processor.generate_labels(df)
-    
-    X, y = classifier.prepare_data(df_labeled)
-    classifier.train(X, y)
-    
-    predictions = classifier.predict(X)
-    assert len(predictions) == len(y)
-```
-
-## Documentation Standards
-
-### Code Documentation
-- Docstrings for all public functions
-- Type hints for all parameters
-- Usage examples in docstrings
-- Clear parameter descriptions
-
-### API Documentation
-- Update `docs/api/` files for new functions
-- Include parameter types and return values
-- Provide usage examples
-- Document error conditions
-
-## Common Patterns
-
-### Feature Engineering
-```python
-from quanttradeai.features import technical as ta
-
-# Generate technical indicators
-df['sma_20'] = ta.sma(df['Close'], 20)
-df['rsi'] = ta.rsi(df['Close'], 14)
-macd_df = ta.macd(df['Close'])
-```
-
-### Risk Management
-```python
-from quanttradeai import apply_stop_loss_take_profit
-
-# Apply risk rules
-df_with_risk = apply_stop_loss_take_profit(df, stop_loss_pct=0.02)
-```
-
-### Performance Metrics
-```python
-from quanttradeai.utils.metrics import classification_metrics, sharpe_ratio
-
-# Calculate metrics
-metrics = classification_metrics(y_true, y_pred)
-sharpe = sharpe_ratio(returns, risk_free_rate=0.02)
-```
-
-## Troubleshooting
-
-### Common Issues
-1. **Data Loading Failures**: Check network connectivity, API limits
-2. **Memory Issues**: Reduce data size, use batching
-3. **Model Training Errors**: Check data quality, class balance
-4. **Configuration Errors**: Validate YAML syntax, required fields
-
-### Debugging Steps
-1. Check logs for error messages
-2. Validate input data quality
-3. Test individual components
-4. Verify configuration parameters
-
-## LLM Sentiment Analysis
-
-LiteLLM provides a unified interface for scoring text sentiment. Enable it through `config/features_config.yaml`:
-
-```yaml
-sentiment:
-  enabled: true
-  provider: openai
-  model: gpt-3.5-turbo
-  api_key_env_var: OPENAI_API_KEY
-```
-
-Set the corresponding API key:
+Use the small CLI surface first:
 
 ```bash
-export OPENAI_API_KEY="sk-..."
+poetry run quanttradeai init --template research -o config/project.yaml
+poetry run quanttradeai validate -c config/project.yaml
+poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
+poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 ```
 
-Switch providers by editing `provider`, `model`, and `api_key_env_var`. The data pipeline automatically adds a `sentiment_score` column during the `generate_sentiment` step.
+Agent projects follow the same pattern:
 
-For CLI and Python examples see [docs/llm-sentiment.md](docs/llm-sentiment.md).
+```bash
+poetry run quanttradeai init --template llm-agent -o config/project.yaml
+poetry run quanttradeai validate -c config/project.yaml
+poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
+poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
+poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
+poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live breakout_gpt
+```
 
-## Future Development Areas
+Deployment stays under the same command:
 
-### High Priority
-- Real-time data streaming
-- Advanced risk management
-- Multi-timeframe support
+```bash
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target render -o deployments/breakout-render
+```
 
-### Medium Priority
-- GPU acceleration
-- Microservices architecture
-- Advanced NLP features
-- Reinforcement learning
+## Product Objects
 
-### Low Priority
-- Quantum computing integration
-- Blockchain connectivity
-- Multi-modal AI
-- Federated learning
+- `project`: name, profile, and environment metadata.
+- `data`: symbols, time windows, historical data, and streaming settings.
+- `features`: reusable feature definitions shared by research and agents.
+- `research`: labels, model training, evaluation, backtest, and promotion rules.
+- `agents`: first-class `rule`, `model`, `llm`, and `hybrid` trading agents.
+- `risk` and `position_manager`: live safety and runtime controls.
+- `deployment`: local, Docker Compose, or Render bundle metadata.
+- `runs`: persisted artifacts for research, backtest, paper, live, batch, and sweep runs.
 
-## Resources
+## Agent Design Rules
 
-### Documentation
-- [API Reference](docs/api/)
-- [Configuration Guide](docs/configuration.md)
-- [Quick Reference](docs/quick-reference.md)
+- Prefer YAML changes in `config/project.yaml` over new config files.
+- Keep the CLI path small: `init`, `validate`, `research run`, `agent run`, `runs list`, `promote`, and `deploy`.
+- Preserve time-aware evaluation and avoid data leakage.
+- Keep training and serving feature definitions aligned.
+- Make LLM behavior auditable through prompt files, context blocks, decisions, executions, and prompt samples.
+- Do not remove working legacy utility commands unless a canonical replacement already exists.
 
-### External Libraries
-- [scikit-learn](https://scikit-learn.org/)
-- [XGBoost](https://xgboost.readthedocs.io/)
-- [Optuna](https://optuna.org/)
-- [pandas-ta](https://twopirllc.github.io/pandas-ta/)
+## Deployment Notes
 
-### Testing & Quality
-- [pytest](https://docs.pytest.org/)
-- [Black](https://black.readthedocs.io/)
-- [flake8](https://flake8.pycqa.org/)
+`deploy --target render` generates a Render Background Worker bundle with:
 
-## Commit Guidelines
+- `render.yaml`
+- `Dockerfile`
+- `.env.example`
+- `resolved_project_config.yaml`
+- `deployment_manifest.json`
+- `assets/` for selected-agent prompts, notes, and model artifacts
 
-### Before Committing
-1. Run `make format` - Format code with Black
-2. Run `make lint` - Check code quality with flake8
-3. Run `make test` - Execute all tests
-4. Update documentation if needed
-5. Add/update tests for new functionality
+Render bundles use `sync: false` secret placeholders and a persistent `/app/runs` disk. For Git-backed Render deploys, generate the bundle into a tracked directory such as `deployments/<agent>-render` or force-add the default `reports/deployments/...` output.
 
-### Commit Messages
-- Use conventional commit format
-- Be descriptive and concise
-- Reference issues when applicable
-- Example: `feat: add new technical indicator for momentum`
+## Development Checks
 
-### Pull Request Requirements
-- All tests must pass
-- Code coverage > 80%
-- Documentation updated
-- No linting errors
-- Clear description of changes
+Before handing off a code change, run the narrow tests for the touched area, then the broader suite if practical:
 
-## Emergency Procedures
+```bash
+poetry check
+poetry run pytest tests/integration/test_deploy_cli.py -q
+poetry run pytest tests/integration/test_cli_smoke.py tests/test_project_config_cli.py -q
+```
 
-### Breaking Changes
-- Maintain backward compatibility when possible
-- Use deprecation warnings for removed features
-- Update documentation immediately
-- Notify team of breaking changes
-
-### Critical Bugs
-- Create hotfix branch immediately
-- Add regression tests
-- Deploy fix as soon as possible
-- Document the issue and solution
-
----
-
-**Remember**: Always test thoroughly, follow coding standards, and maintain documentation. This codebase is used for financial applications - accuracy and reliability are paramount.
+Use `make format`, `make lint`, and `make test` for full local verification.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 | Run a hybrid agent | `init --template hybrid` -> `research run` -> `promote --run research/<run_id>` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Model signals plus LLM reasoning in one project, with research outputs promoted into a stable path before the agent is promoted through environments |
 | Run every project agent together | `agent run --all --mode backtest|paper|live --max-concurrency 4` | A local multi-agent batch that preserves normal child runs plus batch-level manifests and scoreboards |
 | Sweep one agent across parameter variants | `agent run --sweep rsi_threshold_grid --mode backtest --max-concurrency 4` | A local sweep batch that expands one agent into many backtest variants, preserves normal child runs, and ranks them with the same scoreboard flow |
-| Generate a QuantTradeAI deployment bundle | `deploy --agent <name> --target local|docker-compose --mode paper|live` | A local runner or Docker Compose bundle for a promoted paper or live agent with env placeholders and resolved config |
+| Generate a QuantTradeAI deployment bundle | `deploy --agent <name> --target local|docker-compose|render --mode paper|live` | A local runner, Docker Compose bundle, or Render worker bundle for a promoted paper or live agent |
 
 ## How It Fits Together
 
@@ -83,6 +83,7 @@ QuantTradeAI is one framework with two connected tracks:
 | `agent run --sweep <name> --mode backtest` from `project.yaml` | Supported |
 | `deploy --target local` for paper or live agents | Supported |
 | `deploy --target docker-compose` for paper or live agents | Supported |
+| `deploy --target render` for paper or live agents | Supported |
 ## Install In 2 Minutes
 
 QuantTradeAI requires Python `3.11+`.
@@ -299,18 +300,22 @@ Sweep child promotion materializes the winning scalar parameters into the base a
 
 ### Deploy A Paper Or Live Agent
 
-Use this if you want a generated local runner or Docker Compose bundle for a project-defined paper or live agent.
+Use this if you want a generated local runner, Docker Compose bundle, or Render Background Worker bundle for a project-defined paper or live agent.
 
 ```bash
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local --mode live
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose --mode live
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target render
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target render --mode live
 ```
 
 This writes a deployment bundle under `reports/deployments/<agent>/<timestamp>/` with:
 
-- `run.py` for local bundles, or `docker-compose.yml` and `Dockerfile` for Docker Compose bundles
+- `run.py` for local bundles, `docker-compose.yml` for Docker Compose bundles, or `render.yaml` for Render bundles
+- `Dockerfile` for Docker Compose and Render bundles
+- `assets/` for Render bundles that need prompt, notes, or model files copied into the worker image
 - `.env.example`
 - `README.md`
 - `resolved_project_config.yaml`
@@ -319,6 +324,8 @@ This writes a deployment bundle under `reports/deployments/<agent>/<timestamp>/`
 Paper bundles always disable replay in the emitted resolved project config and expect real-time streaming credentials. Local replay-backed paper runs stay unchanged in your source `config/project.yaml`.
 
 Local bundles run `python <bundle>/run.py` from your project environment. The runner uses the bundle's resolved config, loads an optional `.env` file next to `run.py`, and writes runtime artifacts back under the project `runs/` and `reports/` directories.
+
+Render bundles emit a Blueprint worker service with `sync: false` secret placeholders and a persistent `/app/runs` disk. If you plan to deploy from Git, generate the bundle into a tracked path with `-o deployments/<agent>-render` or force-add the generated bundle because `reports/` is gitignored by default.
 
 If the target agent uses `execution.backend: alpaca`, the generated bundle README and manifest call out that the service will submit real Alpaca paper/live market orders instead of simulated local fills.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,9 +62,10 @@ Live batches require every configured agent to already have `mode: live` and req
 ```bash
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target render -o deployments/breakout-render
 ```
 
-Deployment bundles are generated from `config/project.yaml`. Use `--target local` for a Python runner bundle or `--target docker-compose` for a Compose bundle. Paper bundles disable replay in the emitted deployment config and expect valid real-time provider settings.
+Deployment bundles are generated from `config/project.yaml`. Use `--target local` for a Python runner bundle, `--target docker-compose` for a Compose bundle, or `--target render` for a Render Background Worker Blueprint. Paper bundles disable replay in the emitted deployment config and expect valid real-time provider settings.
 
 ## Important Boundaries
 

--- a/docs/configuration/live-runtime-files.md
+++ b/docs/configuration/live-runtime-files.md
@@ -77,7 +77,9 @@ Child runs keep their normal per-run runtime YAML snapshots inside their own run
 
 ## Deployment Bundles
 
-`quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` generates a deployment bundle from the same canonical config. The bundle includes a deployment manifest plus emitted runtime config files for the selected agent and mode.
+`quanttradeai deploy --agent <name> -c config/project.yaml --target local|docker-compose|render` generates a deployment bundle from the same canonical config. The bundle includes a deployment manifest plus emitted runtime config files for the selected agent and mode.
+
+Render bundles add a `render.yaml` Blueprint for a Docker-backed background worker and copy selected-agent prompt, notes, and model assets into `assets/` so the worker image can run from the emitted `resolved_project_config.yaml`.
 
 ## Utility Command Boundary
 

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -11,7 +11,7 @@ It drives:
 - `quanttradeai agent run --all` for multi-agent batches in `backtest`, `paper`, and `live`
 - `quanttradeai agent run --sweep <name>` for backtest-only parameter sweeps
 - `quanttradeai promote` for research-model promotion, sweep winner materialization, and agent backtest-to-paper/paper-to-live promotion
-- `quanttradeai deploy` for docker-compose paper and live agent bundles
+- `quanttradeai deploy` for local, docker-compose, and Render paper/live agent bundles
 
 For local project-defined agents, `agent run --mode paper` defaults to deterministic replay when `data.streaming.replay.enabled: true`.
 
@@ -141,13 +141,15 @@ poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yam
 
 Research promotion updates model directories only and does not change `deployment.mode`.
 Paper promotion updates the matching agent's `mode` and `deployment.mode` to `paper`.
-Live promotion updates only the matching agent's `mode` to `live`. Set `deployment.mode: live` or pass `deploy --mode live` when generating a live docker-compose bundle.
+Live promotion updates only the matching agent's `mode` to `live`. Set `deployment.mode: live` or pass `deploy --mode live` when generating a live deployment bundle.
 
-Docker Compose deployment bundles can be generated with:
+Docker Compose and Render deployment bundles can be generated with:
 
 ```bash
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose --mode live
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target render -o deployments/breakout-render
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target render --mode live -o deployments/breakout-render-live
 ```
 
 ## Canonical Shape
@@ -637,7 +639,9 @@ Deployment metadata for the canonical project workflow.
 
 Current happy-path support:
 
+- `target: "local"`
 - `target: "docker-compose"`
+- `target: "render"`
 - `mode: "paper"` or `mode: "live"`
 
 Example:
@@ -652,13 +656,14 @@ Behavior:
 
 - `quanttradeai promote --run research/<run_id> -c config/project.yaml` copies trained model artifacts into stable `models/...` destinations and writes `promotion_manifest.json`
 - `quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml` updates `deployment.mode` to `paper` when promoting a successful agent backtest run
-- `quanttradeai deploy --agent <name> -c config/project.yaml --target docker-compose` generates a bundle under `reports/deployments/<agent>/<timestamp>/`
+- `quanttradeai deploy --agent <name> -c config/project.yaml --target local|docker-compose|render` generates a bundle under `reports/deployments/<agent>/<timestamp>/` unless `-o` is provided
 - generated paper bundles force `data.streaming.replay.enabled: false` in `resolved_project_config.yaml`
 - live bundles keep replay settings unchanged in `resolved_project_config.yaml`
-- deployment generation fails if the project does not include the real-time `provider`, `websocket_url`, and `channels` required for docker-compose deployment
-- live docker-compose deployment also requires the target agent to already be configured with `mode: live`, plus valid top-level `risk` and `position_manager` sections
-- generated bundles include `docker-compose.yml`, `Dockerfile`, `.env.example`, `README.md`, `resolved_project_config.yaml`, and `deployment_manifest.json`
-- generated compose services run `quanttradeai agent run --agent <name> -c config/project.yaml --mode <bundle-mode>`
+- deployment generation fails if the project does not include the real-time `provider`, `websocket_url`, and `channels` required for deployment
+- live deployment also requires the target agent to already be configured with `mode: live`, plus valid top-level `risk` and `position_manager` sections
+- local bundles include `run.py`; Docker Compose bundles include `docker-compose.yml`; Render bundles include `render.yaml` plus `assets/` for selected-agent prompt, notes, and model files
+- generated bundle services run `quanttradeai agent run --agent <name> -c config/project.yaml --mode <bundle-mode>`
+- Render output must stay inside the project root because the generated Blueprint uses repo-relative Docker paths
 
 ### `sweeps`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,9 +78,12 @@ poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml 
 ```bash
 poetry run quanttradeai deploy --agent paper_momentum -c config/project.yaml --target local
 poetry run quanttradeai deploy --agent paper_momentum -c config/project.yaml --target docker-compose
+poetry run quanttradeai deploy --agent paper_momentum -c config/project.yaml --target render -o deployments/paper_momentum-render
 ```
 
-Generated local and Docker Compose deployment bundles are still real-time paper deployments. QuantTradeAI disables replay in the emitted `resolved_project_config.yaml` and requires the normal provider and websocket settings to be present in the source project config.
+Generated local, Docker Compose, and Render deployment bundles are still real-time paper deployments. QuantTradeAI disables replay in the emitted `resolved_project_config.yaml` and requires the normal provider and websocket settings to be present in the source project config.
+
+Render bundles include `render.yaml`, a Dockerfile, and selected-agent assets under `assets/`. Use a tracked output path such as `deployments/<agent>-render` when you want to commit the Blueprint for Render.
 
 Paper and live runs write standardized artifacts under `runs/agent/paper/...` and `runs/agent/live/...`, including:
 
@@ -123,7 +126,7 @@ poetry run quanttradeai agent run --agent hybrid_swing_agent -c config/project.y
 
 The hybrid template already points `model_signal_sources` at `models/promoted/aapl_daily_classifier`, so the happy path does not require editing timestamped experiment directories by hand.
 
-Deployment bundles for project-defined paper agents are written under `reports/deployments/<agent>/<timestamp>/`. Use `--target local` for a Python runner bundle or `--target docker-compose` for a Compose bundle.
+Deployment bundles for project-defined paper agents are written under `reports/deployments/<agent>/<timestamp>/` by default. Use `--target local` for a Python runner bundle, `--target docker-compose` for a Compose bundle, or `--target render` for a Render Background Worker Blueprint.
 
 ## Workflow 4: Multi-Agent Batches
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -70,6 +70,7 @@ poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml -
 # Generated bundles disable replay and expect real-time streaming settings
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
 poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
+poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target render -o deployments/breakout-render
 
 # Lower-level utility commands that still exist
 poetry run quanttradeai fetch-data
@@ -122,6 +123,15 @@ Canonical local deployment bundle artifacts:
 Canonical Docker Compose deployment bundle artifacts:
 - `reports/deployments/<agent>/<timestamp>/docker-compose.yml`
 - `reports/deployments/<agent>/<timestamp>/Dockerfile`
+- `reports/deployments/<agent>/<timestamp>/.env.example`
+- `reports/deployments/<agent>/<timestamp>/README.md`
+- `reports/deployments/<agent>/<timestamp>/resolved_project_config.yaml`
+- `reports/deployments/<agent>/<timestamp>/deployment_manifest.json`
+
+Canonical Render deployment bundle artifacts:
+- `reports/deployments/<agent>/<timestamp>/render.yaml`
+- `reports/deployments/<agent>/<timestamp>/Dockerfile`
+- `reports/deployments/<agent>/<timestamp>/assets/`
 - `reports/deployments/<agent>/<timestamp>/.env.example`
 - `reports/deployments/<agent>/<timestamp>/README.md`
 - `reports/deployments/<agent>/<timestamp>/resolved_project_config.yaml`

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -1176,7 +1176,7 @@ def cmd_deploy(
     mode: Optional[str] = typer.Option(
         None,
         "--mode",
-        help="Deployment mode. Defaults to deployment.mode from project config; local and docker-compose support paper and live.",
+        help="Deployment mode. Defaults to deployment.mode from project config; local, docker-compose, and render support paper and live.",
     ),
     output: Optional[str] = typer.Option(
         None,

--- a/quanttradeai/deployment.py
+++ b/quanttradeai/deployment.py
@@ -6,6 +6,7 @@ import copy
 import json
 import os
 import re
+import shutil
 import tempfile
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -15,6 +16,7 @@ from typing import Any
 
 import yaml
 
+from quanttradeai.agents.context import context_block_enabled
 from quanttradeai.brokers import resolve_execution_backend
 from quanttradeai.streaming.env_vars import provider_env_var_prefix
 from quanttradeai.utils.config_validator import validate_project_config
@@ -32,7 +34,7 @@ DEFAULT_LLM_API_KEY_ENV_VARS = {
     "anthropic": "ANTHROPIC_API_KEY",
     "huggingface": "HUGGINGFACE_API_KEY",
 }
-SUPPORTED_DEPLOY_TARGETS = {"docker-compose", "local"}
+SUPPORTED_DEPLOY_TARGETS = {"docker-compose", "local", "render"}
 SUPPORTED_DEPLOY_MODES = {"paper", "live"}
 SUPPORTED_AGENT_KINDS = {"rule", "model", "llm", "hybrid"}
 
@@ -91,6 +93,156 @@ def _ensure_project_relative_dir(
         raise ValueError(
             f"{field_name} must resolve under {expected_top_level_dir}/ for docker-compose deployment."
         )
+
+
+def _ensure_render_output_dir(
+    *,
+    project_root: Path,
+    output_path: Path,
+) -> None:
+    try:
+        output_path.resolve().relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise ValueError(
+            "Render deployment output must resolve inside the project root so render.yaml can use repo-relative Docker paths."
+        ) from exc
+
+
+def _resolve_render_asset_path(
+    *,
+    project_root: Path,
+    config_path: Path,
+    raw_path: Any,
+    expected_top_level_dir: str,
+    field_name: str,
+) -> tuple[Path, Path]:
+    candidate = str(raw_path or "").strip()
+    if not candidate:
+        raise ValueError(f"{field_name} must not be blank for Render deployment.")
+
+    if Path(candidate).is_absolute():
+        raise ValueError(
+            f"{field_name} must be project-relative and under {expected_top_level_dir}/ for Render deployment."
+        )
+
+    resolved_path = resolve_project_path(config_path, candidate)
+    try:
+        relative = resolved_path.resolve().relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must resolve inside the project root under {expected_top_level_dir}/ for Render deployment."
+        ) from exc
+
+    if not relative.parts or relative.parts[0] != expected_top_level_dir:
+        raise ValueError(
+            f"{field_name} must resolve under {expected_top_level_dir}/ for Render deployment."
+        )
+
+    return resolved_path, relative
+
+
+def _copy_render_asset(
+    *,
+    source_path: Path,
+    relative_path: Path,
+    assets_root: Path,
+    asset_type: str,
+    seen: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    normalized_relative = relative_path.as_posix()
+    if normalized_relative in seen:
+        return seen[normalized_relative]
+
+    destination = assets_root / relative_path
+    if source_path.is_dir():
+        shutil.copytree(source_path, destination, dirs_exist_ok=True)
+    elif source_path.is_file():
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, destination)
+    else:
+        raise FileNotFoundError(f"Render deployment asset not found: {source_path}")
+
+    record = {
+        "type": asset_type,
+        "source": normalized_relative,
+        "bundle_path": (Path("assets") / relative_path).as_posix(),
+        "image_path": f"/app/{normalized_relative}",
+    }
+    seen[normalized_relative] = record
+    return record
+
+
+def _collect_render_assets(
+    *,
+    prepared: PreparedDeployment,
+    agent_name: str,
+    assets_root: Path,
+) -> list[dict[str, Any]]:
+    asset_manifest: list[dict[str, Any]] = []
+    seen: dict[str, dict[str, Any]] = {}
+
+    def _add_asset(raw_path: Any, expected_dir: str, field_name: str, asset_type: str):
+        source_path, relative_path = _resolve_render_asset_path(
+            project_root=prepared.project_root,
+            config_path=prepared.config_path,
+            raw_path=raw_path,
+            expected_top_level_dir=expected_dir,
+            field_name=field_name,
+        )
+        asset_manifest.append(
+            _copy_render_asset(
+                source_path=source_path,
+                relative_path=relative_path,
+                assets_root=assets_root,
+                asset_type=asset_type,
+                seen=seen,
+            )
+        )
+
+    llm_cfg = dict(prepared.agent_config.get("llm") or {})
+    if llm_cfg.get("prompt_file"):
+        _add_asset(
+            llm_cfg.get("prompt_file"),
+            "prompts",
+            "agents.<name>.llm.prompt_file",
+            "prompt",
+        )
+
+    model_cfg = dict(prepared.agent_config.get("model") or {})
+    if model_cfg.get("path"):
+        _add_asset(
+            model_cfg.get("path"),
+            "models",
+            "agents.<name>.model.path",
+            "model",
+        )
+
+    for source in prepared.agent_config.get("model_signal_sources") or []:
+        if not isinstance(source, dict):
+            raise ValueError(
+                "Render deployment requires object model_signal_sources entries with name and path."
+            )
+        _add_asset(
+            source.get("path"),
+            "models",
+            f"agents.<name>.model_signal_sources.{source.get('name')}.path",
+            "model_signal_source",
+        )
+
+    context_cfg = dict(prepared.agent_config.get("context") or {})
+    notes_cfg = context_cfg.get("notes")
+    if context_block_enabled(notes_cfg):
+        notes_file = f"notes/{agent_name}.md"
+        if isinstance(notes_cfg, dict):
+            notes_file = str(notes_cfg.get("file") or notes_file)
+        _add_asset(
+            notes_file,
+            "notes",
+            "agents.<name>.context.notes.file",
+            "notes",
+        )
+
+    return list(seen.values())
 
 
 def _required_env_vars(
@@ -163,6 +315,45 @@ RUN pip install --upgrade pip && pip install .
 """
 
 
+def _render_render_dockerfile(
+    *,
+    bundle_relative_path: str,
+    agent_name: str,
+    mode: str,
+) -> str:
+    bundle_prefix = bundle_relative_path.rstrip("/") or "."
+    command = [
+        "quanttradeai",
+        "agent",
+        "run",
+        "--agent",
+        agent_name,
+        "-c",
+        "config/project.yaml",
+        "--mode",
+        mode,
+    ]
+    return f"""FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \\
+    PYTHONUNBUFFERED=1 \\
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN mkdir -p /app/config /app/data /app/models /app/prompts /app/reports /app/runs /app/notes
+
+COPY ["pyproject.toml", "README.md", "/app/"]
+COPY ["quanttradeai", "/app/quanttradeai"]
+COPY ["{bundle_prefix}/resolved_project_config.yaml", "/app/config/project.yaml"]
+COPY ["{bundle_prefix}/assets/", "/app/"]
+
+RUN pip install --upgrade pip && pip install .
+
+CMD {json.dumps(command)}
+"""
+
+
 def _render_bundle_readme(
     *,
     agent_name: str,
@@ -230,6 +421,82 @@ def _render_bundle_readme(
                 "## Environment",
                 "",
                 "Set the variables listed in `.env.example` before starting the service.",
+            ]
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def _render_render_bundle_readme(
+    *,
+    agent_name: str,
+    agent_kind: str,
+    mode: str,
+    execution_backend: str,
+    broker_provider: str | None,
+    service_name: str,
+    next_command: str,
+    env_vars: list[tuple[str, str]],
+    safety_requirements: list[str],
+    asset_manifest: list[dict[str, Any]],
+) -> str:
+    lines = [
+        "# QuantTradeAI Render Deployment Bundle",
+        "",
+        f"This bundle deploys the `{agent_name}` `{agent_kind}` agent in `{mode}` mode as a Render Background Worker.",
+        "",
+        "## Mode",
+        "",
+        f"- `mode: {mode}`",
+        f"- `execution.backend: {execution_backend}`",
+        f"- `service: {service_name}`",
+        "",
+        "## Files",
+        "",
+        "- `render.yaml`: Render Blueprint for a Docker-backed worker service.",
+        "- `Dockerfile`: builds QuantTradeAI from this repository and embeds the selected agent bundle.",
+        "- `assets/`: selected-agent prompt, notes, and model assets copied into the image.",
+        "- `.env.example`: provider environment variables inferred from the project config.",
+        "- `resolved_project_config.yaml`: exact project config snapshot used for deployment generation.",
+        "- `deployment_manifest.json`: machine-readable summary of the generated bundle.",
+        "",
+        "## Deploy",
+        "",
+        next_command,
+        "",
+        "The worker writes run artifacts under `/app/runs`, which is mounted as a Render persistent disk in `render.yaml`.",
+    ]
+
+    if execution_backend == "alpaca" and broker_provider:
+        lines.extend(
+            [
+                "",
+                "This bundle uses broker-backed execution.",
+                f"In `{mode}` mode it will submit real `{broker_provider}` market orders instead of simulated local fills.",
+            ]
+        )
+
+    if safety_requirements:
+        lines.extend(["", "## Safety Requirements", ""])
+        lines.extend([f"- {requirement}" for requirement in safety_requirements])
+
+    if env_vars:
+        lines.extend(
+            [
+                "",
+                "## Environment",
+                "",
+                "Render will prompt for these secret values because `render.yaml` emits them with `sync: false`:",
+            ]
+        )
+        lines.extend([f"- `{name}`: {description}" for name, description in env_vars])
+
+    if asset_manifest:
+        lines.extend(["", "## Bundled Assets", ""])
+        lines.extend(
+            [
+                f"- `{item['source']}` -> `{item['image_path']}`"
+                for item in asset_manifest
             ]
         )
 
@@ -635,6 +902,11 @@ def _prepare_deployment(
         raise ValueError(
             f"Unsupported deployment target '{resolved_target}'. Supported targets: {supported}."
         )
+    if resolved_target == "render":
+        _ensure_render_output_dir(
+            project_root=project_root,
+            output_path=output_path,
+        )
 
     resolved_mode = str(mode or deployment_cfg.get("mode") or "paper")
     resolved_mode = resolved_mode.strip().lower()
@@ -939,6 +1211,162 @@ def _write_local_bundle(
     )
 
 
+def _write_render_bundle(
+    prepared: PreparedDeployment,
+    *,
+    agent_name: str,
+) -> dict[str, Any]:
+    output_path = prepared.output_path
+    created_output = not output_path.exists()
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    assets_root = output_path / "assets"
+    try:
+        if assets_root.exists():
+            shutil.rmtree(assets_root)
+        assets_root.mkdir(parents=True, exist_ok=True)
+        asset_manifest = _collect_render_assets(
+            prepared=prepared,
+            agent_name=agent_name,
+            assets_root=assets_root,
+        )
+    except Exception:
+        if created_output and output_path.exists():
+            shutil.rmtree(output_path)
+        raise
+
+    resolved_project_path = output_path / "resolved_project_config.yaml"
+    resolved_project_path.write_text(
+        yaml.safe_dump(prepared.project_config, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    bundle_relative_path = _relative_posix(output_path, prepared.project_root)
+    dockerfile_path = output_path / "Dockerfile"
+    dockerfile_path.write_text(
+        _render_render_dockerfile(
+            bundle_relative_path=bundle_relative_path,
+            agent_name=agent_name,
+            mode=prepared.mode,
+        ),
+        encoding="utf-8",
+    )
+
+    docker_command = (
+        f"quanttradeai agent run --agent {agent_name} "
+        f"-c config/project.yaml --mode {prepared.mode}"
+    )
+    dockerfile_rel = _relative_posix(dockerfile_path, prepared.project_root)
+    render_payload = {
+        "services": [
+            {
+                "type": "worker",
+                "name": prepared.service_name,
+                "runtime": "docker",
+                "plan": "starter",
+                "region": "oregon",
+                "dockerContext": ".",
+                "dockerfilePath": dockerfile_rel,
+                "dockerCommand": docker_command,
+                "numInstances": 1,
+                "maxShutdownDelaySeconds": 60,
+                "envVars": [
+                    {"key": name, "sync": False} for name, _ in prepared.env_vars
+                ],
+                "disk": {
+                    "name": "runs",
+                    "mountPath": "/app/runs",
+                    "sizeGB": 1,
+                },
+            }
+        ]
+    }
+
+    render_yaml_path = output_path / "render.yaml"
+    render_yaml_path.write_text(
+        yaml.safe_dump(render_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    env_example_path = output_path / ".env.example"
+    env_example_path.write_text(
+        _render_env_example(prepared.env_vars, target_label="render"),
+        encoding="utf-8",
+    )
+
+    render_yaml_rel = _relative_posix(render_yaml_path, prepared.project_root)
+    next_command = (
+        f"Commit {render_yaml_rel} and create or sync a Render Blueprint from it."
+    )
+    bundle_readme_path = output_path / "README.md"
+    bundle_readme_path.write_text(
+        _render_render_bundle_readme(
+            agent_name=agent_name,
+            agent_kind=str(prepared.agent_config.get("kind") or ""),
+            mode=prepared.mode,
+            execution_backend=prepared.execution_backend,
+            broker_provider=prepared.broker_provider,
+            service_name=prepared.service_name,
+            next_command=next_command,
+            env_vars=prepared.env_vars,
+            safety_requirements=prepared.safety_requirements,
+            asset_manifest=asset_manifest,
+        ),
+        encoding="utf-8",
+    )
+
+    artifacts = {
+        "render_blueprint": render_yaml_path.as_posix(),
+        "dockerfile": dockerfile_path.as_posix(),
+        "env_example": env_example_path.as_posix(),
+        "readme": bundle_readme_path.as_posix(),
+        "resolved_project_config": resolved_project_path.as_posix(),
+        "assets": assets_root.as_posix(),
+    }
+    command = [
+        "quanttradeai",
+        "agent",
+        "run",
+        "--agent",
+        agent_name,
+        "-c",
+        "config/project.yaml",
+        "--mode",
+        prepared.mode,
+    ]
+    manifest = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "agent_name": agent_name,
+        "agent_kind": prepared.agent_config.get("kind"),
+        "target": prepared.target,
+        "platform": "render",
+        "service_type": "worker",
+        "mode": prepared.mode,
+        "execution_backend": prepared.execution_backend,
+        "broker_provider": prepared.broker_provider,
+        "service_name": prepared.service_name,
+        "project_root": prepared.project_root.as_posix(),
+        "source_config": prepared.config_path.as_posix(),
+        "command": command,
+        "docker_context": ".",
+        "dockerfile_path": dockerfile_rel,
+        "docker_command": docker_command,
+        "render_blueprint": render_yaml_path.as_posix(),
+        "asset_manifest": asset_manifest,
+        "safety_requirements": prepared.safety_requirements,
+        "environment_variables": [name for name, _ in prepared.env_vars],
+        "artifacts": artifacts,
+        "warnings": prepared.warnings,
+        "next_command": next_command,
+    }
+    return _write_manifest_and_result(
+        prepared=prepared,
+        manifest=manifest,
+        artifacts=artifacts,
+        next_command=next_command,
+    )
+
+
 def _write_manifest_and_result(
     *,
     prepared: PreparedDeployment,
@@ -991,6 +1419,8 @@ def deploy_project_agent(
         return _write_docker_compose_bundle(prepared, agent_name=agent_name)
     if prepared.target == "local":
         return _write_local_bundle(prepared, agent_name=agent_name)
+    if prepared.target == "render":
+        return _write_render_bundle(prepared, agent_name=agent_name)
 
     supported = ", ".join(sorted(SUPPORTED_DEPLOY_TARGETS))
     raise ValueError(

--- a/quanttradeai/deployment.py
+++ b/quanttradeai/deployment.py
@@ -320,8 +320,12 @@ def _render_render_dockerfile(
     bundle_relative_path: str,
     agent_name: str,
     mode: str,
+    has_assets: bool,
 ) -> str:
     bundle_prefix = bundle_relative_path.rstrip("/") or "."
+    asset_copy_line = (
+        f'COPY ["{bundle_prefix}/assets/", "/app/"]\n' if has_assets else ""
+    )
     command = [
         "quanttradeai",
         "agent",
@@ -346,8 +350,7 @@ RUN mkdir -p /app/config /app/data /app/models /app/prompts /app/reports /app/ru
 COPY ["pyproject.toml", "README.md", "/app/"]
 COPY ["quanttradeai", "/app/quanttradeai"]
 COPY ["{bundle_prefix}/resolved_project_config.yaml", "/app/config/project.yaml"]
-COPY ["{bundle_prefix}/assets/", "/app/"]
-
+{asset_copy_line}
 RUN pip install --upgrade pip && pip install .
 
 CMD {json.dumps(command)}
@@ -1248,6 +1251,7 @@ def _write_render_bundle(
             bundle_relative_path=bundle_relative_path,
             agent_name=agent_name,
             mode=prepared.mode,
+            has_assets=bool(asset_manifest),
         ),
         encoding="utf-8",
     )

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,6 @@
 # QuantTradeAI Roadmap
 
-Last updated: 2026-04-22
+Last updated: 2026-05-02
 
 This document is the product source of truth for QuantTradeAI.
 It is written for both human contributors and coding agents.
@@ -352,7 +352,7 @@ Status on 2026-04-17:
 - `quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml` is implemented for successful agent backtest-to-paper promotion.
 - `quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live <agent_name>` is implemented for successful paper-to-live promotion with an explicit safety acknowledgement.
 - Top-level `risk` and `position_manager` are now the canonical live safety/runtime sections in `config/project.yaml`.
-- `quanttradeai deploy --agent <name> -c config/project.yaml --target local|docker-compose` now generates paper and live deployment bundles with env placeholders, resolved config, and a deployment manifest. Local bundles include a Python runner, Docker Compose bundles include compose and Dockerfile assets, paper bundles still disable replay in the emitted config, and Alpaca-backed agents are called out explicitly in the generated bundle README and manifest. Managed runner deployment remains future work.
+- `quanttradeai deploy --agent <name> -c config/project.yaml --target local|docker-compose|render` now generates paper and live deployment bundles with env placeholders, resolved config, and a deployment manifest. Local bundles include a Python runner, Docker Compose bundles include compose and Dockerfile assets, Render bundles include a Background Worker Blueprint plus selected-agent assets, paper bundles still disable replay in the emitted config, and Alpaca-backed agents are called out explicitly in the generated bundle README and manifest.
 - Replaced legacy paths have been removed from the primary CLI surface: `train`, `backtest-model`, `live-trade`, `validate-config`, and the `--legacy-config-dir` import flags are gone. `fetch-data`, `evaluate`, and standalone `backtest` remain as utility commands outside the primary product workflow.
 
 ### Stage 2: Multi-Agent Lab
@@ -394,6 +394,13 @@ Deliverables:
 - Support promotion from `backtest` -> `paper` -> `live`.
 - Add one broker/exchange integration with account state, orders, fills, and position sync.
 - Keep secrets and runtime config platform-native.
+
+Status on 2026-05-01:
+
+- `quanttradeai deploy --agent <name> -c config/project.yaml --target render` is implemented for single-agent paper and live deployment bundles.
+- Render bundles generate a Docker-backed Background Worker Blueprint (`render.yaml`), a Dockerfile, `.env.example`, `resolved_project_config.yaml`, `deployment_manifest.json`, and selected-agent runtime assets under `assets/`.
+- Render paper bundles disable replay in the emitted config and require real-time provider settings; Render live bundles require the target agent to already be `mode: live` and preserve the existing live safety gates.
+- Render secrets are emitted as Blueprint `envVars` with `sync: false`, and run artifacts are written under a persistent `/app/runs` disk.
 
 ### Stage 4: Product Hardening
 
@@ -463,11 +470,12 @@ quanttradeai promote --run agent/paper/<run_id> --to live --acknowledge-live pap
 quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode live
 quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
 quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
+quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target render -o deployments/breakout-render
 quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest
 ```
 
 Current implementation note:
-`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`, including `agent run --all --mode paper`; live batches are available through `agent run --all --mode live --acknowledge-live <project_name>`. Agents can also opt into `execution.backend: alpaca` for happy-path real-time paper/live broker submission with broker-synced account and position snapshots. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`, and winning sweep children can be promoted into the base agent config for paper mode. `deploy --target local` and `deploy --target docker-compose` support both simulated and Alpaca-backed paper/live agent bundles.
+`rule`, `model`, `llm`, and `hybrid` agents support `--mode backtest`, `--mode paper`, and `--mode live` today. Local paper mode defaults to replay-backed execution through `data.streaming.replay`, including `agent run --all --mode paper`; live batches are available through `agent run --all --mode live --acknowledge-live <project_name>`. Agents can also opt into `execution.backend: alpaca` for happy-path real-time paper/live broker submission with broker-synced account and position snapshots. Backtest-only parameter sweeps are supported through the optional `sweeps:` section in `config/project.yaml`, and winning sweep child runs can be materialized back to the base agent with `promote --apply-sweep` before rerunning a normal backtest. `deploy --target local`, `deploy --target docker-compose`, and `deploy --target render` support both simulated and Alpaca-backed paper/live agent bundles.
 
 ### Hybrid track
 
@@ -484,7 +492,7 @@ quanttradeai agent run --agent hybrid_swing_agent -c config/project.yaml --mode 
 ```
 
 Current implementation note:
-Hybrid agents are runnable in `backtest`, `paper`, and `live` mode. Live deployment remains future roadmap work.
+Hybrid agents are runnable in `backtest`, `paper`, and `live` mode. Local, Docker Compose, and Render deployment bundles can be generated for promoted hybrid paper/live agents.
 
 ## Definition of Done for the Happy Path
 

--- a/tests/integration/test_deploy_cli.py
+++ b/tests/integration/test_deploy_cli.py
@@ -265,7 +265,7 @@ def test_rule_agent_render_deploy_writes_paper_worker_bundle_and_preserves_proje
     assert {"key": "ALPACA_API_KEY", "sync": False} in service["envVars"]
     assert {"key": "ALPACA_API_SECRET", "sync": False} in service["envVars"]
     assert "deployments/rule-render/resolved_project_config.yaml" in dockerfile_text
-    assert "deployments/rule-render/assets/" in dockerfile_text
+    assert "deployments/rule-render/assets/" not in dockerfile_text
     assert "ALPACA_API_KEY" in env_example
     assert "Render Background Worker" in readme
     assert manifest["target"] == "render"
@@ -457,7 +457,7 @@ def test_llm_agent_render_deploy_copies_prompt_assets(tmp_path: Path, monkeypatc
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
     output_dir = Path(payload["output_dir"])
-    render_yaml, _dockerfile_text, env_example, readme, manifest, resolved_project = (
+    render_yaml, dockerfile_text, env_example, readme, manifest, resolved_project = (
         _load_render_deploy_bundle(output_dir)
     )
 
@@ -467,6 +467,7 @@ def test_llm_agent_render_deploy_copies_prompt_assets(tmp_path: Path, monkeypatc
     assert {"key": "OPENAI_API_KEY", "sync": False} in render_yaml["services"][0][
         "envVars"
     ]
+    assert "deployments/llm-render/assets/" in dockerfile_text
     assert "prompts/breakout.md" in readme
     assert manifest["asset_manifest"] == [
         {
@@ -522,7 +523,7 @@ def test_render_deploy_copies_model_and_hybrid_assets(
     assert result.exit_code == 0, result.stdout
     payload = json.loads(result.stdout)
     output_dir = Path(payload["output_dir"])
-    render_yaml, _dockerfile_text, env_example, readme, manifest, _resolved_project = (
+    render_yaml, dockerfile_text, env_example, readme, manifest, _resolved_project = (
         _load_render_deploy_bundle(output_dir)
     )
     asset_sources = [item["source"] for item in manifest["asset_manifest"]]
@@ -533,6 +534,7 @@ def test_render_deploy_copies_model_and_hybrid_assets(
         assert (output_dir / "assets" / expected_asset).exists()
         assert expected_asset in readme
     assert ("OPENAI_API_KEY" in env_example) is expect_openai_env
+    assert f"deployments/{template}-render/assets/" in dockerfile_text
     assert {"key": "ALPACA_API_KEY", "sync": False} in render_yaml["services"][0][
         "envVars"
     ]

--- a/tests/integration/test_deploy_cli.py
+++ b/tests/integration/test_deploy_cli.py
@@ -85,6 +85,20 @@ def _load_local_deploy_bundle(output_dir: Path) -> tuple[str, str, str, dict, di
     return runner_text, env_example, readme, manifest, resolved_project
 
 
+def _load_render_deploy_bundle(
+    output_dir: Path,
+) -> tuple[dict, str, str, str, dict, dict]:
+    render_yaml = _read_yaml(output_dir / "render.yaml")
+    dockerfile_text = (output_dir / "Dockerfile").read_text(encoding="utf-8")
+    env_example = (output_dir / ".env.example").read_text(encoding="utf-8")
+    readme = (output_dir / "README.md").read_text(encoding="utf-8")
+    manifest = json.loads(
+        (output_dir / "deployment_manifest.json").read_text(encoding="utf-8")
+    )
+    resolved_project = _read_yaml(output_dir / "resolved_project_config.yaml")
+    return render_yaml, dockerfile_text, env_example, readme, manifest, resolved_project
+
+
 def test_rule_agent_deploy_writes_paper_bundle_and_preserves_project_config(
     tmp_path: Path, monkeypatch
 ):
@@ -205,6 +219,104 @@ def test_local_deploy_can_use_project_config_default_target(
     assert not (output_dir / "docker-compose.yml").exists()
 
 
+def test_rule_agent_render_deploy_writes_paper_worker_bundle_and_preserves_project_config(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "rule-agent")
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name="rsi_reversion",
+        config_path=config_path,
+        output_dir="deployments/rule-render",
+        extra_args=["--target", "render"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    output_dir = Path(payload["output_dir"])
+    render_yaml, dockerfile_text, env_example, readme, manifest, resolved_project = (
+        _load_render_deploy_bundle(output_dir)
+    )
+
+    service = render_yaml["services"][0]
+    assert payload["status"] == "success"
+    assert payload["target"] == "render"
+    assert payload["mode"] == "paper"
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert (output_dir / "render.yaml").is_file()
+    assert (output_dir / "Dockerfile").is_file()
+    assert (output_dir / ".env.example").is_file()
+    assert (output_dir / "README.md").is_file()
+    assert (output_dir / "resolved_project_config.yaml").is_file()
+    assert (output_dir / "deployment_manifest.json").is_file()
+    assert (output_dir / "assets").is_dir()
+    assert service["type"] == "worker"
+    assert service["runtime"] == "docker"
+    assert service["dockerContext"] == "."
+    assert service["dockerfilePath"] == "deployments/rule-render/Dockerfile"
+    assert service["dockerCommand"] == (
+        "quanttradeai agent run --agent rsi_reversion "
+        "-c config/project.yaml --mode paper"
+    )
+    assert service["numInstances"] == 1
+    assert service["maxShutdownDelaySeconds"] == 60
+    assert service["disk"] == {"name": "runs", "mountPath": "/app/runs", "sizeGB": 1}
+    assert {"key": "ALPACA_API_KEY", "sync": False} in service["envVars"]
+    assert {"key": "ALPACA_API_SECRET", "sync": False} in service["envVars"]
+    assert "deployments/rule-render/resolved_project_config.yaml" in dockerfile_text
+    assert "deployments/rule-render/assets/" in dockerfile_text
+    assert "ALPACA_API_KEY" in env_example
+    assert "Render Background Worker" in readme
+    assert manifest["target"] == "render"
+    assert manifest["platform"] == "render"
+    assert manifest["service_type"] == "worker"
+    assert manifest["docker_context"] == "."
+    assert manifest["dockerfile_path"] == "deployments/rule-render/Dockerfile"
+    assert manifest["render_blueprint"].endswith("/render.yaml")
+    assert manifest["asset_manifest"] == []
+    assert resolved_project["data"]["streaming"]["replay"]["enabled"] is False
+    assert any(
+        "replay was disabled in the generated bundle" in warning.lower()
+        for warning in payload["warnings"]
+    )
+
+
+def test_render_deploy_can_use_project_config_default_target(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "rule-agent")
+    payload = _read_yaml(config_path)
+    payload["deployment"]["target"] = "render"
+    _write_yaml(config_path, payload)
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name="rsi_reversion",
+        config_path=config_path,
+        output_dir="deployments/rule-render-default",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    deploy_payload = json.loads(result.stdout)
+    output_dir = Path(deploy_payload["output_dir"])
+    (
+        render_yaml,
+        _dockerfile_text,
+        _env_example,
+        _readme,
+        manifest,
+        _resolved_project,
+    ) = _load_render_deploy_bundle(output_dir)
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert deploy_payload["target"] == "render"
+    assert manifest["target"] == "render"
+    assert render_yaml["services"][0]["type"] == "worker"
+    assert (output_dir / "render.yaml").is_file()
+    assert not (output_dir / "docker-compose.yml").exists()
+
+
 def test_rule_agent_live_deploy_uses_config_default_mode_and_preserves_project_config(
     tmp_path: Path, monkeypatch
 ):
@@ -239,6 +351,45 @@ def test_rule_agent_live_deploy_uses_config_default_mode_and_preserves_project_c
     assert "ALPACA_API_KEY" in env_example
     assert "ALPACA_API_SECRET" in env_example
     assert "in `live` mode" in readme
+    assert "Safety Requirements" in readme
+    assert "`mode: live`" in readme
+    assert not any(
+        "replay was disabled in the generated bundle" in warning.lower()
+        for warning in payload["warnings"]
+    )
+    assert resolved_project["data"]["streaming"]["replay"]["enabled"] is True
+
+
+def test_rule_agent_render_live_deploy_uses_worker_safety_gates(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "rule-agent")
+    _configure_live_deploy(config_path, deployment_mode="live")
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name="rsi_reversion",
+        config_path=config_path,
+        output_dir="deployments/rule-render-live",
+        extra_args=["--target", "render"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    output_dir = Path(payload["output_dir"])
+    render_yaml, _dockerfile_text, env_example, readme, manifest, resolved_project = (
+        _load_render_deploy_bundle(output_dir)
+    )
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert payload["status"] == "success"
+    assert payload["target"] == "render"
+    assert payload["mode"] == "live"
+    assert render_yaml["services"][0]["dockerCommand"].endswith("--mode live")
+    assert manifest["mode"] == "live"
+    assert manifest["service_type"] == "worker"
+    assert manifest["safety_requirements"]
+    assert "ALPACA_API_KEY" in env_example
     assert "Safety Requirements" in readme
     assert "`mode: live`" in readme
     assert not any(
@@ -290,6 +441,101 @@ def test_hybrid_agent_local_live_deploy_absolutizes_prompt_and_model_paths(
         "replay was disabled in the generated bundle" in warning.lower()
         for warning in payload["warnings"]
     )
+
+
+def test_llm_agent_render_deploy_copies_prompt_assets(tmp_path: Path, monkeypatch):
+    config_path = _init_template(tmp_path, monkeypatch, "llm-agent")
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name="breakout_gpt",
+        config_path=config_path,
+        output_dir="deployments/llm-render",
+        extra_args=["--target", "render"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    output_dir = Path(payload["output_dir"])
+    render_yaml, _dockerfile_text, env_example, readme, manifest, resolved_project = (
+        _load_render_deploy_bundle(output_dir)
+    )
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert (output_dir / "assets" / "prompts" / "breakout.md").is_file()
+    assert "OPENAI_API_KEY" in env_example
+    assert {"key": "OPENAI_API_KEY", "sync": False} in render_yaml["services"][0][
+        "envVars"
+    ]
+    assert "prompts/breakout.md" in readme
+    assert manifest["asset_manifest"] == [
+        {
+            "type": "prompt",
+            "source": "prompts/breakout.md",
+            "bundle_path": "assets/prompts/breakout.md",
+            "image_path": "/app/prompts/breakout.md",
+        }
+    ]
+    assert resolved_project["agents"][0]["llm"]["prompt_file"] == "prompts/breakout.md"
+
+
+@pytest.mark.parametrize(
+    (
+        "template",
+        "agent_name",
+        "expected_assets",
+        "expect_openai_env",
+    ),
+    [
+        (
+            "model-agent",
+            "paper_momentum",
+            ["models/promoted/aapl_daily_classifier"],
+            False,
+        ),
+        (
+            "hybrid",
+            "hybrid_swing_agent",
+            ["prompts/hybrid_swing.md", "models/promoted/aapl_daily_classifier"],
+            True,
+        ),
+    ],
+)
+def test_render_deploy_copies_model_and_hybrid_assets(
+    tmp_path: Path,
+    monkeypatch,
+    template: str,
+    agent_name: str,
+    expected_assets: list[str],
+    expect_openai_env: bool,
+):
+    config_path = _init_template(tmp_path, monkeypatch, template)
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name=agent_name,
+        config_path=config_path,
+        output_dir=f"deployments/{template}-render",
+        extra_args=["--target", "render"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    output_dir = Path(payload["output_dir"])
+    render_yaml, _dockerfile_text, env_example, readme, manifest, _resolved_project = (
+        _load_render_deploy_bundle(output_dir)
+    )
+    asset_sources = [item["source"] for item in manifest["asset_manifest"]]
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    for expected_asset in expected_assets:
+        assert expected_asset in asset_sources
+        assert (output_dir / "assets" / expected_asset).exists()
+        assert expected_asset in readme
+    assert ("OPENAI_API_KEY" in env_example) is expect_openai_env
+    assert {"key": "ALPACA_API_KEY", "sync": False} in render_yaml["services"][0][
+        "envVars"
+    ]
 
 
 def test_deploy_readme_and_manifest_call_out_alpaca_backed_execution(
@@ -492,6 +738,26 @@ def test_local_live_deploy_requires_agent_to_be_configured_live(
     assert not Path("deployments/local-live-not-configured").exists()
 
 
+def test_render_live_deploy_requires_agent_to_be_configured_live(
+    tmp_path: Path, monkeypatch
+):
+    config_path = _init_template(tmp_path, monkeypatch, "llm-agent")
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name="breakout_gpt",
+        config_path=config_path,
+        output_dir="deployments/render-live-not-configured",
+        extra_args=["--target", "render", "--mode", "live"],
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert "must be configured with mode=live" in combined_output
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert not Path("deployments/render-live-not-configured").exists()
+
+
 @pytest.mark.parametrize(
     ("field_name", "expected_error"),
     [
@@ -595,6 +861,96 @@ def test_local_live_deploy_requires_top_level_live_safety_sections(
     assert config_path.read_text(encoding="utf-8") == original_config
 
 
+def test_render_deploy_rejects_output_outside_project_root(tmp_path: Path, monkeypatch):
+    config_path = _init_template(tmp_path, monkeypatch, "rule-agent")
+    outside_output = tmp_path.parent / "outside-render-bundle"
+
+    result = _deploy_agent(
+        agent_name="rsi_reversion",
+        config_path=config_path,
+        output_dir=str(outside_output),
+        extra_args=["--target", "render"],
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert (
+        "Render deployment output must resolve inside the project root"
+        in combined_output
+    )
+    assert not outside_output.exists()
+
+
+@pytest.mark.parametrize(
+    ("template", "agent_name", "mutator", "expected_error"),
+    [
+        (
+            "llm-agent",
+            "breakout_gpt",
+            "prompt",
+            "agents.<name>.llm.prompt_file must resolve under prompts/",
+        ),
+        (
+            "model-agent",
+            "paper_momentum",
+            "model",
+            "agents.<name>.model.path must resolve under models/",
+        ),
+        (
+            "llm-agent",
+            "breakout_gpt",
+            "notes",
+            "agents.<name>.context.notes.file must resolve under notes/",
+        ),
+    ],
+)
+def test_render_deploy_rejects_assets_outside_expected_project_dirs(
+    tmp_path: Path,
+    monkeypatch,
+    template: str,
+    agent_name: str,
+    mutator: str,
+    expected_error: str,
+):
+    config_path = _init_template(tmp_path, monkeypatch, template)
+    payload = _read_yaml(config_path)
+
+    if mutator == "prompt":
+        bad_prompt = Path("other_prompts") / "agent.md"
+        bad_prompt.parent.mkdir(parents=True, exist_ok=True)
+        bad_prompt.write_text("Bad prompt location.", encoding="utf-8")
+        payload["agents"][0]["llm"]["prompt_file"] = bad_prompt.as_posix()
+    elif mutator == "model":
+        bad_model = Path("artifacts") / "model"
+        bad_model.mkdir(parents=True, exist_ok=True)
+        (bad_model / "README.md").write_text("Bad model location.", encoding="utf-8")
+        payload["agents"][0]["model"]["path"] = bad_model.as_posix()
+    elif mutator == "notes":
+        bad_notes = Path("agent_notes") / "breakout.md"
+        bad_notes.parent.mkdir(parents=True, exist_ok=True)
+        bad_notes.write_text("Bad notes location.", encoding="utf-8")
+        payload["agents"][0]["context"]["notes"] = {
+            "enabled": True,
+            "file": bad_notes.as_posix(),
+        }
+
+    _write_yaml(config_path, payload)
+    original_config = config_path.read_text(encoding="utf-8")
+
+    result = _deploy_agent(
+        agent_name=agent_name,
+        config_path=config_path,
+        output_dir=f"deployments/render-bad-{mutator}",
+        extra_args=["--target", "render"],
+    )
+
+    assert result.exit_code == 1
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert expected_error in combined_output
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert not Path(f"deployments/render-bad-{mutator}").exists()
+
+
 def test_deploy_failure_cases(
     tmp_path: Path,
     monkeypatch,
@@ -656,6 +1012,7 @@ def test_deploy_failure_cases(
         if expected_error == "Unsupported deployment target":
             assert "docker-compose" in combined_output
             assert "local" in combined_output
+            assert "render" in combined_output
         assert config_path.read_text(encoding="utf-8") == original_config
         if requested_output == existing_output:
             assert (requested_output / "stale.txt").is_file()


### PR DESCRIPTION
## Summary

- Add `quanttradeai deploy --target render` for Render Background Worker deployment bundles.
- Generate Render artifacts including `render.yaml`, Dockerfile, `.env.example`, resolved project config, deployment manifest, README, and selected-agent runtime assets.
- Document Render deployment across the roadmap, README, configuration docs, quick reference, getting started guide, live runtime file docs, and refresh `LLM.md` for the current agent-facing workflow.

## Validation

- `make lint.format.test`
- Pre-commit hook during commit: format, lint, test