### PR TITLE
feat: add research sweep workflow

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -12,6 +12,7 @@ Use the small CLI surface first:
 poetry run quanttradeai init --template research -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai research run -c config/project.yaml --sweep <sweep_name> --max-concurrency 4
 poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
 poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 | I want to... | Best path today | What I get |
 | --- | --- | --- |
 | Research a strategy end to end | `init` -> `validate` -> `research run` -> `promote --run research/<run_id>` | Time-aware evaluation, backtests, metrics, run records, and a stable promoted model path |
+| Sweep research parameters | `research run --sweep <name> --max-concurrency 4` | Many YAML-defined research variants with normal child runs plus sparse batch `results.json` and `scoreboard.json` |
 | Compare multiple deterministic strategies | `init --template strategy-lab` -> `validate` -> `agent run --all --mode backtest` -> `agent run --sweep ...` -> `promote` | RSI reversion and SMA trend agents, reusable sweeps, run scoreboards, and promotion without Python, LLM keys, or broker credentials |
 | Run a deterministic rule agent | `init --template rule-agent` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | A YAML-only agent that can move through backtest, paper, and live with explicit promotion gates |
 | Run a trained model as an agent | `init --template model-agent` -> `validate` -> `agent run --mode backtest` -> `promote` -> `agent run --mode paper` -> `promote --to live` -> `agent run --mode live` | One YAML-defined model agent wired to a stable `models/promoted/...` path that can be backtested, promoted, paper-run, and live-run |
@@ -67,6 +68,7 @@ QuantTradeAI is one framework with two connected tracks:
 | Workflow | Status |
 | --- | --- |
 | `research run` from `project.yaml` | Supported |
+| `research run --sweep <name>` from `project.yaml` | Supported |
 | `agent run` for `rule` agents in `backtest` | Supported |
 | `agent run` for `rule` agents in `paper` | Supported |
 | `agent run` for `rule` agents in `live` | Supported |
@@ -115,6 +117,7 @@ Use this if you want the simplest end-to-end quant workflow.
 poetry run quanttradeai init --template research -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai research run -c config/project.yaml --sweep <sweep_name> --max-concurrency 4
 poetry run quanttradeai runs list
 poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
 poetry run quanttradeai runs list --compare research/<run_id_a> --compare research/<run_id_b>
@@ -426,6 +429,9 @@ For the full shape, field reference, and supported agent modes, see [Project YAM
 
 Sweep batch artifacts:
 
+- `runs/research/batches/<timestamp>_<project>_<sweep>/summary.json`
+- `runs/research/batches/<timestamp>_<project>_<sweep>/results.json`
+- `runs/research/batches/<timestamp>_<project>_<sweep>/scoreboard.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/summary.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/results.json`
 - `runs/agent/batches/<timestamp>_<project>_<sweep>_backtest/scoreboard.json`

--- a/docs/configuration/live-runtime-files.md
+++ b/docs/configuration/live-runtime-files.md
@@ -65,6 +65,15 @@ LLM and hybrid live runs also write `prompt_samples.json`.
 
 ## Batch Runs
 
+`quanttradeai research run --sweep` writes batch-level artifacts under `runs/research/batches/...`, including:
+
+- `resolved_project_config.yaml`
+- `summary.json` with `run_result`
+- `results.json`
+- `scoreboard.json`
+
+Child variants keep their normal per-run research artifacts under `runs/research/...`.
+
 `quanttradeai agent run --all` and `quanttradeai agent run --sweep` write batch-level artifacts under `runs/agent/batches/...`, including:
 
 - `resolved_project_config.yaml`

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -7,6 +7,7 @@ It drives:
 - `quanttradeai init`
 - `quanttradeai validate`
 - `quanttradeai research run`
+- `quanttradeai research run --sweep <name>` for research parameter sweeps
 - `quanttradeai agent run` for project-defined agents in `backtest`, `paper`, and `live`
 - `quanttradeai agent run --all` for multi-agent batches in `backtest`, `paper`, and `live`
 - `quanttradeai agent run --sweep <name>` for backtest-only parameter sweeps
@@ -25,6 +26,7 @@ If an agent sets `execution.backend: alpaca`, QuantTradeAI switches paper/live e
 poetry run quanttradeai init --template research -o config/project.yaml
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai research run -c config/project.yaml --sweep rsi_research_grid --max-concurrency 4
 poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 ```
 
@@ -714,7 +716,7 @@ Behavior:
 
 ### `sweeps`
 
-Optional backtest-only parameter sweeps defined in the canonical project config.
+Optional parameter sweeps defined in the canonical project config.
 
 Supported MVP shape:
 
@@ -728,19 +730,30 @@ sweeps:
         values: [25.0, 30.0]
       - path: "rule.sell_above"
         values: [70.0, 75.0]
+
+  - name: "rsi_research_grid"
+    kind: "research_run"
+    parameters:
+      - path: "research.labels.horizon"
+        values: [3, 5, 10]
+      - path: "features.rsi_14.params.period"
+        values: [7, 14, 21]
+      - path: "research.backtest.costs.bps"
+        values: [1, 5]
 ```
 
 Rules:
 
-- `kind` currently supports only `agent_backtest`
-- `agent` must reference an existing project-defined agent
-- `parameters[].path` is a dotted path relative to that agent, not the whole project config
-- each path must resolve to an existing scalar leaf
-- sweeps may not modify `name`, `kind`, or `mode`
+- `kind` supports `agent_backtest` and `research_run`
+- `agent` must reference an existing project-defined agent for `agent_backtest`
+- `parameters[].path` must resolve to an existing scalar leaf
+- agent sweep paths are dotted paths relative to the selected agent and may not modify `name`, `kind`, or `mode`
+- research sweep paths are whole-project paths limited to research labels/costs/tuning/evaluation, selected data fields, and `features.<feature_name>.params.<param>`
 - variants expand as a Cartesian product in the order parameters are declared
-- each sweep child run records a `promote_command` in batch `results.json`
+- each agent sweep child run records a `promote_command` in batch `results.json`
 - promoting a successful sweep child materializes its parameter values into the base agent in `config/project.yaml` and sets the base agent to `mode: paper`
 - sweep child runs cannot promote directly to live; run the materialized paper agent first, then promote that paper run to live
+- research sweeps do not mutate `config/project.yaml`; each variant writes a normal child research run plus sparse batch `summary.json`, `results.json`, and `scoreboard.json`
 
 ### `risk`
 
@@ -793,6 +806,12 @@ Alongside `summary.json` and `metrics.json`, QuantTradeAI writes:
 - `backtest_summary.json` when automatic post-train backtests produce output
 
 Successful research runs also record `artifacts.experiment_dir` in `summary.json`, which is the source used by `quanttradeai promote --run research/<run_id>`.
+
+### `quanttradeai research run --sweep <name>`
+
+Writes a batch directory under `runs/research/batches/<timestamp>_<project>_<sweep>/` and one normal child research run under `runs/research/...` for each expanded variant.
+
+Research sweep batches write `summary.json`, `results.json`, and `scoreboard.json`. Scoreboards sort by `net_sharpe` when automatic backtests produce Sharpe metrics, otherwise by research `accuracy`.
 
 ### `quanttradeai promote`
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -35,6 +35,7 @@ poetry run quanttradeai validate -c config/project.yaml
 
 # Run canonical research workflow
 poetry run quanttradeai research run -c config/project.yaml
+poetry run quanttradeai research run -c config/project.yaml --sweep rsi_research_grid --max-concurrency 4
 poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 poetry run quanttradeai runs list
 poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
@@ -102,6 +103,11 @@ Canonical research artifacts:
 - `runs/research/<timestamp>_<project>/summary.json`
 - `runs/research/<timestamp>_<project>/metrics.json`
 - `runs/research/<timestamp>_<project>/backtest_summary.json`
+
+Canonical research sweep batch artifacts:
+- `runs/research/batches/<timestamp>_<project>_<sweep>/summary.json`
+- `runs/research/batches/<timestamp>_<project>_<sweep>/results.json`
+- `runs/research/batches/<timestamp>_<project>_<sweep>/scoreboard.json`
 
 Canonical agent backtest artifacts:
 - `runs/agent/backtest/<timestamp>_<agent>/resolved_project_config.yaml`
@@ -333,10 +339,10 @@ Use these pages instead of copying large config blocks out of the quick referenc
 
 Quick decision rule:
 
-- Use `config/project.yaml` for `validate`, `research run`, `agent run`, and `agent run --sweep`
+- Use `config/project.yaml` for `validate`, `research run`, `research run --sweep`, `agent run`, and `agent run --sweep`
 - Use `data.streaming.replay` for deterministic local paper runs; keep provider/websocket fields in place for later deployment or live promotion
 - Use `quanttradeai runs list --scoreboard` to rank local runs, then `quanttradeai runs list --compare ...` to inspect shortlisted runs by metrics and config deltas
-- For sweeps, use the `promote_command` in batch `results.json` or `quanttradeai promote --run agent/backtest/<winner_run_id> -c config/project.yaml` to materialize the winner into the base agent before paper mode
+- For agent sweeps, use the `promote_command` in batch `results.json` or `quanttradeai promote --run agent/backtest/<winner_run_id> -c config/project.yaml` to materialize the winner into the base agent before paper mode
 - Use the generated runtime YAML snapshots under each run directory to inspect what actually executed
 
 ## Time-Aware Splitting

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -8,11 +8,14 @@ paths.
 from __future__ import annotations
 
 import json
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
 import typer
+import yaml
 from .utils.config_validator import validate_project_config
 from .utils.project_paths import infer_project_root
 from .utils.project_config import (
@@ -34,6 +37,7 @@ from .utils.run_scoreboard import (
     sort_run_records,
 )
 from .utils.run_result import attach_run_result, compact_cli_result
+from .utils.sweeps import expand_research_sweep
 
 
 app = typer.Typer(add_completion=False, help="QuantTradeAI command line interface")
@@ -848,37 +852,70 @@ def _render_runs_table(records: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-@research_app.command("run")
-def cmd_research_run(
-    config: str = typer.Option(
-        "config/project.yaml", "-c", "--config", help="Path to project config YAML"
-    ),
-    skip_validation: bool = typer.Option(
-        False,
-        "--skip-validation",
-        help="Skip data-quality validation before training",
-    ),
-):
-    """Run the canonical research workflow from project.yaml."""
+def _slugify(value: str | None) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_-]+", "_", (value or "run").strip())
+    return normalized.strip("_").lower() or "run"
 
-    import yaml
 
-    project_path = Path(config)
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _child_run_timestamp(batch_timestamp: str, index: int) -> str:
+    return f"{batch_timestamp}_{index:02d}"
+
+
+def _research_run_name(
+    *,
+    config_path: Path,
+    project_config_override: dict[str, Any] | None,
+    explicit_name: str | None,
+) -> tuple[str, list[str]]:
+    if explicit_name:
+        return explicit_name, []
+    if project_config_override is not None:
+        return (
+            ((project_config_override.get("project") or {}).get("name"))
+            or config_path.stem,
+            [],
+        )
     try:
-        loaded_project = load_project_config(config_path=project_path)
-        run_name = (
-            (loaded_project.raw.get("project") or {}).get("name")
-        ) or project_path.stem
-        initial_warnings = list(loaded_project.warnings)
+        loaded_project = load_project_config(config_path=config_path)
+        run_name = (loaded_project.raw.get("project") or {}).get("name")
+        return run_name or config_path.stem, list(loaded_project.warnings)
     except Exception:
-        run_name = project_path.stem
-        initial_warnings = []
+        return config_path.stem, []
+
+
+def _run_research_workflow(
+    *,
+    project_config_path: str | Path = "config/project.yaml",
+    skip_validation: bool = False,
+    project_config_override: dict[str, Any] | None = None,
+    run_timestamp: str | None = None,
+    run_name: str | None = None,
+    experiment_output_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Run one canonical research workflow and persist normal run artifacts."""
+
+    project_path = Path(project_config_path)
+    timestamp = run_timestamp or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    resolved_run_name, initial_warnings = _research_run_name(
+        config_path=project_path,
+        project_config_override=project_config_override,
+        explicit_name=run_name,
+    )
 
     run_dir, run_id = create_run_dir(
         run_type="research",
         mode="research",
-        name=run_name,
+        name=resolved_run_name,
         timestamp=timestamp,
     )
 
@@ -899,7 +936,7 @@ def cmd_research_run(
         run_dir=run_dir,
         run_type="research",
         mode="research",
-        name=run_name,
+        name=resolved_run_name,
     )
     summary["run_id"] = run_id
 
@@ -907,6 +944,7 @@ def cmd_research_run(
         validation = validate_project_config(
             config_path=project_path,
             output_dir=run_dir / "validation",
+            project_config_override=project_config_override,
             timestamp_subdir=False,
         )
         summary["warnings"] = list(
@@ -940,15 +978,9 @@ def cmd_research_run(
         runtime_model_path = run_dir / "runtime_model_config.yaml"
         runtime_features_path = run_dir / "runtime_features_config.yaml"
         runtime_backtest_path = run_dir / "runtime_backtest_config.yaml"
-        runtime_model_path.write_text(
-            yaml.safe_dump(model_cfg, sort_keys=False), encoding="utf-8"
-        )
-        runtime_features_path.write_text(
-            yaml.safe_dump(features_cfg, sort_keys=False), encoding="utf-8"
-        )
-        runtime_backtest_path.write_text(
-            yaml.safe_dump(backtest_cfg, sort_keys=False), encoding="utf-8"
-        )
+        _write_yaml(runtime_model_path, model_cfg)
+        _write_yaml(runtime_features_path, features_cfg)
+        _write_yaml(runtime_backtest_path, backtest_cfg)
         summary["artifacts"]["runtime_model_config"] = str(runtime_model_path)
         summary["artifacts"]["runtime_features_config"] = str(runtime_features_path)
         summary["artifacts"]["runtime_backtest_config"] = str(runtime_backtest_path)
@@ -961,6 +993,11 @@ def cmd_research_run(
             features_config_path=str(runtime_features_path),
             tuning_enabled=bool(training_cfg.get("tune_hyperparameters", True)),
             optuna_trials=int(training_cfg.get("optuna_trials", 50)),
+            experiment_dir=(
+                str(experiment_output_dir)
+                if experiment_output_dir is not None
+                else None
+            ),
         )
 
         results = (
@@ -1012,6 +1049,7 @@ def cmd_research_run(
                 symbol_backtest = run_model_backtest(
                     model_config=str(runtime_model_path),
                     model_path=str(model_path),
+                    features_config_path=str(runtime_features_path),
                     backtest_config=str(runtime_backtest_path),
                     risk_config=None,
                     skip_validation=skip_validation,
@@ -1022,10 +1060,7 @@ def cmd_research_run(
 
         if backtest_payload:
             backtest_summary_path = run_dir / "backtest_summary.json"
-            backtest_summary_path.write_text(
-                json.dumps(backtest_payload, indent=2),
-                encoding="utf-8",
-            )
+            _write_json(backtest_summary_path, backtest_payload)
             summary["artifacts"]["backtest_summary"] = str(backtest_summary_path)
 
         summary["warnings"] = list(dict.fromkeys(summary["warnings"]))
@@ -1035,7 +1070,7 @@ def cmd_research_run(
             run_dir=run_dir,
             run_type="research",
             mode="research",
-            name=summary.get("project_name") or run_name,
+            name=run_name or summary.get("project_name") or resolved_run_name,
         )
 
         backtest_metrics_by_symbol = {}
@@ -1078,39 +1113,282 @@ def cmd_research_run(
             run_dir=run_dir,
             run_type="research",
             mode="research",
-            name=summary.get("project_name") or run_name,
+            name=run_name or summary.get("project_name") or resolved_run_name,
         )
         metrics_payload = {
             "status": "placeholder",
             "message": "Research pipeline did not complete successfully.",
             "error": str(exc),
         }
-        attach_run_result(
-            summary,
-            project_config_path=project_path,
-            metrics_payload=metrics_payload,
-        )
 
-        (run_dir / "metrics.json").write_text(
-            json.dumps(metrics_payload, indent=2), encoding="utf-8"
-        )
-        (run_dir / "summary.json").write_text(
-            json.dumps(summary, indent=2), encoding="utf-8"
-        )
-        typer.echo(f"Research run failed: {exc}", err=True)
-        raise typer.Exit(code=1)
-
+    metrics_path = run_dir / "metrics.json"
+    summary_path = run_dir / "summary.json"
+    summary["artifacts"]["metrics"] = str(metrics_path)
+    summary["artifacts"]["summary"] = str(summary_path)
     attach_run_result(
         summary,
         project_config_path=project_path,
         metrics_payload=metrics_payload,
     )
-    (run_dir / "summary.json").write_text(
-        json.dumps(summary, indent=2), encoding="utf-8"
+    _write_json(metrics_path, metrics_payload)
+    _write_json(summary_path, summary)
+    return summary
+
+
+def _research_sweep_sort_field(records: list[dict[str, Any]]) -> str:
+    if any(
+        (record.get("scoreboard") or {}).get("net_sharpe") is not None
+        for record in records
+    ):
+        return "net_sharpe"
+    return "accuracy"
+
+
+def _sort_research_sweep_results(
+    entries: list[dict[str, Any]],
+    *,
+    scoreboard_order: list[str],
+) -> list[dict[str, Any]]:
+    order_index = {run_id: index for index, run_id in enumerate(scoreboard_order)}
+    return sorted(
+        entries,
+        key=lambda entry: (
+            order_index.get(str(entry.get("run_id") or ""), len(scoreboard_order)),
+            int(entry.get("display_order") or 0),
+        ),
     )
-    (run_dir / "metrics.json").write_text(
-        json.dumps(metrics_payload, indent=2), encoding="utf-8"
+
+
+def _run_research_sweep_batch(
+    *,
+    project_config_path: str = "config/project.yaml",
+    sweep_name: str,
+    skip_validation: bool = False,
+    max_concurrency: int = 1,
+) -> dict[str, Any]:
+    """Run a research sweep through normal child research runs."""
+
+    if max_concurrency < 1:
+        raise ValueError("--max-concurrency must be at least 1.")
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    started_at = datetime.now(timezone.utc).isoformat()
+    original_project_path = Path(project_config_path).resolve()
+    loaded_project = load_project_config(config_path=original_project_path)
+    project_name = (loaded_project.raw.get("project") or {}).get("name") or Path(
+        original_project_path
+    ).stem
+    batch_name = f"{timestamp}_{_slugify(project_name)}_{_slugify(sweep_name)}"
+    batch_dir = Path("runs") / "research" / "batches" / batch_name
+    batch_dir.mkdir(parents=True, exist_ok=True)
+
+    validation = validate_project_config(
+        config_path=original_project_path,
+        output_dir=batch_dir / "validation",
+        timestamp_subdir=False,
     )
+    resolved_validation_path = Path(validation["artifacts"]["resolved_config"])
+    resolved_project_path = batch_dir / "resolved_project_config.yaml"
+    _copy_artifact(resolved_validation_path, resolved_project_path)
+    resolved_project = (
+        yaml.safe_load(resolved_project_path.read_text(encoding="utf-8")) or {}
+    )
+    expansion = expand_research_sweep(resolved_project, sweep_name)
+
+    specs: list[dict[str, Any]] = []
+    for index, variant in enumerate(expansion["variants"], start=1):
+        variant_name = str(variant["name"])
+        specs.append(
+            {
+                "variant_name": variant_name,
+                "parameters": dict(variant["parameters"]),
+                "project_config_override": dict(variant["project_config"]),
+                "run_timestamp": _child_run_timestamp(timestamp, index),
+                "display_order": index,
+                "experiment_output_dir": Path("models")
+                / "experiments"
+                / f"{batch_name}_{index:03d}_{_slugify(variant_name)}",
+            }
+        )
+
+    def _run_one(spec: dict[str, Any]) -> dict[str, Any]:
+        summary = _run_research_workflow(
+            project_config_path=original_project_path,
+            skip_validation=skip_validation,
+            project_config_override=dict(spec["project_config_override"]),
+            run_timestamp=str(spec["run_timestamp"]),
+            run_name=str(spec["variant_name"]),
+            experiment_output_dir=spec["experiment_output_dir"],
+        )
+        return {**spec, "summary": summary, "status": summary.get("status")}
+
+    results: list[dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=max_concurrency) as executor:
+        futures = [executor.submit(_run_one, spec) for spec in specs]
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    results.sort(key=lambda item: int(item["display_order"]))
+    scoreboard_records = attach_scoreboard([item["summary"] for item in results])
+    scoreboard_sort_by = _research_sweep_sort_field(scoreboard_records)
+    scoreboard_records = sort_run_records(
+        scoreboard_records,
+        sort_by=scoreboard_sort_by,
+        ascending=False,
+    )
+    scoreboard_order = [
+        str(record.get("run_id") or "") for record in scoreboard_records
+    ]
+    scoreboard_by_run_id = {
+        str(record.get("run_id") or ""): dict(record.get("scoreboard") or {})
+        for record in scoreboard_records
+    }
+
+    result_entries = [
+        {
+            "variant_name": item["variant_name"],
+            "parameters": item["parameters"],
+            "status": item["status"],
+            "warnings": list(item["summary"].get("warnings") or []),
+            "error": item["summary"].get("error"),
+            "artifacts": dict(item["summary"].get("artifacts") or {}),
+            "run_timestamp": item["run_timestamp"],
+            "run_id": item["summary"].get("run_id"),
+            "run_dir": item["summary"].get("run_dir"),
+            "display_order": item["display_order"],
+            "scoreboard": scoreboard_by_run_id.get(
+                str(item["summary"].get("run_id") or ""), {}
+            ),
+        }
+        for item in results
+    ]
+    result_entries = _sort_research_sweep_results(
+        result_entries,
+        scoreboard_order=scoreboard_order,
+    )
+    for entry in result_entries:
+        entry.pop("display_order", None)
+
+    results_payload = {
+        "batch_type": "research_sweep",
+        "mode": "research",
+        "scoreboard_sort_by": scoreboard_sort_by,
+        "scoreboard_order": scoreboard_order,
+        "sweep": {
+            "name": expansion["name"],
+            "kind": expansion["kind"],
+            "variant_count": len(expansion["variants"]),
+            "parameters": list(expansion["parameters"]),
+        },
+        "results": result_entries,
+    }
+    scoreboard_payload = {
+        "sort_by": scoreboard_sort_by,
+        "records": scoreboard_records,
+    }
+
+    results_path = batch_dir / "results.json"
+    scoreboard_json_path = batch_dir / "scoreboard.json"
+    summary_path = batch_dir / "summary.json"
+    _write_json(results_path, results_payload)
+    _write_json(scoreboard_json_path, scoreboard_payload)
+
+    success_count = sum(1 for item in results if item["status"] == "success")
+    failure_count = len(results) - success_count
+    batch_status = "success" if failure_count == 0 else "failed"
+    completed_at = datetime.now(timezone.utc).isoformat()
+    batch_artifacts = {
+        "results": str(results_path),
+        "scoreboard_json": str(scoreboard_json_path),
+        "summary": str(summary_path),
+        "resolved_project_config": str(resolved_project_path),
+    }
+    batch_summary = {
+        "batch_type": "research_sweep",
+        "project_name": project_name,
+        "status": batch_status,
+        "timestamps": {
+            "started_at": started_at,
+            "completed_at": completed_at,
+        },
+        "symbols": list((resolved_project.get("data") or {}).get("symbols") or []),
+        "warnings": list(dict.fromkeys(validation.get("warnings", []))),
+        "artifacts": dict(batch_artifacts),
+        "run_dir": str(batch_dir),
+        "variant_count": len(results),
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "scoreboard_sort_by": scoreboard_sort_by,
+        "scoreboard_order": scoreboard_order,
+        "sweep": dict(results_payload["sweep"]),
+    }
+    apply_required_run_fields(
+        batch_summary,
+        run_dir=batch_dir,
+        run_type="batch",
+        mode="research",
+        name=batch_dir.name,
+    )
+    batch_summary["run_id"] = f"research/batches/{batch_dir.name}"
+    attach_run_result(
+        batch_summary,
+        project_config_path=original_project_path.as_posix(),
+        batch_results=result_entries,
+        scoreboard_order=scoreboard_order,
+        scoreboard_sort_by=scoreboard_sort_by,
+    )
+    _write_json(summary_path, batch_summary)
+    return batch_summary
+
+
+@research_app.command("run")
+def cmd_research_run(
+    config: str = typer.Option(
+        "config/project.yaml", "-c", "--config", help="Path to project config YAML"
+    ),
+    skip_validation: bool = typer.Option(
+        False,
+        "--skip-validation",
+        help="Skip data-quality validation before training",
+    ),
+    sweep: Optional[str] = typer.Option(
+        None,
+        "--sweep",
+        help="Run every expanded variant for the named research sweep.",
+    ),
+    max_concurrency: int = typer.Option(
+        1,
+        "--max-concurrency",
+        min=1,
+        help="Maximum concurrent child runs when using --sweep.",
+    ),
+):
+    """Run the canonical research workflow from project.yaml."""
+
+    if sweep:
+        try:
+            batch_summary = _run_research_sweep_batch(
+                project_config_path=config,
+                sweep_name=sweep,
+                skip_validation=skip_validation,
+                max_concurrency=max_concurrency,
+            )
+        except Exception as exc:
+            typer.echo(f"Research sweep failed: {exc}", err=True)
+            raise typer.Exit(code=1)
+
+        _echo_compact_result(batch_summary)
+        if batch_summary["status"] != "success":
+            raise typer.Exit(code=1)
+        return
+
+    summary = _run_research_workflow(
+        project_config_path=config,
+        skip_validation=skip_validation,
+    )
+    if summary["status"] != "success":
+        typer.echo(f"Research run failed: {summary.get('error')}", err=True)
+        raise typer.Exit(code=1)
 
     _echo_compact_result(summary)
 

--- a/quanttradeai/main.py
+++ b/quanttradeai/main.py
@@ -395,6 +395,7 @@ def run_pipeline(
     features_config_path: str = "config/features_config.yaml",
     tuning_enabled: bool | None = None,
     optuna_trials: int | None = None,
+    experiment_dir: str | Path | None = None,
 ):
     """Run the end-to-end training pipeline.
 
@@ -437,9 +438,12 @@ def run_pipeline(
     model = MomentumClassifier(config_path)
 
     # Create experiment directory
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    experiment_dir = f"models/experiments/{timestamp}"
-    Path(experiment_dir).mkdir(parents=True, exist_ok=True)
+    experiment_path = (
+        Path(experiment_dir)
+        if experiment_dir is not None
+        else Path("models/experiments") / datetime.now().strftime("%Y%m%d_%H%M%S")
+    )
+    experiment_path.mkdir(parents=True, exist_ok=True)
 
     try:
         # 1. Fetch Data
@@ -448,7 +452,7 @@ def run_pipeline(
         data_dict = data_loader.fetch_data(refresh=refresh)
 
         # Validate data quality
-        validation_path = Path(experiment_dir) / "validation.json"
+        validation_path = experiment_path / "validation.json"
         _validate_or_raise(
             loader=data_loader,
             data=data_dict,
@@ -524,11 +528,11 @@ def run_pipeline(
             }
 
             # Save model
-            model_path = f"{experiment_dir}/{symbol}"
-            Path(model_path).mkdir(parents=True, exist_ok=True)
-            model.save_model(model_path)
+            model_path = experiment_path / symbol
+            model_path.mkdir(parents=True, exist_ok=True)
+            model.save_model(str(model_path))
             preprocessor_artifacts = _save_feature_preprocessor(
-                preprocessor, model_path
+                preprocessor, str(model_path)
             )
 
             logger.info(f"\n{symbol} Results:")
@@ -536,9 +540,9 @@ def run_pipeline(
             logger.info(f"Test Metrics: {test_metrics}")
             results[symbol]["artifacts"] = preprocessor_artifacts
 
-        coverage_path = Path(experiment_dir) / "test_window_coverage.json"
+        coverage_path = experiment_path / "test_window_coverage.json"
         _write_coverage_report(coverage_path, coverage_report)
-        preprocessing_path = Path(experiment_dir) / "preprocessing.json"
+        preprocessing_path = experiment_path / "preprocessing.json"
         with preprocessing_path.open("w", encoding="utf-8") as handle:
             json.dump(preprocessing_report, handle, indent=2)
         fallback_symbols = [
@@ -555,7 +559,7 @@ def run_pipeline(
         logger.info("Coverage report saved to %s", coverage_path)
 
         # Save experiment results
-        with open(f"{experiment_dir}/results.json", "w") as f:
+        with (experiment_path / "results.json").open("w", encoding="utf-8") as f:
             json.dump(results, f, indent=4)
 
         logger.info("\nPipeline completed successfully!")
@@ -567,7 +571,7 @@ def run_pipeline(
             return {
                 "results": results,
                 "coverage": coverage_info,
-                "experiment_dir": experiment_dir,
+                "experiment_dir": experiment_path.as_posix(),
                 "preprocessing": preprocessing_path.as_posix(),
             }
 
@@ -722,6 +726,7 @@ def run_model_backtest(
     *,
     model_config: str = "config/model_config.yaml",
     model_path: str,
+    features_config_path: str = "config/features_config.yaml",
     backtest_config: str | None = "config/backtest_config.yaml",
     risk_config: str | None = "config/risk_config.yaml",
     cost_bps: float | None = None,
@@ -748,7 +753,7 @@ def run_model_backtest(
         cfg = yaml.safe_load(f)
     setup_directories(cfg.get("data", {}).get("cache_dir", "data/raw"))
     loader = DataLoader(model_config)
-    processor = DataProcessor()
+    processor = DataProcessor(features_config_path)
     clf = MomentumClassifier(model_config)
     clf.load_model(model_path)
     preprocessor = _load_feature_preprocessor(model_path)

--- a/quanttradeai/utils/config_schemas.py
+++ b/quanttradeai/utils/config_schemas.py
@@ -903,15 +903,17 @@ class ProjectSweepParameterConfig(BaseModel):
 
 class ProjectSweepConfig(BaseModel):
     name: str
-    kind: Literal["agent_backtest"]
-    agent: str
+    kind: Literal["agent_backtest", "research_run"]
+    agent: Optional[str] = None
     parameters: List[ProjectSweepParameterConfig] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def validate_sweep(self) -> "ProjectSweepConfig":
         if not self.name.strip():
             raise ValueError("sweeps[].name must not be blank.")
-        if not self.agent.strip():
+        if self.kind == "agent_backtest" and (
+            self.agent is None or not self.agent.strip()
+        ):
             raise ValueError("sweeps[].agent must not be blank.")
         if not self.parameters:
             raise ValueError("sweeps[].parameters must define at least one parameter.")
@@ -987,7 +989,7 @@ class ProjectConfigSchema(BaseModel):
             if sweep.name in seen_sweeps:
                 raise ValueError(f"sweeps[].name '{sweep.name}' must be unique.")
             seen_sweeps.add(sweep.name)
-            if sweep.agent not in agent_names:
+            if sweep.kind == "agent_backtest" and sweep.agent not in agent_names:
                 raise ValueError(
                     f"sweeps[].agent '{sweep.agent}' must reference an existing agent."
                 )

--- a/quanttradeai/utils/config_validator.py
+++ b/quanttradeai/utils/config_validator.py
@@ -40,7 +40,7 @@ from quanttradeai.utils.project_config import (
     normalize_live_risk_compatibility,
     resolve_paper_replay_window,
 )
-from quanttradeai.utils.sweeps import expand_agent_backtest_sweep
+from quanttradeai.utils.sweeps import expand_agent_backtest_sweep, expand_research_sweep
 
 
 DEFAULT_CONFIG_PATHS: Dict[str, Path] = {
@@ -461,7 +461,16 @@ def _validate_project_sweeps(
     for sweep in resolved.get("sweeps") or []:
         sweep_name = str(sweep.get("name") or "").strip() or "<unnamed>"
         try:
-            expansion = expand_agent_backtest_sweep(resolved, sweep_name)
+            sweep_kind = str(sweep.get("kind") or "").strip()
+            if sweep_kind == "agent_backtest":
+                expansion = expand_agent_backtest_sweep(resolved, sweep_name)
+            elif sweep_kind == "research_run":
+                expansion = expand_research_sweep(resolved, sweep_name)
+            else:
+                errors.append(
+                    f"Sweep '{sweep_name}' has unsupported kind '{sweep_kind}'."
+                )
+                continue
         except ValueError as exc:
             errors.append(str(exc))
             continue

--- a/quanttradeai/utils/run_result.py
+++ b/quanttradeai/utils/run_result.py
@@ -96,6 +96,7 @@ def compact_cli_result(summary: dict[str, Any]) -> dict[str, Any]:
         for key in (
             "batch_type",
             "agent_count",
+            "variant_count",
             "success_count",
             "failure_count",
         ):
@@ -106,7 +107,9 @@ def compact_cli_result(summary: dict[str, Any]) -> dict[str, Any]:
             payload["sweep"] = _drop_none(
                 {
                     "name": sweep.get("name"),
+                    "kind": sweep.get("kind"),
                     "base_agent_name": sweep.get("base_agent_name"),
+                    "variant_count": sweep.get("variant_count"),
                 }
             )
     else:
@@ -279,6 +282,7 @@ def _compact_winner(winner: Any) -> dict[str, Any]:
         {
             "agent_name": winner.get("agent_name"),
             "run_id": winner.get("run_id"),
+            "parameters": winner.get("parameters"),
             "score": winner.get("score"),
         }
     )

--- a/quanttradeai/utils/sweeps.py
+++ b/quanttradeai/utils/sweeps.py
@@ -49,6 +49,10 @@ def _path_tokens(path: str) -> list[str]:
     return tokens
 
 
+def _is_existing_scalar_leaf(value: Any) -> bool:
+    return is_scalar_sweep_value(value)
+
+
 def resolve_agent_scalar_path(
     agent_config: dict[str, Any],
     path: str,
@@ -77,6 +81,129 @@ def resolve_agent_scalar_path(
     return current, leaf_key, leaf_value
 
 
+RESEARCH_SWEEP_DATA_LEAVES = {
+    "timeframe",
+    "start_date",
+    "end_date",
+    "test_start",
+    "test_end",
+    "cache_path",
+    "cache_dir",
+    "cache_expiration_days",
+    "use_cache",
+    "refresh",
+    "max_workers",
+}
+
+RESEARCH_SWEEP_RESEARCH_PATHS = {
+    ("research", "model", "tuning", "enabled"),
+    ("research", "model", "tuning", "trials"),
+    ("research", "evaluation", "use_configured_test_window"),
+}
+
+RESEARCH_SWEEP_RESEARCH_PREFIXES = {
+    ("research", "labels"),
+    ("research", "backtest", "costs"),
+}
+
+
+def _feature_definition_by_name(
+    project_config: dict[str, Any],
+    feature_name: str,
+) -> dict[str, Any] | None:
+    for definition in (project_config.get("features") or {}).get("definitions") or []:
+        if isinstance(definition, dict) and definition.get("name") == feature_name:
+            return definition
+    return None
+
+
+def _feature_path_parent(
+    project_config: dict[str, Any],
+    tokens: list[str],
+    path: str,
+) -> tuple[dict[str, Any], str, Any]:
+    if len(tokens) != 4 or tokens[0] != "features" or tokens[2] != "params":
+        raise ValueError(
+            f"Research sweep parameter path '{path}' must use features.<feature_name>.params.<param>."
+        )
+
+    feature_name = tokens[1]
+    feature_definition = _feature_definition_by_name(project_config, feature_name)
+    if feature_definition is None:
+        raise ValueError(
+            f"Research sweep parameter path '{path}' references unknown feature '{feature_name}'."
+        )
+
+    params = feature_definition.get("params")
+    if not isinstance(params, dict) or tokens[3] not in params:
+        raise ValueError(
+            f"Research sweep parameter path '{path}' must resolve to an existing feature params scalar leaf."
+        )
+
+    leaf_value = params[tokens[3]]
+    if not _is_existing_scalar_leaf(leaf_value):
+        raise ValueError(
+            f"Research sweep parameter path '{path}' must resolve to an existing scalar leaf."
+        )
+    return params, tokens[3], leaf_value
+
+
+def _generic_path_parent(
+    project_config: dict[str, Any],
+    tokens: list[str],
+    path: str,
+) -> tuple[dict[str, Any], str, Any]:
+    if tokens[0] == "data":
+        if len(tokens) != 2 or tokens[1] not in RESEARCH_SWEEP_DATA_LEAVES:
+            raise ValueError(
+                f"Research sweep parameter path '{path}' is not supported for data sweeps."
+            )
+    elif tuple(tokens) not in RESEARCH_SWEEP_RESEARCH_PATHS and not any(
+        tuple(tokens[: len(prefix)]) == prefix and len(tokens) == len(prefix) + 1
+        for prefix in RESEARCH_SWEEP_RESEARCH_PREFIXES
+    ):
+        raise ValueError(
+            f"Research sweep parameter path '{path}' is not supported. Use research label/cost/tuning/evaluation leaves, selected data leaves, or features.<feature_name>.params.<param>."
+        )
+
+    current: Any = project_config
+    for token in tokens[:-1]:
+        if not isinstance(current, dict) or token not in current:
+            raise ValueError(
+                f"Research sweep parameter path '{path}' must resolve to an existing scalar leaf."
+            )
+        current = current[token]
+
+    if not isinstance(current, dict) or tokens[-1] not in current:
+        raise ValueError(
+            f"Research sweep parameter path '{path}' must resolve to an existing scalar leaf."
+        )
+
+    leaf_key = tokens[-1]
+    leaf_value = current[leaf_key]
+    if not _is_existing_scalar_leaf(leaf_value):
+        raise ValueError(
+            f"Research sweep parameter path '{path}' must resolve to an existing scalar leaf."
+        )
+    return current, leaf_key, leaf_value
+
+
+def resolve_research_scalar_path(
+    project_config: dict[str, Any],
+    path: str,
+) -> tuple[dict[str, Any], str, Any]:
+    """Resolve a research sweep path against a project config."""
+
+    tokens = _path_tokens(path)
+    if tokens[0] == "features":
+        return _feature_path_parent(project_config, tokens, path)
+    if tokens[0] not in {"data", "research"}:
+        raise ValueError(
+            f"Research sweep parameter path '{path}' must start with data, research, or features."
+        )
+    return _generic_path_parent(project_config, tokens, path)
+
+
 def apply_agent_scalar_overrides(
     agent_config: dict[str, Any],
     overrides: dict[str, Any],
@@ -94,6 +221,23 @@ def apply_agent_scalar_overrides(
     return updated
 
 
+def apply_research_scalar_overrides(
+    project_config: dict[str, Any],
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a cloned project config with validated research overrides applied."""
+
+    updated = deepcopy(project_config)
+    for path, value in overrides.items():
+        if not is_scalar_sweep_value(value):
+            raise ValueError(
+                f"Research sweep parameter path '{path}' contains a non-scalar sweep value."
+            )
+        parent, leaf_key, _leaf_value = resolve_research_scalar_path(updated, path)
+        parent[leaf_key] = value
+    return updated
+
+
 def build_agent_sweep_variant_name(
     *,
     base_agent_name: str,
@@ -104,6 +248,24 @@ def build_agent_sweep_variant_name(
 
     parts = [
         _slugify_token(base_agent_name),
+        _slugify_token(sweep_name),
+    ]
+    for path, value in parameters.items():
+        leaf_name = _path_tokens(path)[-1]
+        parts.append(f"{_slugify_token(leaf_name)}-{slug_scalar_sweep_value(value)}")
+    return "__".join(parts)
+
+
+def build_research_sweep_variant_name(
+    *,
+    project_name: str,
+    sweep_name: str,
+    parameters: dict[str, Any],
+) -> str:
+    """Build a deterministic research sweep variant name."""
+
+    parts = [
+        _slugify_token(project_name),
         _slugify_token(sweep_name),
     ]
     for path, value in parameters.items():
@@ -206,6 +368,65 @@ def expand_agent_backtest_sweep(
         "name": sweep_name,
         "kind": "agent_backtest",
         "base_agent_name": base_agent_name,
+        "parameters": parameters,
+        "variants": variants,
+    }
+
+
+def expand_research_sweep(
+    project_config: dict[str, Any],
+    sweep_name: str,
+) -> dict[str, Any]:
+    """Expand a named research sweep into materialized project variants."""
+
+    sweep = resolve_project_sweep(project_config, sweep_name)
+    if str(sweep.get("kind") or "").strip() != "research_run":
+        raise ValueError(
+            f"Sweep '{sweep_name}' has unsupported kind '{sweep.get('kind')}'."
+        )
+
+    parameters = [dict(parameter) for parameter in (sweep.get("parameters") or [])]
+    if not parameters:
+        raise ValueError(f"Sweep '{sweep_name}' must define at least one parameter.")
+
+    parameter_paths: list[str] = []
+    parameter_values: list[list[Any]] = []
+    for parameter in parameters:
+        path = str(parameter.get("path") or "").strip()
+        values = list(parameter.get("values") or [])
+        if not values:
+            raise ValueError(
+                f"Sweep '{sweep_name}' parameter '{path or '<blank>'}' must define at least one value."
+            )
+        resolve_research_scalar_path(project_config, path)
+        parameter_paths.append(path)
+        parameter_values.append(values)
+
+    project_name = str((project_config.get("project") or {}).get("name") or "research")
+    variants: list[dict[str, Any]] = []
+    for combination in product(*parameter_values):
+        overrides = {
+            path: value
+            for path, value in zip(parameter_paths, combination, strict=True)
+        }
+        variant_project = apply_research_scalar_overrides(project_config, overrides)
+        variant_project.pop("sweeps", None)
+        variant_name = build_research_sweep_variant_name(
+            project_name=project_name,
+            sweep_name=sweep_name,
+            parameters=overrides,
+        )
+        variants.append(
+            {
+                "name": variant_name,
+                "parameters": dict(overrides),
+                "project_config": variant_project,
+            }
+        )
+
+    return {
+        "name": sweep_name,
+        "kind": "research_run",
         "parameters": parameters,
         "variants": variants,
     }

--- a/roadmap.md
+++ b/roadmap.md
@@ -367,6 +367,7 @@ Status on 2026-05-02:
 - `quanttradeai agent run --all -c config/project.yaml --mode backtest` is implemented for local multi-agent backtest batches, with bounded concurrency, preserved child runs, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 - `quanttradeai agent run --all -c config/project.yaml --mode paper` is implemented for local multi-agent paper batches, reusing the existing replay-backed paper path, preserving child runs under `runs/agent/paper/...`, and writing batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 - `quanttradeai agent run --sweep <name> -c config/project.yaml --mode backtest` is implemented for backtest-only parameter sweeps defined under `sweeps:` in `config/project.yaml`, with deterministic variant expansion, preserved child runs, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
+- `quanttradeai research run -c config/project.yaml --sweep <name>` is implemented for research parameter sweeps defined under `sweeps:` in `config/project.yaml`, with deterministic variant expansion, bounded concurrency, preserved child research runs, and sparse batch scoreboards under `runs/research/batches/...`.
 - `quanttradeai promote --run agent/backtest/<sweep_child_run_id> -c config/project.yaml` is implemented for materializing a winning sweep child into the base agent's canonical config and promoting that base agent to paper mode.
 - `quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>` is implemented for local multi-agent live batches, requiring an explicit project-name acknowledgement, live-mode agent configs, live runtime prerequisites, preserved child runs under `runs/agent/live/...`, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
 - `quanttradeai init --template strategy-lab -o config/project.yaml` is implemented as a YAML-only multi-strategy lab with `rsi_reversion`, `sma_trend`, replay-enabled paper settings, top-level risk/runtime defaults, and starter sweeps for RSI thresholds and SMA risk sizing.
@@ -420,6 +421,7 @@ Status on 2026-05-05:
 
 - Research, agent, batch, and sweep runs now attach sparse `run_result` analysis to `summary.json`, and completion-oriented CLI commands print one compact JSON object with `run_id`, `status`, `run_dir`, and derived metrics for coding-agent context.
 - Agent batch and sweep runs keep only the required high-level batch artifacts: `summary.json`, `results.json`, and `scoreboard.json`. Redundant experiment brief, text scoreboard, and batch manifest files are replaced by non-prescriptive `summary.json.run_result` ranking and failure summaries.
+- Research sweep batches also keep only sparse `summary.json`, `results.json`, and `scoreboard.json` artifacts while preserving normal child research runs.
 - `quanttradeai runs list --type batch --json` is implemented for local batch run discovery.
 
 ## Golden Workflows

--- a/tests/integration/test_backtest_model_method.py
+++ b/tests/integration/test_backtest_model_method.py
@@ -37,7 +37,9 @@ class FakeProcessor:
     def process_data(self, df: pd.DataFrame) -> pd.DataFrame:
         return df
 
-    def generate_labels(self, df: pd.DataFrame, forward_returns: int = 1, threshold: float = 0.0) -> pd.DataFrame:
+    def generate_labels(
+        self, df: pd.DataFrame, forward_returns: int = 1, threshold: float = 0.0
+    ) -> pd.DataFrame:
         df = df.copy()
         df["forward_returns"] = df["Close"].shift(-1) / df["Close"] - 1
         df["label"] = 0
@@ -87,6 +89,9 @@ def test_run_model_backtest_happy_path():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         model_cfg = _make_config(tmpdir)
+        features_cfg = os.path.join(tmpdir, "features_config.yaml")
+        with open(features_cfg, "w") as f:
+            yaml.safe_dump({}, f)
         # Ensure model directory exists
         model_dir = os.path.join(tmpdir, "fake_model")
         os.makedirs(model_dir, exist_ok=True)
@@ -114,29 +119,43 @@ def test_run_model_backtest_happy_path():
                 return fake_metrics_portfolio
             return fake_metrics_symbol
 
-        with patch("quanttradeai.main.DataLoader.fetch_data", return_value={"AAA": _mock_data()}), \
-            patch("quanttradeai.main.DataProcessor", FakeProcessor), \
-            patch("quanttradeai.main.MomentumClassifier", FakeClassifier), \
+        processor_paths: list[str | None] = []
+
+        class CapturingProcessor(FakeProcessor):
+            def __init__(self, *args, **kwargs):
+                processor_paths.append(args[0] if args else None)
+                super().__init__(*args, **kwargs)
+
+        with (
+            patch(
+                "quanttradeai.main.DataLoader.fetch_data",
+                return_value={"AAA": _mock_data()},
+            ),
+            patch("quanttradeai.main.DataProcessor", CapturingProcessor),
+            patch("quanttradeai.main.MomentumClassifier", FakeClassifier),
             patch(
                 "quanttradeai.main.simulate_trades",
                 return_value={
                     "AAA": fake_symbol_result,
                     "portfolio": fake_portfolio_result,
                 },
-            ) as mock_sim, \
+            ) as mock_sim,
             patch(
                 "quanttradeai.main.compute_metrics",
                 side_effect=_metrics_side_effect,
-            ) as mock_metrics:
+            ) as mock_metrics,
+        ):
 
             summary = run_model_backtest(
                 model_config=model_cfg,
                 model_path=model_dir,
+                features_config_path=features_cfg,
                 backtest_config=None,
                 skip_validation=True,
             )
 
         mock_sim.assert_called_once()
+        assert processor_paths == [features_cfg]
         kwargs = mock_sim.call_args.kwargs
         assert isinstance(kwargs["portfolio"], PortfolioManager)
         assert kwargs["portfolio"].initial_capital == 100_000.0
@@ -162,10 +181,15 @@ def test_run_model_backtest_missing_features_sets_error():
         model_dir = os.path.join(tmpdir, "fake_model")
         os.makedirs(model_dir, exist_ok=True)
 
-        with patch("quanttradeai.main.DataLoader.fetch_data", return_value={"AAA": _mock_data()}), \
-            patch("quanttradeai.main.DataProcessor", FakeProcessor), \
-            patch("quanttradeai.main.MomentumClassifier", MissingFeatureClassifier), \
-            patch("quanttradeai.main.simulate_trades") as mock_sim:
+        with (
+            patch(
+                "quanttradeai.main.DataLoader.fetch_data",
+                return_value={"AAA": _mock_data()},
+            ),
+            patch("quanttradeai.main.DataProcessor", FakeProcessor),
+            patch("quanttradeai.main.MomentumClassifier", MissingFeatureClassifier),
+            patch("quanttradeai.main.simulate_trades") as mock_sim,
+        ):
 
             summary = run_model_backtest(
                 model_config=model_cfg,
@@ -178,4 +202,3 @@ def test_run_model_backtest_missing_features_sets_error():
         assert "AAA" in summary
         assert "missing required features" in summary["AAA"]["error"].lower()
         assert "portfolio" not in summary
-

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -207,6 +207,37 @@ def test_validate_reports_sweep_count_for_valid_project(tmp_path: Path, monkeypa
     assert payload["summary"]["sweeps"] == 1
 
 
+def test_validate_accepts_research_run_sweep(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    config_payload["sweeps"] = [
+        {
+            "name": "rsi_research_grid",
+            "kind": "research_run",
+            "parameters": [
+                {"path": "research.labels.horizon", "values": [3, 5]},
+                {"path": "features.rsi_14.params.period", "values": [7, 14]},
+            ],
+        }
+    ]
+    cfg_path.write_text(
+        yaml.safe_dump(config_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
+
+    assert result.exit_code == 0, result.stdout
+    assert "sweeps=1" in result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    assert payload["summary"]["sweeps"] == 1
+
+
 def test_strategy_lab_template_includes_two_rule_agents_and_sweeps(
     tmp_path: Path, monkeypatch
 ):
@@ -1697,6 +1728,205 @@ def test_research_run_marks_placeholder_when_backtests_have_no_metrics(
 
     assert metrics_payload["status"] == "placeholder"
     assert metrics_payload["backtest_metrics_by_symbol"] == {}
+
+
+def test_research_run_sweep_writes_sparse_batch_and_child_runs(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    config_payload["research"]["backtest"]["costs"] = {"enabled": True, "bps": 5}
+    config_payload["sweeps"] = [
+        {
+            "name": "rsi_research_grid",
+            "kind": "research_run",
+            "parameters": [
+                {"path": "research.labels.horizon", "values": [3, 5]},
+                {"path": "features.rsi_14.params.period", "values": [7]},
+                {"path": "research.backtest.costs.bps", "values": [1, 5]},
+            ],
+        }
+    ]
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(yaml.safe_dump(config_payload, sort_keys=False), "utf-8")
+
+    def _fake_pipeline(config_path, *args, **kwargs):
+        runtime_cfg = yaml.safe_load(Path(config_path).read_text("utf-8"))
+        experiment_dir = Path(kwargs["experiment_dir"])
+        experiment_dir.mkdir(parents=True, exist_ok=True)
+        (experiment_dir / "AAPL").mkdir(parents=True, exist_ok=True)
+        (experiment_dir / "results.json").write_text("{}", encoding="utf-8")
+        (experiment_dir / "test_window_coverage.json").write_text(
+            "{}", encoding="utf-8"
+        )
+        (experiment_dir / "preprocessing.json").write_text("{}", encoding="utf-8")
+        horizon = runtime_cfg["labels"]["horizon"]
+        return {
+            "results": {"AAPL": {"test_metrics": {"accuracy": horizon / 10.0}}},
+            "coverage": {
+                "path": str(experiment_dir / "test_window_coverage.json"),
+                "fallback_symbols": [],
+            },
+            "experiment_dir": str(experiment_dir),
+            "preprocessing": str(experiment_dir / "preprocessing.json"),
+        }
+
+    def _fake_backtest(**kwargs):
+        runtime_features = yaml.safe_load(
+            Path(kwargs["features_config_path"]).read_text("utf-8")
+        )
+        runtime_backtest = yaml.safe_load(
+            Path(kwargs["backtest_config"]).read_text("utf-8")
+        )
+        assert runtime_features["momentum_features"]["rsi_period"] == 7
+        bps = runtime_backtest["execution"]["transaction_costs"]["value"]
+        return {"AAPL": {"metrics": {"net_sharpe": 10.0 - float(bps), "net_pnl": 0.1}}}
+
+    monkeypatch.setattr("quanttradeai.cli.run_pipeline", _fake_pipeline)
+    monkeypatch.setattr("quanttradeai.cli.run_model_backtest", _fake_backtest)
+
+    result = runner.invoke(
+        app,
+        [
+            "research",
+            "run",
+            "--config",
+            str(cfg_path),
+            "--sweep",
+            "rsi_research_grid",
+            "--max-concurrency",
+            "2",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    batch_dir = Path(payload["run_dir"])
+    assert payload["run_type"] == "batch"
+    assert payload["mode"] == "research"
+    assert payload["run_id"] == f"research/batches/{batch_dir.name}"
+    assert payload["variant_count"] == 4
+    assert payload["winner"]["parameters"]["research.backtest.costs.bps"] == 1
+    assert payload["sweep"]["variant_count"] == 4
+    assert (batch_dir / "summary.json").is_file()
+    assert (batch_dir / "results.json").is_file()
+    assert (batch_dir / "scoreboard.json").is_file()
+    assert not (batch_dir / "batch_manifest.json").exists()
+    assert not (batch_dir / "scoreboard.txt").exists()
+    assert not (batch_dir / "experiment_brief.json").exists()
+
+    results_payload = json.loads((batch_dir / "results.json").read_text("utf-8"))
+    scoreboard_payload = json.loads((batch_dir / "scoreboard.json").read_text("utf-8"))
+    assert results_payload["batch_type"] == "research_sweep"
+    assert results_payload["scoreboard_sort_by"] == "net_sharpe"
+    assert scoreboard_payload["sort_by"] == "net_sharpe"
+    assert len(results_payload["results"]) == 4
+    assert (
+        results_payload["results"][0]["parameters"]["research.backtest.costs.bps"] == 1
+    )
+    assert results_payload["results"][0]["scoreboard"]["net_sharpe"] == 9.0
+
+    for entry in results_payload["results"]:
+        run_dir = Path(entry["run_dir"])
+        runtime_model = yaml.safe_load(
+            (run_dir / "runtime_model_config.yaml").read_text("utf-8")
+        )
+        runtime_features = yaml.safe_load(
+            (run_dir / "runtime_features_config.yaml").read_text("utf-8")
+        )
+        runtime_backtest = yaml.safe_load(
+            (run_dir / "runtime_backtest_config.yaml").read_text("utf-8")
+        )
+        assert (
+            runtime_model["labels"]["horizon"]
+            == entry["parameters"]["research.labels.horizon"]
+        )
+        assert (
+            runtime_features["momentum_features"]["rsi_period"]
+            == entry["parameters"]["features.rsi_14.params.period"]
+        )
+        assert (
+            runtime_backtest["execution"]["transaction_costs"]["value"]
+            == entry["parameters"]["research.backtest.costs.bps"]
+        )
+        assert (run_dir / "summary.json").is_file()
+        assert Path(entry["artifacts"]["experiment_dir"]).is_dir()
+
+    runs_result = runner.invoke(app, ["runs", "list", "--type", "batch", "--json"])
+    assert runs_result.exit_code == 0, runs_result.stdout
+    run_records = json.loads(runs_result.stdout)
+    assert run_records[0]["run_id"] == f"research/batches/{batch_dir.name}"
+
+
+def test_research_run_sweep_falls_back_to_accuracy_scoreboard(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = Path("config/project.yaml")
+
+    config_payload = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    config_payload["sweeps"] = [
+        {
+            "name": "label_grid",
+            "kind": "research_run",
+            "parameters": [
+                {"path": "research.labels.horizon", "values": [3, 5]},
+            ],
+        }
+    ]
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(yaml.safe_dump(config_payload, sort_keys=False), "utf-8")
+
+    def _fake_pipeline(config_path, *args, **kwargs):
+        runtime_cfg = yaml.safe_load(Path(config_path).read_text("utf-8"))
+        experiment_dir = Path(kwargs["experiment_dir"])
+        experiment_dir.mkdir(parents=True, exist_ok=True)
+        (experiment_dir / "AAPL").mkdir(parents=True, exist_ok=True)
+        (experiment_dir / "results.json").write_text("{}", encoding="utf-8")
+        (experiment_dir / "test_window_coverage.json").write_text(
+            "{}", encoding="utf-8"
+        )
+        horizon = runtime_cfg["labels"]["horizon"]
+        return {
+            "results": {"AAPL": {"test_metrics": {"accuracy": horizon / 10.0}}},
+            "coverage": {
+                "path": str(experiment_dir / "test_window_coverage.json"),
+                "fallback_symbols": [],
+            },
+            "experiment_dir": str(experiment_dir),
+        }
+
+    monkeypatch.setattr("quanttradeai.cli.run_pipeline", _fake_pipeline)
+    monkeypatch.setattr(
+        "quanttradeai.cli.run_model_backtest",
+        lambda **kwargs: {"AAPL": {"error": "no metrics"}},
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "research",
+            "run",
+            "--config",
+            str(cfg_path),
+            "--sweep",
+            "label_grid",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    batch_dir = Path(payload["run_dir"])
+    results_payload = json.loads((batch_dir / "results.json").read_text("utf-8"))
+    assert results_payload["scoreboard_sort_by"] == "accuracy"
+    assert results_payload["results"][0]["parameters"]["research.labels.horizon"] == 5
+    assert results_payload["results"][0]["scoreboard"]["accuracy"] == 0.5
 
 
 def test_research_run_forwards_label_settings_to_runtime_model_config(

--- a/tests/utils/test_run_result.py
+++ b/tests/utils/test_run_result.py
@@ -181,6 +181,7 @@ def test_batch_sweep_winner_failures_and_compact_output_are_sparse():
         "winner": {
             "agent_name": "high",
             "run_id": "agent/backtest/high",
+            "parameters": {"rule.buy_below": 25.0},
             "score": 2.5,
         },
         "batch_type": "sweep",

--- a/tests/utils/test_sweeps.py
+++ b/tests/utils/test_sweeps.py
@@ -1,7 +1,11 @@
 import yaml
+import pytest
 
 from quanttradeai.cli import PROJECT_TEMPLATES
-from quanttradeai.utils.sweeps import expand_agent_backtest_sweep
+from quanttradeai.utils.sweeps import (
+    expand_agent_backtest_sweep,
+    expand_research_sweep,
+)
 
 
 def test_expand_agent_backtest_sweep_builds_cartesian_variants_with_deterministic_names():
@@ -62,3 +66,84 @@ def test_strategy_lab_sma_risk_sweep_expands_against_sma_agent():
     assert expansion["variants"][0]["agent_config"]["risk"] == {
         "max_position_pct": 0.03
     }
+
+
+def test_expand_research_sweep_builds_cartesian_variants_and_feature_params():
+    project_cfg = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    project_cfg["research"]["backtest"]["costs"] = {"enabled": True, "bps": 5}
+    project_cfg["sweeps"] = [
+        {
+            "name": "rsi_research_grid",
+            "kind": "research_run",
+            "parameters": [
+                {"path": "research.labels.horizon", "values": [3, 5]},
+                {"path": "features.rsi_14.params.period", "values": [7, 14]},
+                {"path": "research.backtest.costs.bps", "values": [1]},
+            ],
+        }
+    ]
+
+    expansion = expand_research_sweep(project_cfg, "rsi_research_grid")
+
+    assert expansion["kind"] == "research_run"
+    assert [variant["name"] for variant in expansion["variants"]] == [
+        "research_lab__rsi_research_grid__horizon-3__period-7__bps-1",
+        "research_lab__rsi_research_grid__horizon-3__period-14__bps-1",
+        "research_lab__rsi_research_grid__horizon-5__period-7__bps-1",
+        "research_lab__rsi_research_grid__horizon-5__period-14__bps-1",
+    ]
+    first_variant = expansion["variants"][0]["project_config"]
+    assert first_variant["research"]["labels"]["horizon"] == 3
+    assert first_variant["research"]["backtest"]["costs"]["bps"] == 1
+    assert first_variant["features"]["definitions"][0]["params"]["period"] == 7
+    assert "sweeps" not in first_variant
+
+
+def test_expand_research_sweep_rejects_unknown_feature_path():
+    project_cfg = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    project_cfg["sweeps"] = [
+        {
+            "name": "bad_grid",
+            "kind": "research_run",
+            "parameters": [{"path": "features.missing.params.period", "values": [7]}],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="unknown feature"):
+        expand_research_sweep(project_cfg, "bad_grid")
+
+
+def test_expand_research_sweep_rejects_empty_values():
+    project_cfg = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    project_cfg["sweeps"] = [
+        {
+            "name": "empty_grid",
+            "kind": "research_run",
+            "parameters": [{"path": "research.labels.horizon", "values": []}],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="at least one value"):
+        expand_research_sweep(project_cfg, "empty_grid")
+
+
+def test_expand_research_sweep_rejects_non_scalar_leaf():
+    project_cfg = yaml.safe_load(
+        yaml.safe_dump(PROJECT_TEMPLATES["research"], sort_keys=False)
+    )
+    project_cfg["sweeps"] = [
+        {
+            "name": "non_scalar_grid",
+            "kind": "research_run",
+            "parameters": [{"path": "data.symbols", "values": ["AAPL"]}],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="not supported"):
+        expand_research_sweep(project_cfg, "non_scalar_grid")


### PR DESCRIPTION
## Summary
- Add `research_run` sweeps to canonical `config/project.yaml` and validate expanded variants in memory.
- Extend `quanttradeai research run` with `--sweep` and bounded `--max-concurrency`, writing sparse batch artifacts plus normal child research runs.
- Reuse runtime feature configs during research backtests so sweep scoreboards can rank by `net_sharpe` when available.
- Include sweep variant count and winning parameters in compact batch JSON for coding-agent consumption.
- Update docs and roadmap references for research sweeps.

## CLI self-test
- Ran an isolated temp project with cached synthetic AAPL data and a 4-variant `rsi_research_grid`.
- `validate` reported the canonical project summary and resolved config artifacts.
- `research run --sweep rsi_research_grid --max-concurrency 2` returned compact JSON with status, batch dir, `scoreboard_sort_by=net_sharpe`, winner params, and `variant_count=4`.
- `results.json` contained each variant's parameters, child run dirs, runtime configs, metrics, and artifact paths; `scoreboard.json` ranked child runs by `net_sharpe`.
- Removed the temp CLI artifacts after verification.

## Verification
- `poetry run pytest tests/utils/test_run_result.py tests/integration/test_backtest_model_method.py tests/utils/test_sweeps.py tests/test_project_config_cli.py tests/integration/test_runs_cli.py -q`
- `make lint.format.test`
- `poetry check`