### PR TITLE
feat: add agent-native workspace init

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ QuantTradeAI is a YAML-first, CLI-first framework for traders, researchers, and 
 [Getting Started](docs/getting-started.md) | [Project YAML](docs/configuration/project-yaml.md) | [Quick Reference](docs/quick-reference.md) | [Configuration](docs/configuration.md) | [Roadmap](roadmap.md) | [Contributing](CONTRIBUTING.md)
 
 > [!TIP]
-> New users should start with `config/project.yaml`. It is the canonical entrypoint for `init`, `validate`, `research run`, and `agent run`.
+> New users should run `quanttradeai init [PROJECT_DIR]`. It creates `config/project.yaml` plus agent guidance files so Claude Code, Cursor, Codex, and similar tools know how to use the CLI and YAML workflow.
 
 ## Start Here
 
@@ -101,7 +101,12 @@ poetry install --with dev
 poetry run quanttradeai --help
 ```
 
-If you prefer a package install, `pip install .` also works.
+If you prefer a package install, `pip install .` also works. After installing, initialize a workspace and open that folder in your coding agent:
+
+```bash
+quanttradeai init my-lab
+cd my-lab
+```
 
 ## Fastest Working Paths
 
@@ -114,7 +119,7 @@ If you want real broker submission for happy-path paper or live runs, set `agent
 Use this if you want the simplest end-to-end quant workflow.
 
 ```bash
-poetry run quanttradeai init --template research -o config/project.yaml
+poetry run quanttradeai init --template research
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml --sweep <sweep_name> --max-concurrency 4
@@ -143,7 +148,7 @@ poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 Use this if you want the smallest deterministic agent workflow with no LLM dependency.
 
 ```bash
-poetry run quanttradeai init --template rule-agent -o config/project.yaml
+poetry run quanttradeai init --template rule-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
@@ -173,7 +178,7 @@ agents:
 Use this when you want a ready-made QuantTradeAI lab that can compare more than one deterministic strategy from YAML.
 
 ```bash
-poetry run quanttradeai init --template strategy-lab -o config/project.yaml
+poetry run quanttradeai init --template strategy-lab
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest --max-concurrency 4
@@ -204,7 +209,7 @@ agents:
 Use this if you already have a trained model artifact and want one YAML-defined agent that can run in backtest, paper, and live mode.
 
 ```bash
-poetry run quanttradeai init --template model-agent -o config/project.yaml
+poetry run quanttradeai init --template model-agent
 poetry run quanttradeai validate -c config/project.yaml
 
 # Replace models/promoted/aapl_daily_classifier/ with a real trained model artifact
@@ -224,7 +229,7 @@ poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml 
 Use this if you want prompt-driven agent logic from YAML and want to move the same agent definition from backtest into paper and live mode.
 
 ```bash
-poetry run quanttradeai init --template llm-agent -o config/project.yaml
+poetry run quanttradeai init --template llm-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
@@ -238,7 +243,7 @@ poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --
 Use this if you want to combine trained model signals and LLM reasoning in one project and then promote the same agent through paper and live mode.
 
 ```bash
-poetry run quanttradeai init --template hybrid -o config/project.yaml
+poetry run quanttradeai init --template hybrid
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,13 +30,13 @@ poetry install
 ### Basic Usage
 ```bash
 # Canonical project workflow
-poetry run quanttradeai init --template research -o config/project.yaml
+poetry run quanttradeai init --template research
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai runs list
 
 # Runnable agent workflow
-poetry run quanttradeai init --template llm-agent -o config/project.yaml
+poetry run quanttradeai init --template llm-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 poetry run quanttradeai agent run --all -c config/project.yaml --mode paper

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ Use it for:
 ### Research
 
 ```bash
-poetry run quanttradeai init --template research -o config/project.yaml
+poetry run quanttradeai init --template research
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai runs list
@@ -41,7 +41,7 @@ poetry run quanttradeai runs list
 ### Agent Backtest
 
 ```bash
-poetry run quanttradeai init --template llm-agent -o config/project.yaml
+poetry run quanttradeai init --template llm-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml

--- a/docs/configuration/legacy-configs.md
+++ b/docs/configuration/legacy-configs.md
@@ -17,7 +17,7 @@ Use the canonical `config/project.yaml` workflow instead.
 | --- | --- |
 | `quanttradeai train` | `quanttradeai research run -c config/project.yaml` |
 | `quanttradeai validate-config` | `quanttradeai validate -c config/project.yaml` |
-| `quanttradeai backtest-model` | `quanttradeai init --template model-agent -o config/project.yaml` -> set `agents[].model.path` -> `quanttradeai agent run --agent <name> -c config/project.yaml --mode backtest` |
+| `quanttradeai backtest-model` | `quanttradeai init --template model-agent` -> set `agents[].model.path` -> `quanttradeai agent run --agent <name> -c config/project.yaml --mode backtest` |
 | `quanttradeai live-trade` | `quanttradeai agent run --agent <name> -c config/project.yaml --mode live` |
 | `validate --legacy-config-dir ...` | create or commit `config/project.yaml`, then run `quanttradeai validate -c config/project.yaml` |
 | `research run --legacy-config-dir ...` | create or commit `config/project.yaml`, then run `quanttradeai research run -c config/project.yaml` |
@@ -25,7 +25,7 @@ Use the canonical `config/project.yaml` workflow instead.
 ## Recommended Migration Path
 
 1. Initialize the closest template:
-   `quanttradeai init --template research|model-agent|llm-agent|hybrid -o config/project.yaml`
+   `quanttradeai init --template research|model-agent|llm-agent|hybrid`
 2. Move the settings you still need into `config/project.yaml`.
 3. For model agents, point `agents[].model.path` at a stable promoted model directory under `models/promoted/...`.
 4. Run `quanttradeai validate -c config/project.yaml`.

--- a/docs/configuration/project-yaml.md
+++ b/docs/configuration/project-yaml.md
@@ -2,6 +2,8 @@
 
 `config/project.yaml` is the canonical config entrypoint for QuantTradeAI.
 
+`quanttradeai init [PROJECT_DIR]` creates a workspace with this file at `config/project.yaml`. If `PROJECT_DIR` is omitted, the current directory is initialized. The default template is `strategy-lab`; use `--template research|strategy-lab|rule-agent|model-agent|llm-agent|hybrid` to choose another starter.
+
 It drives:
 
 - `quanttradeai init`
@@ -23,7 +25,7 @@ If an agent sets `execution.backend: alpaca`, QuantTradeAI switches paper/live e
 ### Research
 
 ```bash
-poetry run quanttradeai init --template research -o config/project.yaml
+poetry run quanttradeai init --template research
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml --sweep rsi_research_grid --max-concurrency 4
@@ -33,7 +35,7 @@ poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 ### Strategy Lab
 
 ```bash
-poetry run quanttradeai init --template strategy-lab -o config/project.yaml
+poetry run quanttradeai init --template strategy-lab
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest --max-concurrency 4
@@ -47,7 +49,7 @@ The `strategy-lab` template defines two deterministic rule agents, `rsi_reversio
 ### Model Agents
 
 ```bash
-poetry run quanttradeai init --template model-agent -o config/project.yaml
+poetry run quanttradeai init --template model-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
@@ -61,7 +63,7 @@ The `model-agent` template also creates a placeholder model artifact at `models/
 ### Rule Agents
 
 ```bash
-poetry run quanttradeai init --template rule-agent -o config/project.yaml
+poetry run quanttradeai init --template rule-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
@@ -73,7 +75,7 @@ poetry run quanttradeai agent run --agent rsi_reversion -c config/project.yaml -
 ### LLM And Hybrid Agents
 
 ```bash
-poetry run quanttradeai init --template llm-agent -o config/project.yaml
+poetry run quanttradeai init --template llm-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
@@ -87,7 +89,7 @@ The `llm-agent` and `hybrid` templates also create starter prompt files under `p
 Hybrid projects add the research promotion handoff before agent runs:
 
 ```bash
-poetry run quanttradeai init --template hybrid -o config/project.yaml
+poetry run quanttradeai init --template hybrid
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml

--- a/docs/examples/execution-costs.md
+++ b/docs/examples/execution-costs.md
@@ -3,7 +3,7 @@
 Run a model agent backtest from `config/project.yaml`, then compare it with a second run after increasing `research.backtest.costs.bps`.
 
 ```bash
-poetry run quanttradeai init --template model-agent -o config/project.yaml
+poetry run quanttradeai init --template model-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,10 +10,19 @@ cd QuantTradeAI
 poetry install --with dev
 ```
 
+For a package install, initialize a workspace and open that folder in your coding agent:
+
+```bash
+quanttradeai init my-lab
+cd my-lab
+```
+
+`quanttradeai init` writes `config/project.yaml`, `AGENTS.md`, `CLAUDE.md`, and the project skill under `.claude/skills/quanttradeai-research/`.
+
 ## Workflow 1: Research From `project.yaml`
 
 ```bash
-poetry run quanttradeai init --template research -o config/project.yaml
+poetry run quanttradeai init --template research
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai runs list
@@ -40,7 +49,7 @@ poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
 Use this when you want one QuantTradeAI project with multiple deterministic strategies, reusable sweeps, and promotion-ready run records without writing Python or setting LLM/broker credentials.
 
 ```bash
-poetry run quanttradeai init --template strategy-lab -o config/project.yaml
+poetry run quanttradeai init --template strategy-lab
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest --max-concurrency 4
@@ -66,7 +75,7 @@ poetry run quanttradeai agent run --agent <base_agent_name> -c config/project.ya
 ## Workflow 3: Model Agent From `project.yaml`
 
 ```bash
-poetry run quanttradeai init --template model-agent -o config/project.yaml
+poetry run quanttradeai init --template model-agent
 poetry run quanttradeai validate -c config/project.yaml
 ```
 
@@ -129,7 +138,7 @@ Live runs also write compiled `runtime_risk_config.yaml` and `runtime_position_m
 LLM and hybrid agents are supported in backtest, paper, and live mode from `project.yaml`.
 
 ```bash
-poetry run quanttradeai init --template llm-agent -o config/project.yaml
+poetry run quanttradeai init --template llm-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
@@ -141,7 +150,7 @@ poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --
 Hybrid projects use the same pattern:
 
 ```bash
-poetry run quanttradeai init --template hybrid -o config/project.yaml
+poetry run quanttradeai init --template hybrid
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai research run -c config/project.yaml
 poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -30,7 +30,7 @@ agents:
 poetry run quanttradeai --help
 
 # Initialize and validate canonical project config
-poetry run quanttradeai init --template research -o config/project.yaml
+poetry run quanttradeai init --template research
 poetry run quanttradeai validate -c config/project.yaml
 
 # Run canonical research workflow
@@ -43,7 +43,7 @@ poetry run quanttradeai runs list --compare research/<run_id_a> --compare resear
 poetry run quanttradeai runs list --compare agent/backtest/<run_id_a> --compare agent/backtest/<run_id_b> --sort-by net_sharpe
 
 # Start a YAML-only strategy lab with RSI and SMA rule agents
-poetry run quanttradeai init --template strategy-lab -o config/project.yaml
+poetry run quanttradeai init --template strategy-lab
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
 poetry run quanttradeai agent run --sweep rsi_threshold_grid -c config/project.yaml --mode backtest --max-concurrency 4
@@ -52,7 +52,7 @@ poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
 poetry run quanttradeai promote --run agent/backtest/<winner_run_id> -c config/project.yaml
 
 # Run a YAML-defined llm or hybrid agent
-poetry run quanttradeai init --template llm-agent -o config/project.yaml
+poetry run quanttradeai init --template llm-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
 # Promote the successful backtest run before starting paper mode
@@ -258,7 +258,7 @@ metrics = compute_metrics(df_trades, risk_free_rate=0.02)
 ### Backtest a Model Agent
 ```bash
 # Use the model-agent template and point agents[].model.path at a promoted model
-poetry run quanttradeai init --template model-agent -o config/project.yaml
+poetry run quanttradeai init --template model-agent
 poetry run quanttradeai validate -c config/project.yaml
 poetry run quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
 

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -733,7 +733,14 @@ def _format_path_list(paths: list[Path]) -> str:
     return ", ".join(path.as_posix() for path in paths)
 
 
-def _check_can_write(paths: list[Path], force: bool) -> None:
+def _init_overwrite_guard_paths(project_config_path: Path) -> list[Path]:
+    workspace = infer_project_root(project_config_path)
+    return [project_config_path, workspace / ".quanttradeai" / "workspace.yaml"]
+
+
+def _check_can_write(
+    paths: list[Path], force: bool, overwrite_guard_paths: list[Path] | None = None
+) -> None:
     blocking_dirs = [path for path in paths if path.exists() and path.is_dir()]
     if blocking_dirs:
         raise ValueError(
@@ -741,7 +748,8 @@ def _check_can_write(paths: list[Path], force: bool) -> None:
             f"{_format_path_list(blocking_dirs)}"
         )
 
-    existing = [path for path in paths if path.exists()]
+    guarded_paths = overwrite_guard_paths or paths
+    existing = [path for path in guarded_paths if path.exists()]
     if existing and not force:
         raise ValueError(
             "Refusing to overwrite existing QuantTradeAI file(s): "
@@ -755,14 +763,16 @@ def _write_project_template(template_name: str, project_config_path: Path) -> No
         yaml.safe_dump(PROJECT_TEMPLATES[template_name], handle, sort_keys=False)
 
 
-def _write_text_file(path: Path, content: str) -> None:
+def _write_text_file(path: Path, content: str, force: bool = True) -> None:
+    if path.exists() and not force:
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content.strip() + "\n", encoding="utf-8")
 
 
-def _write_agent_context_files(workspace: Path) -> None:
+def _write_agent_context_files(workspace: Path, force: bool) -> None:
     for relative_path, content in INIT_CONTEXT_FILES.items():
-        _write_text_file(workspace / relative_path, content)
+        _write_text_file(workspace / relative_path, content, force=force)
 
 
 def _write_workspace_metadata(workspace: Path, template_name: str) -> None:
@@ -1846,16 +1856,21 @@ def cmd_init(
 
     project_config_path = _project_config_path(workspace)
     owned_paths = _init_owned_paths(normalized, project_config_path)
+    overwrite_guard_paths = _init_overwrite_guard_paths(project_config_path)
 
     try:
-        _check_can_write(owned_paths, force=force)
+        _check_can_write(
+            owned_paths,
+            force=force,
+            overwrite_guard_paths=overwrite_guard_paths,
+        )
     except ValueError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1)
 
     workspace.mkdir(parents=True, exist_ok=True)
     _write_project_template(normalized, project_config_path)
-    _write_agent_context_files(workspace)
+    _write_agent_context_files(workspace, force=force)
     _write_workspace_metadata(workspace, normalized)
     _write_template_assets(normalized, project_config_path, force)
 

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -16,6 +16,8 @@ from typing import Any, Optional
 
 import typer
 import yaml
+
+from .init_context import INIT_CONTEXT_FILES
 from .utils.config_validator import validate_project_config
 from .utils.project_paths import infer_project_root
 from .utils.project_config import (
@@ -698,6 +700,87 @@ def _write_template_assets(template_name: str, output_path: Path, force: bool) -
             continue
         asset_path.parent.mkdir(parents=True, exist_ok=True)
         asset_path.write_text(content.strip() + "\n", encoding="utf-8")
+
+
+def _resolve_init_workspace(project_dir: Path | None) -> Path:
+    if project_dir is None:
+        return Path.cwd().resolve()
+    return project_dir.expanduser().resolve()
+
+
+def _project_config_path(workspace: Path) -> Path:
+    return workspace / "config" / "project.yaml"
+
+
+def _template_asset_paths(template_name: str, project_config_path: Path) -> list[Path]:
+    project_root = infer_project_root(project_config_path)
+    return [
+        project_root / relative_path
+        for relative_path in PROJECT_TEMPLATE_PROMPTS.get(template_name, {})
+    ]
+
+
+def _init_owned_paths(template_name: str, project_config_path: Path) -> list[Path]:
+    workspace = infer_project_root(project_config_path)
+    paths = [project_config_path]
+    paths.extend(workspace / relative_path for relative_path in INIT_CONTEXT_FILES)
+    paths.append(workspace / ".quanttradeai" / "workspace.yaml")
+    paths.extend(_template_asset_paths(template_name, project_config_path))
+    return list(dict.fromkeys(paths))
+
+
+def _format_path_list(paths: list[Path]) -> str:
+    return ", ".join(path.as_posix() for path in paths)
+
+
+def _check_can_write(paths: list[Path], force: bool) -> None:
+    blocking_dirs = [path for path in paths if path.exists() and path.is_dir()]
+    if blocking_dirs:
+        raise ValueError(
+            "Cannot initialize because generated file path is a directory: "
+            f"{_format_path_list(blocking_dirs)}"
+        )
+
+    existing = [path for path in paths if path.exists()]
+    if existing and not force:
+        raise ValueError(
+            "Refusing to overwrite existing QuantTradeAI file(s): "
+            f"{_format_path_list(existing)}. Run again with --force to overwrite them."
+        )
+
+
+def _write_project_template(template_name: str, project_config_path: Path) -> None:
+    project_config_path.parent.mkdir(parents=True, exist_ok=True)
+    with project_config_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(PROJECT_TEMPLATES[template_name], handle, sort_keys=False)
+
+
+def _write_text_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.strip() + "\n", encoding="utf-8")
+
+
+def _write_agent_context_files(workspace: Path) -> None:
+    for relative_path, content in INIT_CONTEXT_FILES.items():
+        _write_text_file(workspace / relative_path, content)
+
+
+def _write_workspace_metadata(workspace: Path, template_name: str) -> None:
+    metadata = {
+        "version": 1,
+        "template": template_name,
+        "project_config": "config/project.yaml",
+        "agent_context": {
+            "agents_md": "AGENTS.md",
+            "claude_md": "CLAUDE.md",
+            "skill": ".claude/skills/quanttradeai-research/SKILL.md",
+        },
+        "created_by": "quanttradeai",
+    }
+    metadata_path = workspace / ".quanttradeai" / "workspace.yaml"
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    with metadata_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(metadata, handle, sort_keys=False)
 
 
 @app.command("fetch-data")
@@ -1739,37 +1822,45 @@ def cmd_agent_run(
 
 @app.command("init")
 def cmd_init(
+    project_dir: Optional[Path] = typer.Argument(
+        None, help="Workspace directory to initialize"
+    ),
     template: str = typer.Option(
-        ..., "--template", help="Project template to initialize"
+        "strategy-lab", "--template", help="Project template to initialize"
     ),
-    output: str = typer.Option(
-        "config/project.yaml",
-        "-o",
-        "--output",
-        help="Path for generated project config",
-    ),
-    force: bool = typer.Option(False, "--force", help="Overwrite existing file"),
+    force: bool = typer.Option(False, "--force", help="Overwrite generated files"),
 ):
-    """Initialize a canonical project config for the happy path."""
-
-    import yaml
+    """Initialize a QuantTradeAI workspace."""
 
     normalized = template.lower()
     if normalized not in PROJECT_TEMPLATES:
         valid = ", ".join(sorted(PROJECT_TEMPLATES))
         raise typer.BadParameter(f"template must be one of: {valid}")
 
-    output_path = Path(output)
-    if output_path.exists() and not force:
-        typer.echo(f"Refusing to overwrite existing file: {output_path}", err=True)
+    workspace = _resolve_init_workspace(project_dir)
+    if workspace.exists() and not workspace.is_dir():
+        typer.echo(
+            f"Workspace path exists and is not a directory: {workspace}", err=True
+        )
         raise typer.Exit(code=1)
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8") as handle:
-        yaml.safe_dump(PROJECT_TEMPLATES[normalized], handle, sort_keys=False)
-    _write_template_assets(normalized, output_path, force)
+    project_config_path = _project_config_path(workspace)
+    owned_paths = _init_owned_paths(normalized, project_config_path)
 
-    typer.echo(f"Wrote {normalized} template to {output_path}")
+    try:
+        _check_can_write(owned_paths, force=force)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
+
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_project_template(normalized, project_config_path)
+    _write_agent_context_files(workspace)
+    _write_workspace_metadata(workspace, normalized)
+    _write_template_assets(normalized, project_config_path, force)
+
+    typer.echo(f"Initialized QuantTradeAI workspace at {workspace}")
+    typer.echo(f"Wrote {normalized} template to {project_config_path}")
 
 
 @app.command("validate")

--- a/quanttradeai/init_context.py
+++ b/quanttradeai/init_context.py
@@ -1,0 +1,246 @@
+# flake8: noqa: E501
+"""Generated workspace guidance files for `quanttradeai init`."""
+
+AGENTS_MD_CONTENT = """# QuantTradeAI Workspace
+
+This is a QuantTradeAI workspace for running strategy research and agent workflows through the `quanttradeai` CLI and YAML.
+
+## Primary Interface
+
+- Treat `config/project.yaml` as the canonical project file.
+- Prefer editing YAML and running QuantTradeAI CLI commands over writing custom Python scripts.
+- Run `quanttradeai validate -c config/project.yaml` after every YAML change.
+- Do not edit QuantTradeAI package or framework internals unless the human explicitly asks to modify QuantTradeAI itself.
+
+## Default Workflow
+
+- Default to `backtest` and replay-backed `paper` workflows.
+- Never run `live` mode, broker-backed execution, or live deployment unless the human explicitly asks for it.
+- Prefer sweeps and batch runs for strategy research and optimization.
+- Use `quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4` for batch backtests.
+- Use `quanttradeai agent run --sweep <sweep_name> -c config/project.yaml --mode backtest --max-concurrency 4` for configured sweeps.
+- Promote only successful runs after reviewing their artifacts.
+
+## Artifact Review
+
+- Do not rely only on terminal output when making recommendations.
+- Inspect machine-readable artifacts before summarizing results.
+- Read `summary.json.run_result` first for a single run.
+- Read `scoreboard.json` for rankings across batch or sweep runs.
+- Read `metrics.json` and `results.json` to validate the ranking details.
+- Compare top runs before recommending a winner.
+- Explain recommendations using metrics, assumptions, and tradeoffs from the artifacts.
+
+## Useful Commands
+
+```bash
+quanttradeai validate -c config/project.yaml
+quanttradeai research run -c config/project.yaml
+quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
+quanttradeai agent run --sweep <sweep_name> -c config/project.yaml --mode backtest --max-concurrency 4
+quanttradeai runs list --scoreboard --sort-by net_sharpe
+quanttradeai promote --run agent/backtest/<winning_run_id> -c config/project.yaml
+quanttradeai agent run --agent <agent_name> -c config/project.yaml --mode paper
+```
+"""
+
+
+CLAUDE_MD_CONTENT = """@AGENTS.md
+
+## Claude Code
+
+- Follow `AGENTS.md` as the main QuantTradeAI operating guide.
+- Use the project skill at `.claude/skills/quanttradeai-research/SKILL.md` when the user asks to research, test, compare, optimize, paper trade, or deploy strategies.
+- Live trading requires explicit user approval.
+"""
+
+
+CLAUDE_SKILL_MD_CONTENT = """---
+name: quanttradeai-research
+description: Use QuantTradeAI CLI and config/project.yaml to research, backtest, sweep, compare, promote, paper trade, or prepare deployment for trading strategies.
+---
+
+# QuantTradeAI Research
+
+## When To Use
+
+Use this skill when the human asks to research, test, compare, optimize, sweep, promote, paper trade, or prepare deployment for trading strategies in this workspace.
+
+## Primary Interface
+
+- Use the `quanttradeai` CLI and `config/project.yaml`.
+- Prefer YAML edits and CLI runs over custom scripts.
+- Validate after every YAML change.
+
+## Default Experiment Loop
+
+1. Read `config/project.yaml`.
+2. Edit symbols, features, agents, sweeps, or risk settings in YAML.
+3. Run `quanttradeai validate -c config/project.yaml`.
+4. Run backtests or sweeps.
+5. Read JSON artifacts before judging results.
+6. Compare top runs and recommend a winner only with artifact evidence.
+7. Promote only successful runs.
+
+## Command Patterns
+
+See `workflow.md` for detailed command sequences.
+
+## Artifact Reading Order
+
+See `artifacts.md`. Start with `summary.json.run_result` for single runs and `scoreboard.json` for batch or sweep rankings.
+
+## Safety Rules
+
+See `safety.md`. Backtest is the default. Paper mode is allowed unless the user restricts it. Live trading and broker-backed execution require explicit human approval.
+
+## Responding To The Human
+
+- State what was changed in YAML.
+- State which commands ran and whether they passed.
+- Summarize the winning run and closest alternatives using artifact metrics.
+- Call out missing data, failed runs, or validation issues plainly.
+"""
+
+
+CLAUDE_WORKFLOW_MD_CONTENT = """# QuantTradeAI Workflow
+
+## Strategy Research
+
+Start with `config/project.yaml`. Update symbols, date windows, features, agents, sweeps, and risk settings there. Prefer existing template structure and explainable rules before adding complexity.
+
+```bash
+quanttradeai validate -c config/project.yaml
+quanttradeai research run -c config/project.yaml
+```
+
+## YAML Editing
+
+After every YAML edit, validate before running experiments.
+
+```bash
+quanttradeai validate -c config/project.yaml
+```
+
+If validation fails, fix the YAML first. Do not continue to promotion or deployment with an invalid project file.
+
+## Backtest
+
+Run all configured agents in backtest mode when comparing strategies.
+
+```bash
+quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
+```
+
+Run one agent when isolating a specific candidate.
+
+```bash
+quanttradeai agent run --agent <agent_name> -c config/project.yaml --mode backtest
+```
+
+## Sweep
+
+Use configured sweeps for parameter research.
+
+```bash
+quanttradeai agent run --sweep <sweep_name> -c config/project.yaml --mode backtest --max-concurrency 4
+```
+
+## Scoreboard
+
+Rank runs with the scoreboard before choosing a winner.
+
+```bash
+quanttradeai runs list --scoreboard --sort-by net_sharpe
+```
+
+Use the metric that matches the user's goal when they specify one.
+
+## Compare
+
+Compare top runs directly before making a recommendation.
+
+```bash
+quanttradeai runs list --compare agent/backtest/<run_a> --compare agent/backtest/<run_b> --sort-by net_sharpe
+```
+
+## Promotion
+
+Promote only successful runs after reviewing artifacts.
+
+```bash
+quanttradeai promote --run agent/backtest/<winning_run_id> -c config/project.yaml
+```
+
+For research model promotion, use the research run id requested by the CLI output or artifacts.
+
+## Paper Mode
+
+Paper mode is the next step after a successful backtest and promotion.
+
+```bash
+quanttradeai agent run --agent <agent_name> -c config/project.yaml --mode paper
+```
+
+Prefer replay-backed paper mode unless the human explicitly asks for broker-backed behavior.
+
+## Deployment Preparation
+
+If the user asks to deploy, clarify whether they mean a deployment bundle or actual live trading. Preparing a deployment bundle is not the same as starting live trading. Keep live mode gated on explicit approval.
+"""
+
+
+CLAUDE_ARTIFACTS_MD_CONTENT = """# QuantTradeAI Artifacts
+
+Use JSON artifacts as the source of truth. Do not rely only on terminal output.
+
+## Reading Order
+
+1. `summary.json`
+2. `summary.json.run_result`
+3. `metrics.json`
+4. `scoreboard.json`
+5. `results.json`
+6. `decisions.jsonl`
+7. `executions.jsonl`
+8. `resolved_project_config.yaml`
+
+## Single Runs
+
+For single runs, read `summary.json.run_result` first, then `metrics.json`. Use `resolved_project_config.yaml` to confirm what settings actually ran.
+
+## Batch And Sweeps
+
+For batch or sweep results, read `scoreboard.json` for rankings and `results.json` for run details. Compare the top candidates before recommending a winner.
+
+## LLM And Hybrid Runs
+
+Inspect prompt samples only when needed to explain a decision, debug behavior, or verify prompt wiring. Avoid reading huge files unless necessary.
+
+## Large Files
+
+Prefer compact summaries and JSON records. Avoid loading full logs, large JSONL files, or generated data unless a specific question requires it.
+"""
+
+
+CLAUDE_SAFETY_MD_CONTENT = """# QuantTradeAI Safety
+
+- Backtest mode is safe by default.
+- Replay-backed paper mode is allowed unless the user restricts it.
+- Live mode requires explicit human approval.
+- Broker-backed execution requires explicit human approval.
+- Never promote to live unless the user asks.
+- Never run live commands just because a previous step succeeded.
+- If the user asks for "deploy", clarify whether they mean generate a deployment bundle or actually live trade.
+- Prefer simulated and replay workflows first.
+"""
+
+
+INIT_CONTEXT_FILES = {
+    "AGENTS.md": AGENTS_MD_CONTENT,
+    "CLAUDE.md": CLAUDE_MD_CONTENT,
+    ".claude/skills/quanttradeai-research/SKILL.md": CLAUDE_SKILL_MD_CONTENT,
+    ".claude/skills/quanttradeai-research/workflow.md": CLAUDE_WORKFLOW_MD_CONTENT,
+    ".claude/skills/quanttradeai-research/artifacts.md": CLAUDE_ARTIFACTS_MD_CONTENT,
+    ".claude/skills/quanttradeai-research/safety.md": CLAUDE_SAFETY_MD_CONTENT,
+}

--- a/roadmap.md
+++ b/roadmap.md
@@ -370,7 +370,8 @@ Status on 2026-05-02:
 - `quanttradeai research run -c config/project.yaml --sweep <name>` is implemented for research parameter sweeps defined under `sweeps:` in `config/project.yaml`, with deterministic variant expansion, bounded concurrency, preserved child research runs, and sparse batch scoreboards under `runs/research/batches/...`.
 - `quanttradeai promote --run agent/backtest/<sweep_child_run_id> -c config/project.yaml` is implemented for materializing a winning sweep child into the base agent's canonical config and promoting that base agent to paper mode.
 - `quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>` is implemented for local multi-agent live batches, requiring an explicit project-name acknowledgement, live-mode agent configs, live runtime prerequisites, preserved child runs under `runs/agent/live/...`, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
-- `quanttradeai init --template strategy-lab -o config/project.yaml` is implemented as a YAML-only multi-strategy lab with `rsi_reversion`, `sma_trend`, replay-enabled paper settings, top-level risk/runtime defaults, and starter sweeps for RSI thresholds and SMA risk sizing.
+- `quanttradeai init [PROJECT_DIR] --template strategy-lab` is implemented as the package-user workspace initializer, writing `config/project.yaml`, cross-agent `AGENTS.md`, a Claude adapter, a Claude project skill, and workspace metadata.
+- `strategy-lab` is the default init template and provides a YAML-only multi-strategy lab with `rsi_reversion`, `sma_trend`, replay-enabled paper settings, top-level risk/runtime defaults, and starter sweeps for RSI thresholds and SMA risk sizing.
 - `rule.preset: sma_crossover` is implemented for deterministic rule agents, using `rule.fast_feature` and `rule.slow_feature` from shared project feature definitions and agent context.
 
 Deliverables:
@@ -461,7 +462,7 @@ Do not expand it casually.
 ### Research track
 
 ```bash
-quanttradeai init --template research -o config/project.yaml
+quanttradeai init --template research
 quanttradeai validate -c config/project.yaml
 quanttradeai research run -c config/project.yaml
 quanttradeai runs list
@@ -471,7 +472,7 @@ quanttradeai promote --run research/<run_id> -c config/project.yaml
 ### Agent track
 
 ```bash
-quanttradeai init --template model-agent -o config/project.yaml
+quanttradeai init --template model-agent
 quanttradeai validate -c config/project.yaml
 quanttradeai agent run --agent paper_momentum -c config/project.yaml --mode backtest
 quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
@@ -490,7 +491,7 @@ Current implementation note:
 ### Hybrid track
 
 ```bash
-quanttradeai init --template hybrid -o config/project.yaml
+quanttradeai init --template hybrid
 quanttradeai validate -c config/project.yaml
 quanttradeai research run -c config/project.yaml
 quanttradeai promote --run research/<run_id> -c config/project.yaml

--- a/tests/integration/test_agent_batch_cli.py
+++ b/tests/integration/test_agent_batch_cli.py
@@ -58,13 +58,13 @@ def _seed_agent_assets(tmp_path: Path) -> Path:
 
     llm_init = runner.invoke(
         app,
-        ["init", "--template", "llm-agent", "--output", str(config_path)],
+        ["init", "--template", "llm-agent"],
     )
     assert llm_init.exit_code == 0, llm_init.stdout
 
     hybrid_init = runner.invoke(
         app,
-        ["init", "--template", "hybrid", "--output", str(config_path), "--force"],
+        ["init", "--template", "hybrid", "--force"],
     )
     assert hybrid_init.exit_code == 0, hybrid_init.stdout
 
@@ -89,7 +89,7 @@ def _seed_sweep_assets(tmp_path: Path) -> Path:
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", str(config_path)],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -343,7 +343,7 @@ def test_agent_run_all_errors_when_project_has_no_agents(tmp_path: Path, monkeyp
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "research", "--output", str(config_path)],
+        ["init", "--template", "research"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -495,7 +495,7 @@ def test_strategy_lab_agent_run_all_backtest_enumerates_both_agents(
     config_path = Path("config/project.yaml")
     init_result = runner.invoke(
         app,
-        ["init", "--template", "strategy-lab", "--output", str(config_path)],
+        ["init", "--template", "strategy-lab"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1283,7 +1283,7 @@ def test_agent_run_sweep_uses_canonical_project_root_for_llm_assets(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "llm-agent", "--output", str(config_path)],
+        ["init", "--template", "llm-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 

--- a/tests/integration/test_agent_cli.py
+++ b/tests/integration/test_agent_cli.py
@@ -146,7 +146,7 @@ def test_agent_run_backtest_writes_artifacts(tmp_path: Path, monkeypatch):
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "llm-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "llm-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -231,7 +231,7 @@ def test_llm_agent_backtest_context_blocks_include_orders_memory_news_and_notes(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "llm-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "llm-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -330,7 +330,7 @@ def test_agent_run_backtest_omits_ledger_artifact_when_no_trades(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "llm-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "llm-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -655,7 +655,7 @@ def test_hybrid_agent_run_includes_model_signals(tmp_path: Path, monkeypatch):
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "hybrid", "--output", "config/project.yaml"],
+        ["init", "--template", "hybrid"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -742,7 +742,7 @@ def test_rule_agent_backtest_writes_standardized_artifacts(tmp_path: Path, monke
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -819,7 +819,7 @@ def test_model_agent_backtest_writes_standardized_artifacts(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "model-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "model-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -896,7 +896,7 @@ def test_model_agent_paper_run_writes_metrics_and_execution_log(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "model-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "model-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -956,7 +956,7 @@ def test_model_agent_paper_run_uses_replay_manifest(tmp_path: Path, monkeypatch)
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "model-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "model-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1026,7 +1026,7 @@ def test_model_agent_live_run_writes_live_artifacts_and_risk_metrics(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "model-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "model-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1093,7 +1093,7 @@ def test_model_agent_live_run_with_alpaca_backend_writes_broker_artifacts(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "model-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "model-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1197,7 +1197,7 @@ def test_llm_agent_paper_run_writes_standardized_artifacts(tmp_path: Path, monke
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "llm-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "llm-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1307,7 +1307,7 @@ def test_llm_agent_paper_context_blocks_include_orders_memory_news_and_notes(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "llm-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "llm-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1432,7 +1432,7 @@ def test_llm_agent_paper_run_uses_replay_without_realtime_streaming(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "llm-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "llm-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1493,7 +1493,7 @@ def test_rule_agent_paper_run_writes_metrics_and_execution_log(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1604,7 +1604,7 @@ def test_rule_agent_paper_run_with_alpaca_backend_writes_broker_artifacts(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1711,7 +1711,7 @@ def test_rule_agent_paper_run_uses_replay_without_realtime_streaming(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1769,7 +1769,7 @@ def test_rule_agent_live_run_writes_live_artifacts_and_risk_metrics(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1878,7 +1878,7 @@ def test_hybrid_agent_paper_run_includes_model_signals_in_decisions(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "hybrid", "--output", "config/project.yaml"],
+        ["init", "--template", "hybrid"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1990,7 +1990,7 @@ def test_hybrid_agent_paper_run_uses_replay_without_realtime_streaming(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "hybrid", "--output", "config/project.yaml"],
+        ["init", "--template", "hybrid"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -2076,7 +2076,7 @@ def test_agent_run_warns_when_cli_mode_differs_from_configured_mode(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "llm-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "llm-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -2135,7 +2135,7 @@ def test_agent_run_live_rejects_skip_validation(tmp_path: Path, monkeypatch):
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -2174,7 +2174,7 @@ def test_agent_run_live_requires_agent_to_be_configured_live(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", "config/project.yaml"],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 

--- a/tests/integration/test_deploy_cli.py
+++ b/tests/integration/test_deploy_cli.py
@@ -16,7 +16,7 @@ def _init_template(tmp_path: Path, monkeypatch, template: str) -> Path:
     config_path = Path("config/project.yaml")
     result = runner.invoke(
         app,
-        ["init", "--template", template, "--output", str(config_path)],
+        ["init", "--template", template],
     )
     assert result.exit_code == 0, result.stdout
     return config_path

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -57,10 +57,11 @@ def test_compile_research_runtime_configs_can_disable_configured_test_window():
 
 def test_init_creates_each_template(tmp_path: Path):
     for template_name, expected in PROJECT_TEMPLATES.items():
-        output = tmp_path / f"{template_name}.yaml"
+        workspace = tmp_path / template_name
+        output = workspace / "config" / "project.yaml"
         result = runner.invoke(
             app,
-            ["init", "--template", template_name, "--output", str(output)],
+            ["init", str(workspace), "--template", template_name],
         )
 
         assert result.exit_code == 0, result.stdout
@@ -82,16 +83,18 @@ def test_init_refuses_existing_without_force_and_overwrites_with_force(tmp_path:
     output = tmp_path / "config" / "project.yaml"
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text("project:\n  name: old\n", encoding="utf-8")
+    agents_path = tmp_path / "AGENTS.md"
+    agents_path.write_text("old agent notes\n", encoding="utf-8")
 
     fail_result = runner.invoke(
         app,
-        ["init", "--template", "research", "--output", str(output)],
+        ["init", str(tmp_path), "--template", "research"],
     )
     assert fail_result.exit_code == 1
 
     pass_result = runner.invoke(
         app,
-        ["init", "--template", "research", "--output", str(output), "--force"],
+        ["init", str(tmp_path), "--template", "research", "--force"],
     )
     assert pass_result.exit_code == 0
 
@@ -99,14 +102,96 @@ def test_init_refuses_existing_without_force_and_overwrites_with_force(tmp_path:
     assert (
         rendered["project"]["name"] == PROJECT_TEMPLATES["research"]["project"]["name"]
     )
+    assert "QuantTradeAI Workspace" in agents_path.read_text(encoding="utf-8")
+
+
+def test_init_current_directory_uses_strategy_lab_by_default(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["init"])
+
+    assert result.exit_code == 0, result.stdout
+    cfg_path = Path("config/project.yaml")
+    assert cfg_path.is_file()
+    rendered = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert (
+        rendered["project"]["name"]
+        == PROJECT_TEMPLATES["strategy-lab"]["project"]["name"]
+    )
+
+
+def test_init_named_workspace_writes_agent_context_and_metadata(tmp_path: Path):
+    workspace = tmp_path / "my-lab"
+
+    result = runner.invoke(app, ["init", str(workspace)])
+
+    assert result.exit_code == 0, result.stdout
+    expected_files = [
+        "config/project.yaml",
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".claude/skills/quanttradeai-research/SKILL.md",
+        ".claude/skills/quanttradeai-research/workflow.md",
+        ".claude/skills/quanttradeai-research/artifacts.md",
+        ".claude/skills/quanttradeai-research/safety.md",
+        ".quanttradeai/workspace.yaml",
+    ]
+    for relative_path in expected_files:
+        assert (workspace / relative_path).is_file()
+
+    agents_text = (workspace / "AGENTS.md").read_text(encoding="utf-8")
+    assert "This is a QuantTradeAI workspace" in agents_text
+    assert "config/project.yaml" in agents_text
+    assert "Never run `live` mode" in agents_text
+    assert "summary.json.run_result" in agents_text
+    assert "scoreboard.json" in agents_text
+    assert "Do not edit QuantTradeAI package or framework internals" in agents_text
+
+    claude_text = (workspace / "CLAUDE.md").read_text(encoding="utf-8")
+    assert claude_text.startswith("@AGENTS.md")
+    assert ".claude/skills/quanttradeai-research/SKILL.md" in claude_text
+
+    skill_text = (
+        workspace / ".claude/skills/quanttradeai-research/SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert "name: quanttradeai-research" in skill_text
+    assert "description: Use QuantTradeAI CLI" in skill_text
+
+    metadata = yaml.safe_load(
+        (workspace / ".quanttradeai/workspace.yaml").read_text(encoding="utf-8")
+    )
+    assert metadata == {
+        "version": 1,
+        "template": "strategy-lab",
+        "project_config": "config/project.yaml",
+        "agent_context": {
+            "agents_md": "AGENTS.md",
+            "claude_md": "CLAUDE.md",
+            "skill": ".claude/skills/quanttradeai-research/SKILL.md",
+        },
+        "created_by": "quanttradeai",
+    }
+
+
+def test_init_help_exposes_only_workspace_template_and_force_options():
+    result = runner.invoke(app, ["init", "--help"])
+
+    assert result.exit_code == 0
+    assert "PROJECT_DIR" in result.output
+    assert "--template" in result.output
+    assert "--force" in result.output
+    assert "--output" not in result.output
 
 
 def test_validate_passes_for_generated_templates(tmp_path: Path):
     for template_name in PROJECT_TEMPLATES:
-        cfg_path = tmp_path / template_name / "project.yaml"
+        workspace = tmp_path / template_name
+        cfg_path = workspace / "config" / "project.yaml"
         init_result = runner.invoke(
             app,
-            ["init", "--template", template_name, "--output", str(cfg_path)],
+            ["init", str(workspace), "--template", template_name],
         )
         assert init_result.exit_code == 0, init_result.stdout
 
@@ -246,7 +331,7 @@ def test_strategy_lab_template_includes_two_rule_agents_and_sweeps(
 
     result = runner.invoke(
         app,
-        ["init", "--template", "strategy-lab", "--output", str(cfg_path)],
+        ["init", "--template", "strategy-lab"],
     )
 
     assert result.exit_code == 0, result.stdout
@@ -568,15 +653,16 @@ def test_init_writes_prompt_assets_for_agent_templates(tmp_path: Path, monkeypat
     }
 
     for template_name, prompt_files in expected_assets.items():
-        cfg_path = Path("config") / template_name / "project.yaml"
+        workspace = tmp_path / template_name
         result = runner.invoke(
             app,
-            ["init", "--template", template_name, "--output", str(cfg_path)],
+            ["init", str(workspace), "--template", template_name],
         )
 
         assert result.exit_code == 0, result.stdout
+        assert (workspace / "config" / "project.yaml").is_file()
         for prompt_file in prompt_files:
-            assert (tmp_path / "config" / template_name / prompt_file).is_file()
+            assert (workspace / prompt_file).is_file()
 
 
 def test_model_agent_template_includes_canonical_streaming_block(
@@ -587,7 +673,7 @@ def test_model_agent_template_includes_canonical_streaming_block(
 
     result = runner.invoke(
         app,
-        ["init", "--template", "model-agent", "--output", str(cfg_path)],
+        ["init", "--template", "model-agent"],
     )
 
     assert result.exit_code == 0, result.stdout
@@ -612,7 +698,7 @@ def test_rule_agent_template_includes_canonical_streaming_block(
 
     result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+        ["init", "--template", "rule-agent"],
     )
 
     assert result.exit_code == 0, result.stdout
@@ -639,7 +725,7 @@ def test_llm_and_hybrid_templates_include_canonical_streaming_block(
         cfg_path = Path("config/project.yaml")
         result = runner.invoke(
             app,
-            ["init", "--template", template_name, "--output", str(cfg_path)],
+            ["init", "--template", template_name, "--force"],
         )
 
         assert result.exit_code == 0, result.stdout
@@ -661,7 +747,7 @@ def test_research_and_hybrid_templates_include_research_promotion_targets(
         cfg_path = Path("config/project.yaml")
         result = runner.invoke(
             app,
-            ["init", "--template", template_name, "--output", str(cfg_path)],
+            ["init", "--template", template_name, "--force"],
         )
 
         assert result.exit_code == 0, result.stdout
@@ -684,7 +770,7 @@ def test_hybrid_template_is_prewired_to_promoted_model_signal(
 
     result = runner.invoke(
         app,
-        ["init", "--template", "hybrid", "--output", str(cfg_path)],
+        ["init", "--template", "hybrid"],
     )
 
     assert result.exit_code == 0, result.stdout
@@ -707,7 +793,7 @@ def test_agent_templates_include_live_risk_and_position_manager_defaults(
         cfg_path = Path("config/project.yaml")
         result = runner.invoke(
             app,
-            ["init", "--template", template_name, "--output", str(cfg_path)],
+            ["init", "--template", template_name, "--force"],
         )
 
         assert result.exit_code == 0, result.stdout
@@ -727,7 +813,7 @@ def test_validate_fails_when_model_agent_path_missing(tmp_path: Path, monkeypatc
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "model-agent", "--output", str(cfg_path)],
+        ["init", "--template", "model-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -748,7 +834,7 @@ def test_validate_passes_for_rule_agent_template(tmp_path: Path, monkeypatch):
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1000,7 +1086,7 @@ def test_validate_passes_when_live_agent_has_canonical_risk_and_position_manager
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1025,7 +1111,7 @@ def test_validate_fails_when_live_agent_streaming_is_disabled(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1051,7 +1137,7 @@ def test_validate_defaults_agent_execution_backend_to_simulated(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1145,7 +1231,7 @@ def test_validate_fails_when_live_agent_missing_top_level_risk(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1174,7 +1260,7 @@ def test_validate_fails_when_live_agent_drawdown_protection_is_disabled(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1200,7 +1286,7 @@ def test_validate_fails_when_live_agent_position_manager_is_invalid(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1226,7 +1312,7 @@ def test_validate_warns_for_legacy_nested_live_risk_compatibility(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "rule-agent", "--output", str(cfg_path)],
+        ["init", "--template", "rule-agent"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1570,7 +1656,7 @@ def test_research_run_happy_path_writes_run_artifacts(tmp_path: Path, monkeypatc
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "research", "--output", str(cfg_path)],
+        ["init", "--template", "research"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 
@@ -1690,7 +1776,7 @@ def test_research_run_marks_placeholder_when_backtests_have_no_metrics(
 
     init_result = runner.invoke(
         app,
-        ["init", "--template", "research", "--output", str(cfg_path)],
+        ["init", "--template", "research"],
     )
     assert init_result.exit_code == 0, init_result.stdout
 

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -122,6 +122,36 @@ def test_init_current_directory_uses_strategy_lab_by_default(
     )
 
 
+def test_init_preserves_existing_agent_context_without_force(tmp_path: Path):
+    agents_path = tmp_path / "AGENTS.md"
+    claude_path = tmp_path / "CLAUDE.md"
+    agents_path.write_text("existing agent notes\n", encoding="utf-8")
+    claude_path.write_text("existing claude notes\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["init", str(tmp_path), "--template", "research"])
+
+    assert result.exit_code == 0, result.stdout
+    assert (tmp_path / "config" / "project.yaml").is_file()
+    assert agents_path.read_text(encoding="utf-8") == "existing agent notes\n"
+    assert claude_path.read_text(encoding="utf-8") == "existing claude notes\n"
+    assert (
+        tmp_path / ".claude" / "skills" / "quanttradeai-research" / "SKILL.md"
+    ).is_file()
+    assert (tmp_path / ".quanttradeai" / "workspace.yaml").is_file()
+
+
+def test_init_preserves_existing_template_assets_without_force(tmp_path: Path):
+    prompt_path = tmp_path / "prompts" / "breakout.md"
+    prompt_path.parent.mkdir(parents=True)
+    prompt_path.write_text("existing prompt\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["init", str(tmp_path), "--template", "llm-agent"])
+
+    assert result.exit_code == 0, result.stdout
+    assert (tmp_path / "config" / "project.yaml").is_file()
+    assert prompt_path.read_text(encoding="utf-8") == "existing prompt\n"
+
+
 def test_init_named_workspace_writes_agent_context_and_metadata(tmp_path: Path):
     workspace = tmp_path / "my-lab"
 

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -175,16 +175,6 @@ def test_init_named_workspace_writes_agent_context_and_metadata(tmp_path: Path):
     }
 
 
-def test_init_help_exposes_only_workspace_template_and_force_options():
-    result = runner.invoke(app, ["init", "--help"])
-
-    assert result.exit_code == 0
-    assert "PROJECT_DIR" in result.output
-    assert "--template" in result.output
-    assert "--force" in result.output
-    assert "--output" not in result.output
-
-
 def test_validate_passes_for_generated_templates(tmp_path: Path):
     for template_name in PROJECT_TEMPLATES:
         workspace = tmp_path / template_name


### PR DESCRIPTION
## Summary

- Replace the package-user init UX with `quanttradeai init [PROJECT_DIR]`, defaulting to `strategy-lab` and writing `config/project.yaml` inside the workspace.
- Generate agent-facing workspace context: `AGENTS.md`, `CLAUDE.md`, `.claude/skills/quanttradeai-research/*`, and `.quanttradeai/workspace.yaml`.
- Preserve template support and template asset generation for research, strategy-lab, rule-agent, model-agent, llm-agent, and hybrid templates.
- Update tests and docs to remove the primary `-o/--output` init UX.

## Validation

- CLI smoke tested generated workspaces with `quanttradeai init`, `quanttradeai init my-lab --template research`, relative `quanttradeai validate -c config/project.yaml`, generated guidance files, metadata, and llm prompt assets.
- `make lint.format.test`

## Notes

Temporary CLI smoke-test workspaces were created under the system temp directory and cleaned up after validation.