### PR TITLE
Add agent experiment briefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 | Run a trained model as an agent | `init --template model-agent` -> `validate` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | One YAML-defined model agent wired to a stable `models/promoted/...` path that can be backtested, promoted, paper-run, and live-run |
 | Run an LLM agent | `init --template llm-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Prompt-driven agent logic using project config across all three modes |
 | Run a hybrid agent | `init --template hybrid` -> `research run` -> `promote --run research/<run_id>` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | Model signals plus LLM reasoning in one project, with research outputs promoted into a stable path before the agent is promoted through environments |
-| Run every project agent together | `agent run --all --mode backtest|paper|live --max-concurrency 4` | A local multi-agent batch that preserves normal child runs plus batch-level manifests and scoreboards |
+| Run every project agent together | `agent run --all --mode backtest|paper|live --max-concurrency 4` | A local multi-agent batch that preserves normal child runs plus batch-level manifests, scoreboards, and experiment briefs |
 | Sweep one agent across parameter variants | `agent run --sweep rsi_threshold_grid --mode backtest --max-concurrency 4` | A local sweep batch that expands one agent into many backtest variants, preserves normal child runs, and ranks them with the same scoreboard flow |
 | Generate a QuantTradeAI deployment bundle | `deploy --agent <name> --target local|docker-compose|render --mode paper|live` | A local runner, Docker Compose bundle, or Render worker bundle for a promoted paper or live agent |
 
@@ -84,6 +84,7 @@ QuantTradeAI is one framework with two connected tracks:
 | `agent run --all --mode paper` from `project.yaml` | Supported |
 | `agent run --all --mode live` from `project.yaml` with acknowledgement | Supported |
 | `agent run --sweep <name> --mode backtest` from `project.yaml` | Supported |
+| Batch experiment briefs and `runs list --type batch` | Supported |
 | `deploy --target local` for paper or live agents | Supported |
 | `deploy --target docker-compose` for paper or live agents | Supported |
 | `deploy --target render` for paper or live agents | Supported |
@@ -291,12 +292,15 @@ Live batches require every agent in `config/project.yaml` to already have `mode:
 
 This writes batch artifacts under `runs/agent/batches/<timestamp>_<project>_<mode>/`:
 
+- `summary.json`
 - `batch_manifest.json`
 - `results.json`
 - `scoreboard.json`
 - `scoreboard.txt`
+- `experiment_brief.json`
+- `experiment_brief.md`
 
-Each child agent still writes its normal run under `runs/agent/backtest/...`, `runs/agent/paper/...`, or `runs/agent/live/...`, so `quanttradeai runs list --scoreboard` continues to work for ranking and `quanttradeai runs list --compare ...` can inspect shortlisted runs in detail. Backtest batches rank by `net_sharpe`; paper and live batches rank by `total_pnl`.
+Each child agent still writes its normal run under `runs/agent/backtest/...`, `runs/agent/paper/...`, or `runs/agent/live/...`, so `quanttradeai runs list --scoreboard` continues to work for ranking and `quanttradeai runs list --compare ...` can inspect shortlisted runs in detail. Batch summaries are discoverable with `quanttradeai runs list --type batch --json`. Backtest batches rank by `net_sharpe`; paper and live batches rank by `total_pnl`.
 
 ### Sweep One Agent
 
@@ -426,12 +430,15 @@ For the full shape, field reference, and supported agent modes, see [Project YAM
 
 Sweep batch artifacts:
 
+- `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/summary.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/batch_manifest.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/results.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/scoreboard.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/scoreboard.txt`
+- `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/experiment_brief.json`
+- `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/experiment_brief.md`
 
-This makes it easier to rank runs, inspect what actually changed, and reuse winning configurations.
+This makes it easier to rank runs, inspect what actually changed, reuse winning configurations, and hand the next action to a coding agent without opening every batch artifact manually.
 
 To rank and compare local runs directly from the CLI, use the scoreboard first and then compare explicit run ids:
 
@@ -441,6 +448,7 @@ poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
 poetry run quanttradeai runs list --compare research/<run_id_a> --compare research/<run_id_b>
 poetry run quanttradeai runs list --compare agent/backtest/<run_id_a> --compare agent/backtest/<run_id_b> --sort-by net_sharpe
 poetry run quanttradeai runs list --type agent --mode live --scoreboard --sort-by total_pnl
+poetry run quanttradeai runs list --type batch --json
 ```
 
 ## Documentation Map

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -109,6 +109,8 @@ poetry run quanttradeai agent run --all -c config/project.yaml --mode live --ack
 
 Multi-agent batches preserve the normal child runs under `runs/agent/backtest/...`, `runs/agent/paper/...`, or `runs/agent/live/...` and write batch artifacts under `runs/agent/batches/<timestamp>_<project>_<mode>/`.
 
+Every batch directory includes `summary.json`, `experiment_brief.json`, and `experiment_brief.md`. The JSON brief identifies the top successful run from the existing scoreboard order, failed children, useful logs, and exact next commands for promotion or inspection. Batch summaries are discoverable with `quanttradeai runs list --type batch --json`.
+
 Backtest batches rank by `net_sharpe`. Paper and live batches rank by `total_pnl`. Live batches require every configured agent to already have `mode: live` and require `--acknowledge-live` to match `project.name`.
 
 ### Backtest Sweeps
@@ -808,6 +810,8 @@ Writes under `runs/agent/backtest/<timestamp>_<agent>/`.
 
 Writes a batch directory under `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/` and one normal child backtest run under `runs/agent/backtest/...` for each expanded variant.
 
+The sweep batch also writes `summary.json`, `experiment_brief.json`, and `experiment_brief.md`. The brief uses the winning child's existing `promote_command` and includes the follow-up paper command for the base agent.
+
 ### `quanttradeai agent run --mode paper`
 
 Writes under `runs/agent/paper/<timestamp>_<agent>/`.
@@ -820,7 +824,7 @@ When replay is enabled, the run directory also includes `replay_manifest.json`, 
 
 Writes a batch directory under `runs/agent/batches/<timestamp>_<project>_paper/` and one normal child paper run under `runs/agent/paper/...` for each enumerated agent.
 
-Batch scoreboards for paper mode sort by `total_pnl`.
+Batch scoreboards for paper mode sort by `total_pnl`. The experiment brief recommends the live-promotion command for the top successful paper run.
 
 ### `quanttradeai agent run --all --mode live`
 
@@ -828,7 +832,7 @@ Writes a batch directory under `runs/agent/batches/<timestamp>_<project>_live/` 
 
 Live batches require `--acknowledge-live <project.name>`, reject `--skip-validation`, and fail fast unless every configured agent already has `mode: live`.
 
-Batch scoreboards for live mode sort by `total_pnl`.
+Batch scoreboards for live mode sort by `total_pnl`. The experiment brief points to metrics, executions, decisions, and logs for inspection instead of producing a promotion command.
 
 ### `quanttradeai agent run --mode live`
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -67,6 +67,7 @@ poetry run quanttradeai agent run --all -c config/project.yaml --mode paper
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper --max-concurrency 4
 # Acknowledged live batch across every live-configured project agent
 poetry run quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>
+poetry run quanttradeai runs list --type batch --json
 
 # Backtest one sweep of agent parameter variants
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest
@@ -147,20 +148,22 @@ Canonical Render deployment bundle artifacts:
 - `reports/deployments/<agent>/<timestamp>/deployment_manifest.json`
 
 Canonical multi-agent batch artifacts:
-- `runs/agent/batches/<timestamp>_<project>_backtest/batch_manifest.json`
-- `runs/agent/batches/<timestamp>_<project>_backtest/results.json`
-- `runs/agent/batches/<timestamp>_<project>_backtest/scoreboard.json`
-- `runs/agent/batches/<timestamp>_<project>_backtest/scoreboard.txt`
-- `runs/agent/batches/<timestamp>_<project>_paper/batch_manifest.json`
-- `runs/agent/batches/<timestamp>_<project>_paper/results.json`
-- `runs/agent/batches/<timestamp>_<project>_paper/scoreboard.json`
-- `runs/agent/batches/<timestamp>_<project>_paper/scoreboard.txt`
+- `runs/agent/batches/<timestamp>_<project>_<mode>/summary.json`
+- `runs/agent/batches/<timestamp>_<project>_<mode>/batch_manifest.json`
+- `runs/agent/batches/<timestamp>_<project>_<mode>/results.json`
+- `runs/agent/batches/<timestamp>_<project>_<mode>/scoreboard.json`
+- `runs/agent/batches/<timestamp>_<project>_<mode>/scoreboard.txt`
+- `runs/agent/batches/<timestamp>_<project>_<mode>/experiment_brief.json`
+- `runs/agent/batches/<timestamp>_<project>_<mode>/experiment_brief.md`
 
 Canonical sweep batch artifacts:
+- `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/summary.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/batch_manifest.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/results.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/scoreboard.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/scoreboard.txt`
+- `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/experiment_brief.json`
+- `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/experiment_brief.md`
 
 ## Python API Patterns
 

--- a/quanttradeai/agents/batch.py
+++ b/quanttradeai/agents/batch.py
@@ -20,6 +20,11 @@ from quanttradeai.utils.project_config import (
     compile_paper_streaming_runtime_config,
     load_project_config,
 )
+from quanttradeai.utils.experiment_brief import (
+    build_experiment_brief,
+    render_experiment_brief_markdown,
+)
+from quanttradeai.utils.run_records import apply_required_run_fields
 from quanttradeai.utils.run_scoreboard import (
     attach_scoreboard,
     render_scoreboard_table,
@@ -294,6 +299,7 @@ def run_agent_batch(
         raise ValueError("--sweep currently supports only --mode backtest.")
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    started_at = datetime.now(timezone.utc).isoformat()
     original_project_path = Path(project_config_path).resolve()
     loaded_project = load_project_config(config_path=original_project_path)
     project_name = (loaded_project.raw.get("project") or {}).get("name") or Path(
@@ -452,6 +458,7 @@ def run_agent_batch(
             "paper_source": item["summary"].get("paper_source"),
             "execution_backend": item["summary"].get("execution_backend"),
             "broker_provider": item["summary"].get("broker_provider"),
+            "artifacts": dict(item["summary"].get("artifacts") or {}),
             "run_timestamp": item["run_timestamp"],
             "run_id": item["summary"].get("run_id"),
             "run_dir": item["summary"].get("run_dir"),
@@ -505,6 +512,10 @@ def run_agent_batch(
     results_path = batch_dir / "results.json"
     scoreboard_json_path = batch_dir / "scoreboard.json"
     scoreboard_txt_path = batch_dir / "scoreboard.txt"
+    brief_json_path = batch_dir / "experiment_brief.json"
+    brief_md_path = batch_dir / "experiment_brief.md"
+    summary_path = batch_dir / "summary.json"
+    manifest_path = batch_dir / "batch_manifest.json"
     _write_json(results_path, results_payload)
     _write_json(scoreboard_json_path, scoreboard_payload)
     scoreboard_txt_path.write_text(
@@ -515,9 +526,22 @@ def run_agent_batch(
     success_count = sum(1 for item in results if item["status"] == "success")
     failure_count = len(results) - success_count
     batch_status = "success" if failure_count == 0 else "failed"
+    completed_at = datetime.now(timezone.utc).isoformat()
+    batch_artifacts = {
+        "results": str(results_path),
+        "scoreboard_json": str(scoreboard_json_path),
+        "scoreboard_txt": str(scoreboard_txt_path),
+        "experiment_brief_json": str(brief_json_path),
+        "experiment_brief_md": str(brief_md_path),
+        "summary": str(summary_path),
+        "manifest": str(manifest_path),
+        "resolved_project_config": str(resolved_project_path),
+    }
+    batch_run_id = f"agent/batches/{batch_dir.name}"
+    batch_warnings = list(dict.fromkeys(validation.get("warnings", [])))
 
     manifest = {
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": completed_at,
         "status": batch_status,
         "batch_type": batch_type,
         "project_name": project_name,
@@ -531,11 +555,7 @@ def run_agent_batch(
         "failure_count": failure_count,
         "scoreboard_sort_by": scoreboard_sort_by,
         "scoreboard_order": scoreboard_order,
-        "artifacts": {
-            "results": str(results_path),
-            "scoreboard_json": str(scoreboard_json_path),
-            "scoreboard_txt": str(scoreboard_txt_path),
-        },
+        "artifacts": dict(batch_artifacts),
         "agents": [
             {
                 key: entry.get(key)
@@ -549,6 +569,7 @@ def run_agent_batch(
                     "paper_source",
                     "execution_backend",
                     "broker_provider",
+                    "artifacts",
                     "run_timestamp",
                     "run_id",
                     "run_dir",
@@ -560,7 +581,7 @@ def run_agent_batch(
             }
             for entry in result_entries
         ],
-        "warnings": list(dict.fromkeys(validation.get("warnings", []))),
+        "warnings": batch_warnings,
     }
     if sweep_payload is not None:
         manifest["sweep"] = dict(sweep_payload)
@@ -568,7 +589,60 @@ def run_agent_batch(
             sweep_payload.get("expanded_variants") or []
         )
 
-    manifest_path = batch_dir / "batch_manifest.json"
+    batch_summary = {
+        "batch_type": batch_type,
+        "project_name": project_name,
+        "status": batch_status,
+        "timestamps": {
+            "started_at": started_at,
+            "completed_at": completed_at,
+        },
+        "symbols": list((resolved_project.get("data") or {}).get("symbols") or []),
+        "warnings": batch_warnings,
+        "artifacts": dict(batch_artifacts),
+        "run_dir": str(batch_dir),
+        "agent_count": len(results),
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "scoreboard_sort_by": scoreboard_sort_by,
+        "scoreboard_order": scoreboard_order,
+    }
+    if sweep_payload is not None:
+        batch_summary["sweep"] = dict(sweep_payload)
+    apply_required_run_fields(
+        batch_summary,
+        run_dir=batch_dir,
+        run_type="batch",
+        mode=mode,
+        name=batch_dir.name,
+    )
+    batch_summary["run_id"] = batch_run_id
+
+    brief = build_experiment_brief(
+        batch={
+            "run_id": batch_summary["run_id"],
+            "batch_type": batch_type,
+            "project_name": project_name,
+            "mode": mode,
+            "status": batch_status,
+            "agent_count": len(results),
+            "success_count": success_count,
+            "failure_count": failure_count,
+            "run_dir": str(batch_dir),
+        },
+        results=result_entries,
+        scoreboard_order=scoreboard_order,
+        scoreboard_sort_by=scoreboard_sort_by,
+        project_config_path=original_project_path.as_posix(),
+        artifacts=batch_artifacts,
+        warnings=batch_warnings,
+    )
+    _write_json(brief_json_path, brief)
+    brief_md_path.write_text(
+        render_experiment_brief_markdown(brief),
+        encoding="utf-8",
+    )
+    _write_json(summary_path, batch_summary)
     _write_json(manifest_path, manifest)
 
     return {
@@ -580,10 +654,7 @@ def run_agent_batch(
         "agent_count": len(results),
         "success_count": success_count,
         "failure_count": failure_count,
-        "artifacts": {
-            **manifest["artifacts"],
-            "manifest": str(manifest_path),
-        },
+        "artifacts": dict(batch_artifacts),
         "results": results_payload["results"],
         "warnings": manifest["warnings"],
         **({"sweep": dict(sweep_payload)} if sweep_payload is not None else {}),

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -1104,7 +1104,7 @@ def cmd_research_run(
 @runs_app.command("list")
 def cmd_runs_list(
     run_type: str = typer.Option(
-        "all", "--type", help="Run type filter: all, research, or agent"
+        "all", "--type", help="Run type filter: all, research, agent, or batch"
     ),
     mode: str = typer.Option(
         "all",
@@ -1192,7 +1192,9 @@ def cmd_runs_list(
     discovered = discover_runs()
     filters = RunFilters(
         run_type=_normalize_choice(
-            run_type, allowed={"all", "research", "agent"}, field_name="type"
+            run_type,
+            allowed={"all", "research", "agent", "batch"},
+            field_name="type",
         ),
         mode=_normalize_choice(
             mode,

--- a/quanttradeai/utils/experiment_brief.py
+++ b/quanttradeai/utils/experiment_brief.py
@@ -1,0 +1,375 @@
+"""Deterministic experiment briefs for agent batch runs."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+EXPERIMENT_BRIEF_KIND = "quanttradeai.experiment_brief"
+EXPERIMENT_BRIEF_SCHEMA_VERSION = 1
+
+
+def _unique_strings(values: list[Any]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        unique.append(text)
+        seen.add(text)
+    return unique
+
+
+def _scoreboard_metric(scoreboard: dict[str, Any], sort_by: str) -> Any:
+    if sort_by in scoreboard:
+        return scoreboard.get(sort_by)
+    return scoreboard.get("primary_metric")
+
+
+def _entry_candidate(
+    entry: dict[str, Any],
+    *,
+    rank: int,
+    scoreboard_sort_by: str,
+) -> dict[str, Any]:
+    scoreboard = dict(entry.get("scoreboard") or {})
+    payload = {
+        "rank": rank,
+        "agent_name": entry.get("agent_name"),
+        "base_agent_name": entry.get("base_agent_name"),
+        "run_id": entry.get("run_id"),
+        "run_dir": entry.get("run_dir"),
+        "status": entry.get("status"),
+        "parameters": entry.get("parameters"),
+        "scoreboard_sort_by": scoreboard_sort_by,
+        "score": _scoreboard_metric(scoreboard, scoreboard_sort_by),
+        "scoreboard": scoreboard,
+        "artifacts": dict(entry.get("artifacts") or {}),
+        "stdout_log": entry.get("stdout_log"),
+        "stderr_log": entry.get("stderr_log"),
+    }
+    if entry.get("variant_project_config"):
+        payload["variant_project_config"] = entry.get("variant_project_config")
+    if entry.get("promote_command"):
+        payload["promote_command"] = entry.get("promote_command")
+    return payload
+
+
+def _ordered_successful_entries(
+    *,
+    results: list[dict[str, Any]],
+    scoreboard_order: list[str],
+) -> list[dict[str, Any]]:
+    by_run_id = {
+        str(entry.get("run_id") or ""): entry
+        for entry in results
+        if entry.get("run_id")
+    }
+    ordered: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for run_id in scoreboard_order:
+        entry = by_run_id.get(str(run_id))
+        if not entry or entry.get("status") != "success":
+            continue
+        ordered.append(entry)
+        seen.add(id(entry))
+
+    for entry in results:
+        if id(entry) in seen or entry.get("status") != "success":
+            continue
+        ordered.append(entry)
+    return ordered
+
+
+def _failure_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "agent_name": entry.get("agent_name"),
+        "base_agent_name": entry.get("base_agent_name"),
+        "run_id": entry.get("run_id"),
+        "run_dir": entry.get("run_dir"),
+        "status": entry.get("status"),
+        "error": entry.get("error"),
+        "warnings": list(entry.get("warnings") or []),
+        "parameters": entry.get("parameters"),
+        "artifacts": dict(entry.get("artifacts") or {}),
+        "stdout_log": entry.get("stdout_log"),
+        "stderr_log": entry.get("stderr_log"),
+    }
+
+
+def _compare_command(
+    *,
+    successful_entries: list[dict[str, Any]],
+    scoreboard_sort_by: str,
+) -> str | None:
+    run_ids = [
+        str(entry.get("run_id") or "").strip()
+        for entry in successful_entries[:2]
+        if entry.get("run_id")
+    ]
+    if len(run_ids) < 2:
+        return None
+    return (
+        "quanttradeai runs list "
+        f"--compare {run_ids[0]} --compare {run_ids[1]} "
+        f"--sort-by {scoreboard_sort_by}"
+    )
+
+
+def _next_action_for_winner(
+    *,
+    batch_type: str,
+    mode: str,
+    winner: dict[str, Any] | None,
+    project_config_path: str,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    if winner is None:
+        return (
+            {
+                "action": "inspect_failures",
+                "reason": "No successful child runs were available to promote or compare.",
+                "command": None,
+                "follow_up_command": None,
+            },
+            {},
+        )
+
+    run_id = str(winner.get("run_id") or "")
+    agent_name = str(winner.get("agent_name") or "")
+    base_agent_name = str(winner.get("base_agent_name") or agent_name)
+    commands: dict[str, str] = {}
+
+    if batch_type == "sweep" and mode == "backtest":
+        promote_command = str(winner.get("promote_command") or "").strip()
+        if not promote_command:
+            promote_command = (
+                "quanttradeai promote " f"--run {run_id} -c {project_config_path}"
+            )
+        paper_command = (
+            "quanttradeai agent run "
+            f"--agent {base_agent_name} -c {project_config_path} --mode paper"
+        )
+        commands["promote_winner"] = promote_command
+        commands["run_promoted_paper_agent"] = paper_command
+        return (
+            {
+                "action": "materialize_sweep_winner",
+                "reason": "Promote the best sweep child into the base agent, then run the promoted paper agent.",
+                "command": promote_command,
+                "follow_up_command": paper_command,
+            },
+            commands,
+        )
+
+    if mode == "backtest":
+        promote_command = (
+            "quanttradeai promote " f"--run {run_id} -c {project_config_path}"
+        )
+        commands["promote_winner"] = promote_command
+        return (
+            {
+                "action": "promote_winner_to_paper",
+                "reason": "Promote the best successful backtest run to paper mode.",
+                "command": promote_command,
+                "follow_up_command": None,
+            },
+            commands,
+        )
+
+    if mode == "paper":
+        promote_command = (
+            "quanttradeai promote "
+            f"--run {run_id} -c {project_config_path} "
+            f"--to live --acknowledge-live {agent_name}"
+        )
+        commands["promote_winner_to_live"] = promote_command
+        return (
+            {
+                "action": "promote_winner_to_live",
+                "reason": "Promote the best successful paper run to live mode with explicit acknowledgement.",
+                "command": promote_command,
+                "follow_up_command": None,
+            },
+            commands,
+        )
+
+    return (
+        {
+            "action": "inspect_live_batch",
+            "reason": "Live batch runs should be inspected through metrics, decisions, executions, and logs.",
+            "command": None,
+            "follow_up_command": None,
+        },
+        commands,
+    )
+
+
+def build_experiment_brief(
+    *,
+    batch: dict[str, Any],
+    results: list[dict[str, Any]],
+    scoreboard_order: list[str],
+    scoreboard_sort_by: str,
+    project_config_path: str,
+    artifacts: dict[str, Any],
+    warnings: list[str] | None = None,
+    top_n: int = 5,
+) -> dict[str, Any]:
+    """Build a stable, agent-readable experiment brief payload."""
+
+    batch_type = str(batch.get("batch_type") or "")
+    mode = str(batch.get("mode") or "")
+    successful_entries = _ordered_successful_entries(
+        results=results,
+        scoreboard_order=scoreboard_order,
+    )
+    ranked_candidates = [
+        _entry_candidate(
+            entry,
+            rank=index,
+            scoreboard_sort_by=scoreboard_sort_by,
+        )
+        for index, entry in enumerate(successful_entries[:top_n], start=1)
+    ]
+    winner = ranked_candidates[0] if ranked_candidates else None
+    failures = [
+        _failure_entry(entry) for entry in results if entry.get("status") != "success"
+    ]
+
+    recommended_next_action, commands = _next_action_for_winner(
+        batch_type=batch_type,
+        mode=mode,
+        winner=winner,
+        project_config_path=project_config_path,
+    )
+    compare = _compare_command(
+        successful_entries=successful_entries,
+        scoreboard_sort_by=scoreboard_sort_by,
+    )
+    if compare:
+        commands["compare_top_runs"] = compare
+
+    all_warnings: list[Any] = list(warnings or [])
+    for entry in results:
+        all_warnings.extend(entry.get("warnings") or [])
+
+    return {
+        "kind": EXPERIMENT_BRIEF_KIND,
+        "schema_version": EXPERIMENT_BRIEF_SCHEMA_VERSION,
+        "batch": dict(batch),
+        "ranking": {
+            "scoreboard_sort_by": scoreboard_sort_by,
+            "scoreboard_order": list(scoreboard_order),
+            "top_candidates": ranked_candidates,
+            "successful_count": len(successful_entries),
+        },
+        "winner": winner,
+        "failures": failures,
+        "recommended_next_action": recommended_next_action,
+        "commands": commands,
+        "artifacts": dict(artifacts),
+        "warnings": _unique_strings(all_warnings),
+    }
+
+
+def _render_value(value: Any) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True)
+    return str(value)
+
+
+def render_experiment_brief_markdown(brief: dict[str, Any]) -> str:
+    """Render the experiment brief as compact Markdown."""
+
+    batch = dict(brief.get("batch") or {})
+    ranking = dict(brief.get("ranking") or {})
+    winner = brief.get("winner")
+    action = dict(brief.get("recommended_next_action") or {})
+    commands = dict(brief.get("commands") or {})
+    artifacts = dict(brief.get("artifacts") or {})
+    failures = list(brief.get("failures") or [])
+    warnings = list(brief.get("warnings") or [])
+
+    lines = [
+        "# Experiment Brief",
+        "",
+        "## Batch",
+        "",
+        f"- Run ID: {_render_value(batch.get('run_id'))}",
+        f"- Type: {_render_value(batch.get('batch_type'))}",
+        f"- Mode: {_render_value(batch.get('mode'))}",
+        f"- Status: {_render_value(batch.get('status'))}",
+        f"- Project: {_render_value(batch.get('project_name'))}",
+        f"- Successes: {_render_value(batch.get('success_count'))}",
+        f"- Failures: {_render_value(batch.get('failure_count'))}",
+        "",
+        "## Recommendation",
+        "",
+        f"- Action: {_render_value(action.get('action'))}",
+        f"- Reason: {_render_value(action.get('reason'))}",
+    ]
+    if action.get("command"):
+        lines.append(f"- Command: `{action['command']}`")
+    if action.get("follow_up_command"):
+        lines.append(f"- Follow-up: `{action['follow_up_command']}`")
+
+    lines.extend(["", "## Winner", ""])
+    if isinstance(winner, dict):
+        lines.extend(
+            [
+                f"- Agent: {_render_value(winner.get('agent_name'))}",
+                f"- Run ID: {_render_value(winner.get('run_id'))}",
+                f"- Score ({ranking.get('scoreboard_sort_by')}): {_render_value(winner.get('score'))}",
+                f"- Parameters: {_render_value(winner.get('parameters'))}",
+                f"- Run Dir: {_render_value(winner.get('run_dir'))}",
+            ]
+        )
+    else:
+        lines.append("- No successful winner.")
+
+    lines.extend(["", "## Top Candidates", ""])
+    candidates = list(ranking.get("top_candidates") or [])
+    if not candidates:
+        lines.append("- None.")
+    else:
+        for candidate in candidates:
+            lines.append(
+                "- "
+                f"{candidate.get('rank')}. {candidate.get('agent_name')} "
+                f"({candidate.get('run_id')}): "
+                f"{ranking.get('scoreboard_sort_by')}={_render_value(candidate.get('score'))}"
+            )
+
+    lines.extend(["", "## Failures", ""])
+    if not failures:
+        lines.append("- None.")
+    else:
+        for failure in failures:
+            detail = failure.get("error") or "failed"
+            lines.append(
+                f"- {failure.get('agent_name')} ({failure.get('run_id')}): {detail}"
+            )
+            if failure.get("stderr_log"):
+                lines.append(f"  stderr: {failure['stderr_log']}")
+
+    lines.extend(["", "## Commands", ""])
+    if not commands:
+        lines.append("- None.")
+    else:
+        for name, command in commands.items():
+            lines.append(f"- {name}: `{command}`")
+
+    lines.extend(["", "## Artifacts", ""])
+    for name, path in artifacts.items():
+        lines.append(f"- {name}: {_render_value(path)}")
+
+    if warnings:
+        lines.extend(["", "## Warnings", ""])
+        for warning in warnings:
+            lines.append(f"- {warning}")
+
+    return "\n".join(lines) + "\n"

--- a/quanttradeai/utils/run_records.py
+++ b/quanttradeai/utils/run_records.py
@@ -11,7 +11,7 @@ from typing import Any, Iterable
 
 
 RUNS_ROOT = Path("runs")
-RUN_TYPES = {"research", "agent"}
+RUN_TYPES = {"research", "agent", "batch"}
 RUN_MODES = {"research", "backtest", "paper", "live"}
 RUN_STATUSES = {"success", "failed"}
 
@@ -54,6 +54,8 @@ def create_run_dir(
 
     if run_type == "research":
         run_dir = runs_root / "research" / f"{timestamp}_{safe_name}"
+    elif run_type == "batch":
+        run_dir = runs_root / "agent" / "batches" / f"{timestamp}_{safe_name}"
     else:
         if mode not in RUN_MODES:
             raise ValueError(f"Unsupported mode for agent run: {mode}")

--- a/roadmap.md
+++ b/roadmap.md
@@ -416,6 +416,11 @@ Deliverables:
 - Add AI-assisted experiment planning and ops support only where it materially saves user time.
 - Tighten docs, templates, and examples around the final product model.
 
+Status on 2026-05-03:
+
+- Agent batch and sweep runs now write agent-readable experiment briefs (`experiment_brief.json` and `experiment_brief.md`) plus batch-level `summary.json` records under `runs/agent/batches/...`, so coding agents can identify the best child run, inspect failures, and execute the recommended next command without manually stitching together batch artifacts.
+- `quanttradeai runs list --type batch --json` is implemented for local batch run discovery.
+
 ## Golden Workflows
 
 The roadmap is only successful if these workflows feel excellent.

--- a/tests/integration/test_agent_batch_cli.py
+++ b/tests/integration/test_agent_batch_cli.py
@@ -433,6 +433,15 @@ def test_agent_run_all_writes_batch_artifacts_and_sorts_scoreboard(
     assert (batch_dir / "results.json").is_file()
     assert (batch_dir / "scoreboard.json").is_file()
     assert (batch_dir / "scoreboard.txt").is_file()
+    assert (batch_dir / "summary.json").is_file()
+    assert (batch_dir / "experiment_brief.json").is_file()
+    assert (batch_dir / "experiment_brief.md").is_file()
+    assert payload["artifacts"]["experiment_brief_json"] == str(
+        batch_dir / "experiment_brief.json"
+    )
+    assert payload["artifacts"]["experiment_brief_md"] == str(
+        batch_dir / "experiment_brief.md"
+    )
 
     results_payload = json.loads((batch_dir / "results.json").read_text("utf-8"))
     assert [item["agent_name"] for item in results_payload["results"]] == [
@@ -451,6 +460,33 @@ def test_agent_run_all_writes_batch_artifacts_and_sorts_scoreboard(
         "rsi_reversion",
     ]
     assert "NET_SHARPE" in (batch_dir / "scoreboard.txt").read_text("utf-8")
+
+    brief = json.loads((batch_dir / "experiment_brief.json").read_text("utf-8"))
+    assert brief["kind"] == "quanttradeai.experiment_brief"
+    assert brief["schema_version"] == 1
+    assert brief["winner"]["agent_name"] == "breakout_gpt"
+    assert brief["recommended_next_action"]["action"] == "promote_winner_to_paper"
+    assert brief["commands"]["promote_winner"] == (
+        f"quanttradeai promote --run {brief['winner']['run_id']} "
+        f"-c {config_path.resolve().as_posix()}"
+    )
+    assert "compare_top_runs" in brief["commands"]
+
+    manifest = json.loads((batch_dir / "batch_manifest.json").read_text("utf-8"))
+    assert manifest["artifacts"]["experiment_brief_json"] == str(
+        batch_dir / "experiment_brief.json"
+    )
+
+    batch_summary = json.loads((batch_dir / "summary.json").read_text("utf-8"))
+    assert batch_summary["run_type"] == "batch"
+    assert batch_summary["run_id"] == f"agent/batches/{batch_dir.name}"
+
+    runs_result = runner.invoke(app, ["runs", "list", "--type", "batch", "--json"])
+    assert runs_result.exit_code == 0, runs_result.stdout
+    run_records = json.loads(runs_result.stdout)
+    assert [record["run_id"] for record in run_records] == [
+        f"agent/batches/{batch_dir.name}"
+    ]
 
 
 def test_strategy_lab_agent_run_all_backtest_enumerates_both_agents(
@@ -1157,7 +1193,12 @@ def test_agent_run_sweep_writes_variant_artifacts_and_preserves_source_config(
     assert (batch_dir / "batch_manifest.json").is_file()
     assert (batch_dir / "results.json").is_file()
     assert (batch_dir / "scoreboard.json").is_file()
+    assert (batch_dir / "experiment_brief.json").is_file()
+    assert (batch_dir / "experiment_brief.md").is_file()
     assert (batch_dir / "variants").is_dir()
+    assert payload["artifacts"]["experiment_brief_json"] == str(
+        batch_dir / "experiment_brief.json"
+    )
 
     results_payload = json.loads((batch_dir / "results.json").read_text("utf-8"))
     assert results_payload["batch_type"] == "sweep"
@@ -1205,6 +1246,20 @@ def test_agent_run_sweep_writes_variant_artifacts_and_preserves_source_config(
         },
         "materializable": True,
     }
+
+    brief = json.loads((batch_dir / "experiment_brief.json").read_text("utf-8"))
+    assert brief["winner"]["agent_name"] == (
+        "rsi_reversion__rsi_threshold_grid__buy_below-30_0__sell_above-75_0"
+    )
+    assert brief["recommended_next_action"]["action"] == "materialize_sweep_winner"
+    assert brief["commands"]["promote_winner"] == (
+        f"quanttradeai promote --run {brief['winner']['run_id']} "
+        f"-c {config_path.resolve().as_posix()}"
+    )
+    assert brief["commands"]["run_promoted_paper_agent"] == (
+        "quanttradeai agent run --agent rsi_reversion "
+        f"-c {config_path.resolve().as_posix()} --mode paper"
+    )
 
 
 def test_agent_run_sweep_uses_canonical_project_root_for_llm_assets(

--- a/tests/utils/test_experiment_brief.py
+++ b/tests/utils/test_experiment_brief.py
@@ -1,0 +1,239 @@
+from quanttradeai.utils.experiment_brief import (
+    build_experiment_brief,
+    render_experiment_brief_markdown,
+)
+
+
+def _entry(
+    name: str,
+    run_id: str,
+    *,
+    status: str = "success",
+    score: float | None = None,
+    mode: str = "backtest",
+    base_agent_name: str | None = None,
+    parameters: dict | None = None,
+    promote_command: str | None = None,
+    error: str | None = None,
+    warnings: list[str] | None = None,
+) -> dict:
+    entry = {
+        "agent_name": name,
+        "base_agent_name": base_agent_name,
+        "agent_kind": "rule",
+        "configured_mode": mode,
+        "status": status,
+        "warnings": list(warnings or []),
+        "error": error,
+        "parameters": parameters,
+        "artifacts": {"summary": f"runs/{run_id}/summary.json"},
+        "run_id": run_id,
+        "run_dir": f"runs/{run_id}",
+        "stdout_log": f"logs/{name}.stdout.log",
+        "stderr_log": f"logs/{name}.stderr.log",
+        "scoreboard": {"net_sharpe": score, "total_pnl": score},
+    }
+    if promote_command:
+        entry["promote_command"] = promote_command
+    return entry
+
+
+def _batch(*, batch_type: str, mode: str, status: str = "success") -> dict:
+    return {
+        "run_id": "agent/batches/20260101_000000_lab_backtest",
+        "batch_type": batch_type,
+        "project_name": "lab",
+        "mode": mode,
+        "status": status,
+        "agent_count": 2,
+        "success_count": 2 if status == "success" else 1,
+        "failure_count": 0 if status == "success" else 1,
+        "run_dir": "runs/agent/batches/20260101_000000_lab_backtest",
+    }
+
+
+def test_sweep_brief_chooses_top_ranked_success_and_uses_promote_command():
+    winner_command = (
+        "quanttradeai promote --run agent/backtest/high -c C:/repo/config/project.yaml"
+    )
+    results = [
+        _entry(
+            "low",
+            "agent/backtest/low",
+            score=0.5,
+            base_agent_name="rsi_reversion",
+            parameters={"rule.buy_below": 25.0},
+            promote_command="quanttradeai promote --run agent/backtest/low -c C:/repo/config/project.yaml",
+        ),
+        _entry(
+            "high",
+            "agent/backtest/high",
+            score=2.5,
+            base_agent_name="rsi_reversion",
+            parameters={"rule.buy_below": 30.0},
+            promote_command=winner_command,
+        ),
+    ]
+
+    brief = build_experiment_brief(
+        batch=_batch(batch_type="sweep", mode="backtest"),
+        results=results,
+        scoreboard_order=["agent/backtest/high", "agent/backtest/low"],
+        scoreboard_sort_by="net_sharpe",
+        project_config_path="C:/repo/config/project.yaml",
+        artifacts={"results": "results.json"},
+    )
+
+    assert brief["winner"]["agent_name"] == "high"
+    assert brief["winner"]["parameters"] == {"rule.buy_below": 30.0}
+    assert brief["winner"]["artifacts"] == {
+        "summary": "runs/agent/backtest/high/summary.json"
+    }
+    assert brief["recommended_next_action"]["action"] == "materialize_sweep_winner"
+    assert brief["commands"]["promote_winner"] == winner_command
+    assert (
+        brief["commands"]["run_promoted_paper_agent"]
+        == "quanttradeai agent run --agent rsi_reversion -c C:/repo/config/project.yaml --mode paper"
+    )
+    assert "compare_top_runs" in brief["commands"]
+
+
+def test_all_agent_backtest_brief_creates_paper_promotion_command():
+    results = [
+        _entry("agent_a", "agent/backtest/a", score=1.0),
+        _entry("agent_b", "agent/backtest/b", score=1.5),
+    ]
+
+    brief = build_experiment_brief(
+        batch=_batch(batch_type="all_agents", mode="backtest"),
+        results=results,
+        scoreboard_order=["agent/backtest/b", "agent/backtest/a"],
+        scoreboard_sort_by="net_sharpe",
+        project_config_path="config/project.yaml",
+        artifacts={},
+    )
+
+    assert brief["winner"]["agent_name"] == "agent_b"
+    assert brief["recommended_next_action"]["action"] == "promote_winner_to_paper"
+    assert (
+        brief["commands"]["promote_winner"]
+        == "quanttradeai promote --run agent/backtest/b -c config/project.yaml"
+    )
+
+
+def test_paper_batch_brief_creates_live_promotion_command_with_acknowledgement():
+    results = [
+        _entry("paper_a", "agent/paper/a", score=10.0, mode="paper"),
+        _entry("paper_b", "agent/paper/b", score=20.0, mode="paper"),
+    ]
+
+    brief = build_experiment_brief(
+        batch=_batch(batch_type="all_agents", mode="paper"),
+        results=results,
+        scoreboard_order=["agent/paper/b", "agent/paper/a"],
+        scoreboard_sort_by="total_pnl",
+        project_config_path="config/project.yaml",
+        artifacts={},
+    )
+
+    assert brief["winner"]["agent_name"] == "paper_b"
+    assert brief["recommended_next_action"]["action"] == "promote_winner_to_live"
+    assert brief["commands"]["promote_winner_to_live"] == (
+        "quanttradeai promote --run agent/paper/b -c config/project.yaml "
+        "--to live --acknowledge-live paper_b"
+    )
+
+
+def test_partial_failure_brief_keeps_failure_logs_and_picks_best_success():
+    results = [
+        _entry("winner", "agent/backtest/winner", score=1.0),
+        _entry(
+            "failed",
+            "agent/backtest/failed",
+            status="failed",
+            error="model failure",
+            warnings=["child warning"],
+        ),
+    ]
+
+    brief = build_experiment_brief(
+        batch=_batch(batch_type="all_agents", mode="backtest", status="failed"),
+        results=results,
+        scoreboard_order=["agent/backtest/winner", "agent/backtest/failed"],
+        scoreboard_sort_by="net_sharpe",
+        project_config_path="config/project.yaml",
+        artifacts={},
+        warnings=["batch warning"],
+    )
+
+    assert brief["winner"]["agent_name"] == "winner"
+    assert brief["failures"] == [
+        {
+            "agent_name": "failed",
+            "base_agent_name": None,
+            "run_id": "agent/backtest/failed",
+            "run_dir": "runs/agent/backtest/failed",
+            "status": "failed",
+            "error": "model failure",
+            "warnings": ["child warning"],
+            "parameters": None,
+            "artifacts": {"summary": "runs/agent/backtest/failed/summary.json"},
+            "stdout_log": "logs/failed.stdout.log",
+            "stderr_log": "logs/failed.stderr.log",
+        }
+    ]
+    assert brief["warnings"] == ["batch warning", "child warning"]
+
+
+def test_all_failures_brief_recommends_inspecting_failures():
+    results = [
+        _entry(
+            "failed_a",
+            "agent/backtest/failed_a",
+            status="failed",
+            error="first failure",
+        ),
+        _entry(
+            "failed_b",
+            "agent/backtest/failed_b",
+            status="failed",
+            error="second failure",
+        ),
+    ]
+
+    brief = build_experiment_brief(
+        batch=_batch(batch_type="all_agents", mode="backtest", status="failed"),
+        results=results,
+        scoreboard_order=["agent/backtest/failed_a", "agent/backtest/failed_b"],
+        scoreboard_sort_by="net_sharpe",
+        project_config_path="config/project.yaml",
+        artifacts={},
+    )
+
+    assert brief["winner"] is None
+    assert brief["recommended_next_action"] == {
+        "action": "inspect_failures",
+        "reason": "No successful child runs were available to promote or compare.",
+        "command": None,
+        "follow_up_command": None,
+    }
+    assert brief["commands"] == {}
+    assert len(brief["failures"]) == 2
+
+
+def test_render_experiment_brief_markdown_mirrors_core_sections():
+    brief = build_experiment_brief(
+        batch=_batch(batch_type="all_agents", mode="backtest"),
+        results=[_entry("winner", "agent/backtest/winner", score=1.0)],
+        scoreboard_order=["agent/backtest/winner"],
+        scoreboard_sort_by="net_sharpe",
+        project_config_path="config/project.yaml",
+        artifacts={"experiment_brief_json": "experiment_brief.json"},
+    )
+
+    rendered = render_experiment_brief_markdown(brief)
+
+    assert "# Experiment Brief" in rendered
+    assert "## Recommendation" in rendered
+    assert "promote_winner_to_paper" in rendered
+    assert "experiment_brief_json" in rendered


### PR DESCRIPTION
## Summary

- Add deterministic experiment brief JSON and Markdown artifacts for agent batch and sweep runs.
- Add batch-level run summaries so `quanttradeai runs list --type batch --json` discovers batch runs.
- Document the new artifacts in the README, quick reference, project YAML docs, and roadmap.

## Validation

- `make lint.format.test`
- Commit hook reran `format`, `lint`, and `test` successfully.

## Notes

This is additive: existing batch manifests, result files, scoreboards, child run outputs, promotion behavior, and compare behavior are preserved.