### PR TITLE
Add agent-readable run briefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,10 +423,10 @@ For the full shape, field reference, and supported agent modes, see [Project YAM
 
 | Workflow | Output directory | Typical artifacts |
 | --- | --- | --- |
-| Research | `runs/research/<timestamp>_<project>/` | `resolved_project_config.yaml`, runtime YAML snapshots, `summary.json`, `metrics.json`, backtest artifacts |
-| Agent backtest | `runs/agent/backtest/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, backtest files |
-| Agent paper | `runs/agent/paper/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime YAML snapshots, `replay_manifest.json` when replay is enabled, and broker snapshots when `execution.backend: alpaca` |
-| Agent live | `runs/agent/live/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `decisions.jsonl`, `executions.jsonl`, runtime streaming/risk/position-manager YAML snapshots, and broker snapshots when `execution.backend: alpaca` |
+| Research | `runs/research/<timestamp>_<project>/` | `resolved_project_config.yaml`, runtime YAML snapshots, `summary.json`, `metrics.json`, `run_brief.json`, `run_brief.md`, backtest artifacts |
+| Agent backtest | `runs/agent/backtest/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `run_brief.json`, `run_brief.md`, `decisions.jsonl`, backtest files |
+| Agent paper | `runs/agent/paper/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `run_brief.json`, `run_brief.md`, `decisions.jsonl`, `executions.jsonl`, runtime YAML snapshots, `replay_manifest.json` when replay is enabled, and broker snapshots when `execution.backend: alpaca` |
+| Agent live | `runs/agent/live/<timestamp>_<agent>/` | `resolved_project_config.yaml`, `summary.json`, `metrics.json`, `run_brief.json`, `run_brief.md`, `decisions.jsonl`, `executions.jsonl`, runtime streaming/risk/position-manager YAML snapshots, and broker snapshots when `execution.backend: alpaca` |
 
 Sweep batch artifacts:
 
@@ -438,7 +438,9 @@ Sweep batch artifacts:
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/experiment_brief.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/experiment_brief.md`
 
-This makes it easier to rank runs, inspect what actually changed, reuse winning configurations, and hand the next action to a coding agent without opening every batch artifact manually.
+Each single research or agent run also writes `run_brief.json` and `run_brief.md`. These briefs summarize the normalized run identity, scoreboard metrics, warnings/errors, artifact paths, and exact next commands such as promotion, deployment, or ranking.
+
+This makes it easier to rank runs, inspect what actually changed, reuse winning configurations, and hand the next action to a coding agent without opening every artifact manually.
 
 To rank and compare local runs directly from the CLI, use the scoreboard first and then compare explicit run ids:
 

--- a/quanttradeai/agents/backtest.py
+++ b/quanttradeai/agents/backtest.py
@@ -25,6 +25,7 @@ from quanttradeai.trading.portfolio import PortfolioManager
 from quanttradeai.utils.config_validator import validate_project_config
 from quanttradeai.utils.project_config import compile_research_runtime_configs
 from quanttradeai.utils.project_paths import resolve_project_path
+from quanttradeai.utils.run_brief import write_run_brief_artifacts
 from quanttradeai.utils.run_records import apply_required_run_fields, create_run_dir
 
 from .base import AgentSimulationState, action_to_target, signal_to_action
@@ -500,6 +501,7 @@ def run_agent_backtest(
             mode=mode,
             name=agent_name,
         )
+        write_run_brief_artifacts(summary, run_dir, project_config_path)
         _write_json(run_dir / "summary.json", summary)
         return summary
 
@@ -515,5 +517,6 @@ def run_agent_backtest(
             mode=mode,
             name=agent_name,
         )
+        write_run_brief_artifacts(summary, run_dir, project_config_path)
         _write_json(run_dir / "summary.json", summary)
         raise

--- a/quanttradeai/agents/model_agent.py
+++ b/quanttradeai/agents/model_agent.py
@@ -45,6 +45,7 @@ from quanttradeai.utils.project_config import (
     resolve_paper_replay_window,
 )
 from quanttradeai.utils.project_paths import resolve_project_path
+from quanttradeai.utils.run_brief import write_run_brief_artifacts
 from quanttradeai.utils.run_records import apply_required_run_fields, create_run_dir
 
 from .base import signal_to_action
@@ -473,6 +474,7 @@ def run_model_agent_backtest(
             mode="backtest",
             name=agent_name,
         )
+        write_run_brief_artifacts(summary, run_dir, project_config_path)
         _write_json(run_dir / "summary.json", summary)
         return summary
     except Exception as exc:
@@ -487,6 +489,7 @@ def run_model_agent_backtest(
             mode="backtest",
             name=agent_name,
         )
+        write_run_brief_artifacts(summary, run_dir, project_config_path)
         _write_json(run_dir / "summary.json", summary)
         raise
 
@@ -779,6 +782,7 @@ def _run_model_agent_streaming(
             mode=mode,
             name=agent_name,
         )
+        write_run_brief_artifacts(summary, run_dir, project_config_path)
         _write_json(run_dir / "summary.json", summary)
         return summary
     except Exception as exc:
@@ -793,5 +797,6 @@ def _run_model_agent_streaming(
             mode=mode,
             name=agent_name,
         )
+        write_run_brief_artifacts(summary, run_dir, project_config_path)
         _write_json(run_dir / "summary.json", summary)
         raise

--- a/quanttradeai/agents/paper.py
+++ b/quanttradeai/agents/paper.py
@@ -49,6 +49,7 @@ from quanttradeai.utils.project_config import (
     compile_research_runtime_configs,
     resolve_paper_replay_window,
 )
+from quanttradeai.utils.run_brief import write_run_brief_artifacts
 from quanttradeai.utils.run_records import apply_required_run_fields, create_run_dir
 
 from .backtest import (
@@ -1250,6 +1251,7 @@ def _run_agent_streaming(
             mode=mode,
             name=agent_name,
         )
+        write_run_brief_artifacts(summary, run_dir, project_config_path)
         _write_json(run_dir / "summary.json", summary)
         return summary
     except Exception as exc:
@@ -1264,5 +1266,6 @@ def _run_agent_streaming(
             mode=mode,
             name=agent_name,
         )
+        write_run_brief_artifacts(summary, run_dir, project_config_path)
         _write_json(run_dir / "summary.json", summary)
         raise

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -33,6 +33,7 @@ from .utils.run_scoreboard import (
     render_scoreboard_table,
     sort_run_records,
 )
+from .utils.run_brief import write_run_brief_artifacts
 
 
 app = typer.Typer(add_completion=False, help="QuantTradeAI command line interface")
@@ -1081,20 +1082,22 @@ def cmd_research_run(
             "error": str(exc),
         }
 
-        (run_dir / "summary.json").write_text(
-            json.dumps(summary, indent=2), encoding="utf-8"
-        )
         (run_dir / "metrics.json").write_text(
             json.dumps(metrics_payload, indent=2), encoding="utf-8"
+        )
+        write_run_brief_artifacts(summary, run_dir, project_path)
+        (run_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2), encoding="utf-8"
         )
         typer.echo(f"Research run failed: {exc}", err=True)
         raise typer.Exit(code=1)
 
-    (run_dir / "summary.json").write_text(
-        json.dumps(summary, indent=2), encoding="utf-8"
-    )
     (run_dir / "metrics.json").write_text(
         json.dumps(metrics_payload, indent=2), encoding="utf-8"
+    )
+    write_run_brief_artifacts(summary, run_dir, project_path)
+    (run_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2), encoding="utf-8"
     )
 
     typer.echo(f"Research run completed: {run_dir}")

--- a/quanttradeai/utils/run_brief.py
+++ b/quanttradeai/utils/run_brief.py
@@ -59,7 +59,14 @@ def _scoreboard_for_summary(
             "status": "missing",
             "error": "Run summary could not be normalized for scoreboard loading.",
         }
-    return load_scoreboard_record(record)
+    scoreboard = load_scoreboard_record(record)
+    for key in ("decision_count", "execution_count"):
+        if scoreboard.get(key) is None and summary.get(key) is not None:
+            try:
+                scoreboard[key] = int(summary[key])
+            except (TypeError, ValueError):
+                scoreboard[key] = summary[key]
+    return scoreboard
 
 
 def _deployment_target(project_config: dict[str, Any]) -> str | None:
@@ -321,6 +328,12 @@ def write_run_brief_artifacts(
     artifacts["run_brief_md"] = str(run_brief_md_path)
     summary["artifacts"] = artifacts
 
+    # Scoreboard loading reads summary.json for fallback fields such as
+    # decision_count, so persist the normalized summary before building the brief.
+    (run_dir_path / "summary.json").write_text(
+        json.dumps(summary, indent=2, default=str),
+        encoding="utf-8",
+    )
     brief = build_run_brief(
         summary=summary,
         run_dir=run_dir_path,

--- a/quanttradeai/utils/run_brief.py
+++ b/quanttradeai/utils/run_brief.py
@@ -1,0 +1,340 @@
+"""Agent-readable briefs for single QuantTradeAI runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from quanttradeai.utils.run_records import normalize_run_summary
+from quanttradeai.utils.run_scoreboard import load_scoreboard_record
+
+
+RUN_BRIEF_KIND = "quanttradeai.run_brief"
+RUN_BRIEF_SCHEMA_VERSION = 1
+
+
+def _unique_strings(values: list[Any]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        unique.append(text)
+        seen.add(text)
+    return unique
+
+
+def _config_command_path(project_config_path: str | Path) -> str:
+    return Path(project_config_path).resolve().as_posix()
+
+
+def _summary_artifacts(summary: dict[str, Any]) -> dict[str, Any]:
+    return dict(summary.get("artifacts") or {})
+
+
+def _load_resolved_project_config(summary: dict[str, Any]) -> dict[str, Any]:
+    resolved_path = _summary_artifacts(summary).get("resolved_project_config")
+    if not resolved_path:
+        return {}
+
+    try:
+        payload = yaml.safe_load(Path(str(resolved_path)).read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _scoreboard_for_summary(
+    summary: dict[str, Any],
+    *,
+    run_dir: Path,
+) -> dict[str, Any]:
+    record = normalize_run_summary(summary, run_dir=run_dir)
+    if record is None:
+        return {
+            "status": "missing",
+            "error": "Run summary could not be normalized for scoreboard loading.",
+        }
+    return load_scoreboard_record(record)
+
+
+def _deployment_target(project_config: dict[str, Any]) -> str | None:
+    deployment = dict(project_config.get("deployment") or {})
+    target = str(deployment.get("target") or "").strip()
+    return target or None
+
+
+def _recommended_next_action(
+    *,
+    summary: dict[str, Any],
+    project_config_path: str,
+    resolved_project_config: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, str]]:
+    status = str(summary.get("status") or "").strip().lower()
+    run_id = str(summary.get("run_id") or "").strip()
+    run_type = str(summary.get("run_type") or "").strip().lower()
+    mode = str(summary.get("mode") or "").strip().lower()
+    name = str(summary.get("name") or "").strip()
+    agent_name = str(summary.get("agent_name") or name).strip()
+    config_path = _config_command_path(project_config_path)
+
+    if status != "success":
+        return (
+            {
+                "action": "inspect_failure",
+                "reason": "Run failed. Inspect the error, warnings, and artifact paths before retrying.",
+                "command": None,
+                "follow_up_command": None,
+            },
+            {},
+        )
+
+    if run_type == "research":
+        commands = {
+            "rank_research_runs": (
+                "quanttradeai runs list --type research --scoreboard --sort-by net_sharpe"
+            ),
+            "promote_this_run": f"quanttradeai promote --run {run_id} -c {config_path}",
+        }
+        return (
+            {
+                "action": "promote_research_run",
+                "reason": "Promote this successful research artifact if its metrics are acceptable.",
+                "command": commands["promote_this_run"],
+                "follow_up_command": commands["rank_research_runs"],
+            },
+            commands,
+        )
+
+    if run_type == "agent" and mode == "backtest":
+        commands = {
+            "rank_agent_backtests": (
+                "quanttradeai runs list --type agent --mode backtest --scoreboard --sort-by net_sharpe"
+            ),
+            "promote_to_paper": f"quanttradeai promote --run {run_id} -c {config_path}",
+        }
+        return (
+            {
+                "action": "promote_to_paper",
+                "reason": "Promote this successful agent backtest to paper mode if the run is the preferred candidate.",
+                "command": commands["promote_to_paper"],
+                "follow_up_command": commands["rank_agent_backtests"],
+            },
+            commands,
+        )
+
+    if run_type == "agent" and mode == "paper":
+        commands = {
+            "rank_paper_runs": (
+                "quanttradeai runs list --type agent --mode paper --scoreboard --sort-by total_pnl"
+            ),
+            "promote_to_live": (
+                f"quanttradeai promote --run {run_id} -c {config_path} "
+                f"--to live --acknowledge-live {agent_name}"
+            ),
+        }
+        target = _deployment_target(resolved_project_config)
+        if target:
+            commands["deploy_agent"] = (
+                f"quanttradeai deploy --agent {agent_name} -c {config_path} --target {target}"
+            )
+        return (
+            {
+                "action": "promote_to_live",
+                "reason": "Promote this successful paper run to live mode after reviewing execution and risk artifacts.",
+                "command": commands["promote_to_live"],
+                "follow_up_command": commands.get("deploy_agent"),
+            },
+            commands,
+        )
+
+    if run_type == "agent" and mode == "live":
+        commands = {
+            "rank_live_runs": (
+                "quanttradeai runs list --type agent --mode live --scoreboard --sort-by total_pnl"
+            )
+        }
+        return (
+            {
+                "action": "inspect_live_run",
+                "reason": "Inspect live metrics, decisions, executions, risk state, and logs before taking operational action.",
+                "command": commands["rank_live_runs"],
+                "follow_up_command": None,
+            },
+            commands,
+        )
+
+    return (
+        {
+            "action": "inspect_run",
+            "reason": "Inspect the run artifacts and metrics before choosing the next workflow step.",
+            "command": None,
+            "follow_up_command": None,
+        },
+        {},
+    )
+
+
+def build_run_brief(
+    *,
+    summary: dict[str, Any],
+    run_dir: str | Path,
+    project_config_path: str | Path,
+) -> dict[str, Any]:
+    """Build a deterministic brief for one research or agent run."""
+
+    run_dir_path = Path(run_dir)
+    resolved_project_config = _load_resolved_project_config(summary)
+    next_action, commands = _recommended_next_action(
+        summary=summary,
+        project_config_path=str(project_config_path),
+        resolved_project_config=resolved_project_config,
+    )
+    run_payload = {
+        "run_id": summary.get("run_id"),
+        "run_type": summary.get("run_type"),
+        "mode": summary.get("mode"),
+        "name": summary.get("name"),
+        "status": summary.get("status"),
+        "run_dir": str(summary.get("run_dir") or run_dir_path),
+        "timestamps": dict(summary.get("timestamps") or {}),
+        "symbols": list(summary.get("symbols") or []),
+    }
+    for key in ("project_name", "project_profile", "agent_name", "agent_kind"):
+        if summary.get(key) is not None:
+            run_payload[key] = summary.get(key)
+
+    return {
+        "kind": RUN_BRIEF_KIND,
+        "schema_version": RUN_BRIEF_SCHEMA_VERSION,
+        "run": run_payload,
+        "scoreboard": _scoreboard_for_summary(summary, run_dir=run_dir_path),
+        "recommended_next_action": next_action,
+        "commands": commands,
+        "artifacts": _summary_artifacts(summary),
+        "warnings": _unique_strings(list(summary.get("warnings") or [])),
+        "error": summary.get("error"),
+    }
+
+
+def _render_value(value: Any) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True)
+    return str(value)
+
+
+def render_run_brief_markdown(brief: dict[str, Any]) -> str:
+    """Render a compact Markdown view of a single-run brief."""
+
+    run = dict(brief.get("run") or {})
+    scoreboard = dict(brief.get("scoreboard") or {})
+    action = dict(brief.get("recommended_next_action") or {})
+    commands = dict(brief.get("commands") or {})
+    artifacts = dict(brief.get("artifacts") or {})
+    warnings = list(brief.get("warnings") or [])
+
+    lines = [
+        "# Run Brief",
+        "",
+        "## Run",
+        "",
+        f"- Run ID: {_render_value(run.get('run_id'))}",
+        f"- Type: {_render_value(run.get('run_type'))}",
+        f"- Mode: {_render_value(run.get('mode'))}",
+        f"- Name: {_render_value(run.get('name'))}",
+        f"- Status: {_render_value(run.get('status'))}",
+        f"- Symbols: {_render_value(run.get('symbols'))}",
+        f"- Run Dir: {_render_value(run.get('run_dir'))}",
+        "",
+        "## Recommendation",
+        "",
+        f"- Action: {_render_value(action.get('action'))}",
+        f"- Reason: {_render_value(action.get('reason'))}",
+    ]
+    if action.get("command"):
+        lines.append(f"- Command: `{action['command']}`")
+    if action.get("follow_up_command"):
+        lines.append(f"- Follow-up: `{action['follow_up_command']}`")
+
+    lines.extend(["", "## Scoreboard", ""])
+    for key in (
+        "primary_metric_name",
+        "primary_metric",
+        "accuracy",
+        "f1",
+        "net_sharpe",
+        "net_pnl",
+        "total_pnl",
+        "portfolio_value",
+        "execution_count",
+        "decision_count",
+        "risk_status",
+        "status",
+        "error",
+    ):
+        if key in scoreboard and scoreboard.get(key) is not None:
+            lines.append(f"- {key}: {_render_value(scoreboard.get(key))}")
+
+    lines.extend(["", "## Commands", ""])
+    if commands:
+        for name, command in commands.items():
+            lines.append(f"- {name}: `{command}`")
+    else:
+        lines.append("- None.")
+
+    lines.extend(["", "## Artifacts", ""])
+    if artifacts:
+        for name, path in artifacts.items():
+            lines.append(f"- {name}: {_render_value(path)}")
+    else:
+        lines.append("- None.")
+
+    if brief.get("error"):
+        lines.extend(["", "## Error", "", f"- {_render_value(brief.get('error'))}"])
+
+    if warnings:
+        lines.extend(["", "## Warnings", ""])
+        for warning in warnings:
+            lines.append(f"- {warning}")
+
+    return "\n".join(lines) + "\n"
+
+
+def write_run_brief_artifacts(
+    summary: dict[str, Any],
+    run_dir: str | Path,
+    project_config_path: str | Path,
+) -> dict[str, str]:
+    """Write run_brief JSON/Markdown artifacts and attach them to summary."""
+
+    run_dir_path = Path(run_dir)
+    run_brief_json_path = run_dir_path / "run_brief.json"
+    run_brief_md_path = run_dir_path / "run_brief.md"
+    artifacts = dict(summary.get("artifacts") or {})
+    artifacts["run_brief_json"] = str(run_brief_json_path)
+    artifacts["run_brief_md"] = str(run_brief_md_path)
+    summary["artifacts"] = artifacts
+
+    brief = build_run_brief(
+        summary=summary,
+        run_dir=run_dir_path,
+        project_config_path=project_config_path,
+    )
+    run_brief_json_path.write_text(
+        json.dumps(brief, indent=2, default=str),
+        encoding="utf-8",
+    )
+    run_brief_md_path.write_text(
+        render_run_brief_markdown(brief),
+        encoding="utf-8",
+    )
+    return {
+        "run_brief_json": str(run_brief_json_path),
+        "run_brief_md": str(run_brief_md_path),
+    }

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,6 @@
 # QuantTradeAI Roadmap
 
-Last updated: 2026-05-02
+Last updated: 2026-05-04
 
 This document is the product source of truth for QuantTradeAI.
 It is written for both human contributors and coding agents.
@@ -416,10 +416,11 @@ Deliverables:
 - Add AI-assisted experiment planning and ops support only where it materially saves user time.
 - Tighten docs, templates, and examples around the final product model.
 
-Status on 2026-05-03:
+Status on 2026-05-04:
 
 - Agent batch and sweep runs now write agent-readable experiment briefs (`experiment_brief.json` and `experiment_brief.md`) plus batch-level `summary.json` records under `runs/agent/batches/...`, so coding agents can identify the best child run, inspect failures, and execute the recommended next command without manually stitching together batch artifacts.
 - `quanttradeai runs list --type batch --json` is implemented for local batch run discovery.
+- Single research and agent runs now write agent-readable run briefs (`run_brief.json` and `run_brief.md`) under each run directory, so coding agents can inspect metrics, warnings, artifact paths, and the recommended next command without manually stitching together single-run artifacts.
 
 ## Golden Workflows
 

--- a/tests/integration/test_agent_cli.py
+++ b/tests/integration/test_agent_cli.py
@@ -202,6 +202,13 @@ def test_agent_run_backtest_writes_artifacts(tmp_path: Path, monkeypatch):
     assert (run_dir / "equity_curve.csv").is_file()
     assert (run_dir / "decisions.jsonl").is_file()
     assert (run_dir / "prompt_samples.json").is_file()
+    assert (run_dir / "run_brief.json").is_file()
+    assert (run_dir / "run_brief.md").is_file()
+    assert payload["artifacts"]["run_brief_json"] == str(run_dir / "run_brief.json")
+    run_brief = json.loads((run_dir / "run_brief.json").read_text("utf-8"))
+    assert run_brief["kind"] == "quanttradeai.run_brief"
+    assert run_brief["recommended_next_action"]["action"] == "promote_to_paper"
+    assert "promote_to_paper" in run_brief["commands"]
 
     decision_lines = (
         (run_dir / "decisions.jsonl").read_text(encoding="utf-8").strip().splitlines()
@@ -1000,6 +1007,12 @@ def test_model_agent_paper_run_uses_replay_manifest(
     run_dir = Path(payload["run_dir"])
     assert payload["paper_source"] == "replay"
     assert (run_dir / "replay_manifest.json").is_file()
+    assert (run_dir / "run_brief.json").is_file()
+    assert payload["artifacts"]["run_brief_json"] == str(run_dir / "run_brief.json")
+    run_brief = json.loads((run_dir / "run_brief.json").read_text("utf-8"))
+    assert run_brief["recommended_next_action"]["action"] == "promote_to_live"
+    assert "promote_to_live" in run_brief["commands"]
+    assert "deploy_agent" in run_brief["commands"]
     assert observed["gateway"].__class__.__name__ == "ReplayGateway"
     assert observed["bootstrap_history_frames"]
 

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -1606,6 +1606,15 @@ def test_research_run_happy_path_writes_run_artifacts(tmp_path: Path, monkeypatc
     assert "migrated_project_config" not in summary_payload["artifacts"]
     assert metrics_payload["status"] == "available"
     assert metrics_payload["backtest_metrics_by_symbol"]["AAPL"]["net_sharpe"] == 1.2
+    assert (latest_run / "run_brief.json").is_file()
+    assert (latest_run / "run_brief.md").is_file()
+    assert summary_payload["artifacts"]["run_brief_json"] == str(
+        latest_run / "run_brief.json"
+    )
+    run_brief = json.loads((latest_run / "run_brief.json").read_text("utf-8"))
+    assert run_brief["kind"] == "quanttradeai.run_brief"
+    assert run_brief["recommended_next_action"]["action"] == "promote_research_run"
+    assert "promote_this_run" in run_brief["commands"]
 
 
 def test_research_run_rejects_removed_legacy_config_flag(tmp_path: Path, monkeypatch):

--- a/tests/utils/test_run_brief.py
+++ b/tests/utils/test_run_brief.py
@@ -1,0 +1,259 @@
+import json
+from pathlib import Path
+
+import yaml
+
+from quanttradeai.utils.run_brief import (
+    RUN_BRIEF_KIND,
+    RUN_BRIEF_SCHEMA_VERSION,
+    build_run_brief,
+    render_run_brief_markdown,
+    write_run_brief_artifacts,
+)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_yaml(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _config_path(tmp_path: Path) -> Path:
+    config_path = tmp_path / "config" / "project.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("project:\n  name: test\n", encoding="utf-8")
+    return config_path
+
+
+def _summary(
+    run_dir: Path,
+    *,
+    run_id: str,
+    run_type: str,
+    mode: str,
+    name: str,
+    status: str = "success",
+    extra: dict | None = None,
+) -> dict:
+    payload = {
+        "run_id": run_id,
+        "run_type": run_type,
+        "mode": mode,
+        "name": name,
+        "status": status,
+        "timestamps": {"started_at": "2026-01-01T00:00:00+00:00"},
+        "symbols": ["AAPL"],
+        "warnings": [],
+        "artifacts": {},
+        "run_dir": str(run_dir),
+    }
+    payload.update(extra or {})
+    return payload
+
+
+def test_research_success_brief_recommends_ranking_and_promotion(tmp_path: Path):
+    run_dir = tmp_path / "runs" / "research" / "20260101_research_lab"
+    _write_json(
+        run_dir / "metrics.json",
+        {
+            "status": "available",
+            "research_metrics_by_symbol": {"AAPL": {"accuracy": 0.8, "f1": 0.6}},
+            "backtest_metrics_by_symbol": {"AAPL": {"net_sharpe": 1.4, "net_pnl": 0.2}},
+        },
+    )
+    summary = _summary(
+        run_dir,
+        run_id="research/20260101_research_lab",
+        run_type="research",
+        mode="research",
+        name="research_lab",
+        extra={"project_name": "research_lab"},
+    )
+
+    brief = build_run_brief(
+        summary=summary,
+        run_dir=run_dir,
+        project_config_path=_config_path(tmp_path),
+    )
+
+    assert brief["kind"] == RUN_BRIEF_KIND
+    assert brief["schema_version"] == RUN_BRIEF_SCHEMA_VERSION
+    assert brief["recommended_next_action"]["action"] == "promote_research_run"
+    assert "rank_research_runs" in brief["commands"]
+    assert brief["commands"]["promote_this_run"].startswith(
+        "quanttradeai promote --run research/20260101_research_lab -c "
+    )
+    assert brief["scoreboard"]["primary_metric_name"] == "net_sharpe"
+    assert brief["scoreboard"]["primary_metric"] == 1.4
+
+
+def test_agent_backtest_success_brief_recommends_paper_promotion(tmp_path: Path):
+    run_dir = tmp_path / "runs" / "agent" / "backtest" / "20260101_breakout_gpt"
+    _write_json(
+        run_dir / "metrics.json",
+        {"net_sharpe": 1.2, "net_pnl": 0.1, "net_mdd": -0.05},
+    )
+    summary = _summary(
+        run_dir,
+        run_id="agent/backtest/20260101_breakout_gpt",
+        run_type="agent",
+        mode="backtest",
+        name="breakout_gpt",
+        extra={"agent_name": "breakout_gpt", "agent_kind": "llm"},
+    )
+
+    brief = build_run_brief(
+        summary=summary,
+        run_dir=run_dir,
+        project_config_path=_config_path(tmp_path),
+    )
+
+    assert brief["recommended_next_action"]["action"] == "promote_to_paper"
+    assert brief["commands"]["promote_to_paper"].startswith(
+        "quanttradeai promote --run agent/backtest/20260101_breakout_gpt -c "
+    )
+    assert brief["scoreboard"]["net_sharpe"] == 1.2
+
+
+def test_agent_paper_success_brief_recommends_live_promotion_and_deploy(
+    tmp_path: Path,
+):
+    run_dir = tmp_path / "runs" / "agent" / "paper" / "20260101_breakout_gpt"
+    resolved_config_path = run_dir / "resolved_project_config.yaml"
+    _write_json(
+        run_dir / "metrics.json",
+        {
+            "status": "available",
+            "total_pnl": 120.0,
+            "portfolio_value": 100120.0,
+            "execution_count": 3,
+            "decision_count": 5,
+        },
+    )
+    _write_yaml(resolved_config_path, {"deployment": {"target": "render"}})
+    summary = _summary(
+        run_dir,
+        run_id="agent/paper/20260101_breakout_gpt",
+        run_type="agent",
+        mode="paper",
+        name="breakout_gpt",
+        extra={
+            "agent_name": "breakout_gpt",
+            "agent_kind": "llm",
+            "artifacts": {"resolved_project_config": str(resolved_config_path)},
+        },
+    )
+
+    brief = build_run_brief(
+        summary=summary,
+        run_dir=run_dir,
+        project_config_path=_config_path(tmp_path),
+    )
+
+    assert brief["recommended_next_action"]["action"] == "promote_to_live"
+    assert (
+        "--to live --acknowledge-live breakout_gpt"
+        in brief["commands"]["promote_to_live"]
+    )
+    assert brief["commands"]["deploy_agent"].endswith("--target render")
+    assert brief["scoreboard"]["total_pnl"] == 120.0
+
+
+def test_agent_live_success_brief_recommends_live_ranking(tmp_path: Path):
+    run_dir = tmp_path / "runs" / "agent" / "live" / "20260101_breakout_gpt"
+    _write_json(
+        run_dir / "metrics.json",
+        {
+            "status": "available",
+            "total_pnl": 80.0,
+            "portfolio_value": 100080.0,
+            "execution_count": 2,
+            "decision_count": 4,
+            "risk_status": {"status": "ok"},
+        },
+    )
+    summary = _summary(
+        run_dir,
+        run_id="agent/live/20260101_breakout_gpt",
+        run_type="agent",
+        mode="live",
+        name="breakout_gpt",
+        extra={"agent_name": "breakout_gpt", "agent_kind": "rule"},
+    )
+
+    brief = build_run_brief(
+        summary=summary,
+        run_dir=run_dir,
+        project_config_path=_config_path(tmp_path),
+    )
+
+    assert brief["recommended_next_action"]["action"] == "inspect_live_run"
+    assert brief["commands"] == {
+        "rank_live_runs": (
+            "quanttradeai runs list --type agent --mode live --scoreboard --sort-by total_pnl"
+        )
+    }
+    assert brief["scoreboard"]["risk_status"] == "ok"
+
+
+def test_failed_run_brief_uses_inspect_failure_without_commands(tmp_path: Path):
+    run_dir = tmp_path / "runs" / "agent" / "backtest" / "20260101_failed"
+    summary = _summary(
+        run_dir,
+        run_id="agent/backtest/20260101_failed",
+        run_type="agent",
+        mode="backtest",
+        name="failed_agent",
+        status="failed",
+        extra={
+            "agent_name": "failed_agent",
+            "error": "missing prompt",
+            "warnings": ["config warning"],
+        },
+    )
+
+    brief = build_run_brief(
+        summary=summary,
+        run_dir=run_dir,
+        project_config_path=_config_path(tmp_path),
+    )
+
+    assert brief["recommended_next_action"]["action"] == "inspect_failure"
+    assert brief["commands"] == {}
+    assert brief["error"] == "missing prompt"
+    assert brief["warnings"] == ["config warning"]
+    assert brief["scoreboard"]["status"] == "missing"
+
+
+def test_write_run_brief_artifacts_updates_summary_and_markdown(tmp_path: Path):
+    run_dir = tmp_path / "runs" / "agent" / "backtest" / "20260101_breakout_gpt"
+    _write_json(
+        run_dir / "metrics.json",
+        {"net_sharpe": 1.2, "net_pnl": 0.1, "net_mdd": -0.05},
+    )
+    summary = _summary(
+        run_dir,
+        run_id="agent/backtest/20260101_breakout_gpt",
+        run_type="agent",
+        mode="backtest",
+        name="breakout_gpt",
+        extra={"agent_name": "breakout_gpt", "artifacts": {"metrics": "metrics.json"}},
+    )
+
+    artifacts = write_run_brief_artifacts(summary, run_dir, _config_path(tmp_path))
+
+    assert Path(artifacts["run_brief_json"]).is_file()
+    assert Path(artifacts["run_brief_md"]).is_file()
+    assert summary["artifacts"]["run_brief_json"] == artifacts["run_brief_json"]
+    assert summary["artifacts"]["run_brief_md"] == artifacts["run_brief_md"]
+
+    brief = json.loads(Path(artifacts["run_brief_json"]).read_text("utf-8"))
+    rendered = render_run_brief_markdown(brief)
+    assert "## Recommendation" in rendered
+    assert "promote_to_paper" in rendered
+    assert "## Commands" in rendered
+    assert "## Artifacts" in rendered

--- a/tests/utils/test_run_brief.py
+++ b/tests/utils/test_run_brief.py
@@ -257,3 +257,35 @@ def test_write_run_brief_artifacts_updates_summary_and_markdown(tmp_path: Path):
     assert "promote_to_paper" in rendered
     assert "## Commands" in rendered
     assert "## Artifacts" in rendered
+
+
+def test_write_run_brief_artifacts_keeps_summary_backed_decision_count(
+    tmp_path: Path,
+):
+    run_dir = tmp_path / "runs" / "agent" / "backtest" / "20260101_breakout_gpt"
+    _write_json(
+        run_dir / "metrics.json",
+        {"net_sharpe": 1.2, "net_pnl": 0.1, "net_mdd": -0.05},
+    )
+    summary = _summary(
+        run_dir,
+        run_id="agent/backtest/20260101_breakout_gpt",
+        run_type="agent",
+        mode="backtest",
+        name="breakout_gpt",
+        extra={
+            "agent_name": "breakout_gpt",
+            "decision_count": 17,
+            "artifacts": {"metrics": str(run_dir / "metrics.json")},
+        },
+    )
+
+    artifacts = write_run_brief_artifacts(summary, run_dir, _config_path(tmp_path))
+
+    brief = json.loads(Path(artifacts["run_brief_json"]).read_text("utf-8"))
+    persisted_summary = json.loads((run_dir / "summary.json").read_text("utf-8"))
+    assert brief["scoreboard"]["decision_count"] == 17
+    assert persisted_summary["decision_count"] == 17
+    assert (
+        persisted_summary["artifacts"]["run_brief_json"] == artifacts["run_brief_json"]
+    )


### PR DESCRIPTION
## Summary
- Add deterministic `run_brief.json` and `run_brief.md` artifacts for single research and agent runs.
- Wire run brief generation into research, rule/LLM/hybrid agent, and model-agent success and failure paths.
- Document the new run artifacts and update roadmap status.

## Impact
Coding agents can inspect a single run's normalized identity, scoreboard metrics, warnings/errors, artifact paths, and recommended next commands without manually stitching together run files.

## Validation
- `make lint.format.test`
- pre-commit hook: format, lint, test
- Full suite: 399 passed