### PR TITLE
Move init context into package templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
 packages = [
     { include = "quanttradeai" }
 ]
+include = [
+    { path = "quanttradeai/templates/workspace_context/**", format = ["sdist", "wheel"] }
+]
 
 [project.scripts]
 quanttradeai = "quanttradeai.cli:app"

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -17,7 +17,7 @@ from typing import Any, Optional
 import typer
 import yaml
 
-from .init_context import INIT_CONTEXT_FILES
+from .init_context import iter_init_context_templates, write_init_context_files
 from .utils.config_validator import validate_project_config
 from .utils.project_paths import infer_project_root
 from .utils.project_config import (
@@ -723,7 +723,10 @@ def _template_asset_paths(template_name: str, project_config_path: Path) -> list
 def _init_owned_paths(template_name: str, project_config_path: Path) -> list[Path]:
     workspace = infer_project_root(project_config_path)
     paths = [project_config_path]
-    paths.extend(workspace / relative_path for relative_path in INIT_CONTEXT_FILES)
+    paths.extend(
+        workspace / Path(*Path(relative_path).parts)
+        for relative_path in iter_init_context_templates()
+    )
     paths.append(workspace / ".quanttradeai" / "workspace.yaml")
     paths.extend(_template_asset_paths(template_name, project_config_path))
     return list(dict.fromkeys(paths))
@@ -771,8 +774,7 @@ def _write_text_file(path: Path, content: str, force: bool = True) -> None:
 
 
 def _write_agent_context_files(workspace: Path, force: bool) -> None:
-    for relative_path, content in INIT_CONTEXT_FILES.items():
-        _write_text_file(workspace / relative_path, content, force=force)
+    write_init_context_files(workspace, force=force)
 
 
 def _write_workspace_metadata(workspace: Path, template_name: str) -> None:

--- a/quanttradeai/init_context.py
+++ b/quanttradeai/init_context.py
@@ -1,246 +1,85 @@
-# flake8: noqa: E501
-"""Generated workspace guidance files for `quanttradeai init`."""
-
-AGENTS_MD_CONTENT = """# QuantTradeAI Workspace
-
-This is a QuantTradeAI workspace for running strategy research and agent workflows through the `quanttradeai` CLI and YAML.
-
-## Primary Interface
-
-- Treat `config/project.yaml` as the canonical project file.
-- Prefer editing YAML and running QuantTradeAI CLI commands over writing custom Python scripts.
-- Run `quanttradeai validate -c config/project.yaml` after every YAML change.
-- Do not edit QuantTradeAI package or framework internals unless the human explicitly asks to modify QuantTradeAI itself.
-
-## Default Workflow
-
-- Default to `backtest` and replay-backed `paper` workflows.
-- Never run `live` mode, broker-backed execution, or live deployment unless the human explicitly asks for it.
-- Prefer sweeps and batch runs for strategy research and optimization.
-- Use `quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4` for batch backtests.
-- Use `quanttradeai agent run --sweep <sweep_name> -c config/project.yaml --mode backtest --max-concurrency 4` for configured sweeps.
-- Promote only successful runs after reviewing their artifacts.
-
-## Artifact Review
-
-- Do not rely only on terminal output when making recommendations.
-- Inspect machine-readable artifacts before summarizing results.
-- Read `summary.json.run_result` first for a single run.
-- Read `scoreboard.json` for rankings across batch or sweep runs.
-- Read `metrics.json` and `results.json` to validate the ranking details.
-- Compare top runs before recommending a winner.
-- Explain recommendations using metrics, assumptions, and tradeoffs from the artifacts.
-
-## Useful Commands
-
-```bash
-quanttradeai validate -c config/project.yaml
-quanttradeai research run -c config/project.yaml
-quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
-quanttradeai agent run --sweep <sweep_name> -c config/project.yaml --mode backtest --max-concurrency 4
-quanttradeai runs list --scoreboard --sort-by net_sharpe
-quanttradeai promote --run agent/backtest/<winning_run_id> -c config/project.yaml
-quanttradeai agent run --agent <agent_name> -c config/project.yaml --mode paper
-```
-"""
-
-
-CLAUDE_MD_CONTENT = """@AGENTS.md
-
-## Claude Code
-
-- Follow `AGENTS.md` as the main QuantTradeAI operating guide.
-- Use the project skill at `.claude/skills/quanttradeai-research/SKILL.md` when the user asks to research, test, compare, optimize, paper trade, or deploy strategies.
-- Live trading requires explicit user approval.
-"""
-
-
-CLAUDE_SKILL_MD_CONTENT = """---
-name: quanttradeai-research
-description: Use QuantTradeAI CLI and config/project.yaml to research, backtest, sweep, compare, promote, paper trade, or prepare deployment for trading strategies.
----
-
-# QuantTradeAI Research
-
-## When To Use
-
-Use this skill when the human asks to research, test, compare, optimize, sweep, promote, paper trade, or prepare deployment for trading strategies in this workspace.
-
-## Primary Interface
-
-- Use the `quanttradeai` CLI and `config/project.yaml`.
-- Prefer YAML edits and CLI runs over custom scripts.
-- Validate after every YAML change.
-
-## Default Experiment Loop
-
-1. Read `config/project.yaml`.
-2. Edit symbols, features, agents, sweeps, or risk settings in YAML.
-3. Run `quanttradeai validate -c config/project.yaml`.
-4. Run backtests or sweeps.
-5. Read JSON artifacts before judging results.
-6. Compare top runs and recommend a winner only with artifact evidence.
-7. Promote only successful runs.
-
-## Command Patterns
-
-See `workflow.md` for detailed command sequences.
-
-## Artifact Reading Order
-
-See `artifacts.md`. Start with `summary.json.run_result` for single runs and `scoreboard.json` for batch or sweep rankings.
-
-## Safety Rules
-
-See `safety.md`. Backtest is the default. Paper mode is allowed unless the user restricts it. Live trading and broker-backed execution require explicit human approval.
-
-## Responding To The Human
-
-- State what was changed in YAML.
-- State which commands ran and whether they passed.
-- Summarize the winning run and closest alternatives using artifact metrics.
-- Call out missing data, failed runs, or validation issues plainly.
-"""
-
-
-CLAUDE_WORKFLOW_MD_CONTENT = """# QuantTradeAI Workflow
-
-## Strategy Research
-
-Start with `config/project.yaml`. Update symbols, date windows, features, agents, sweeps, and risk settings there. Prefer existing template structure and explainable rules before adding complexity.
-
-```bash
-quanttradeai validate -c config/project.yaml
-quanttradeai research run -c config/project.yaml
-```
-
-## YAML Editing
-
-After every YAML edit, validate before running experiments.
-
-```bash
-quanttradeai validate -c config/project.yaml
-```
-
-If validation fails, fix the YAML first. Do not continue to promotion or deployment with an invalid project file.
-
-## Backtest
-
-Run all configured agents in backtest mode when comparing strategies.
-
-```bash
-quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
-```
-
-Run one agent when isolating a specific candidate.
-
-```bash
-quanttradeai agent run --agent <agent_name> -c config/project.yaml --mode backtest
-```
-
-## Sweep
-
-Use configured sweeps for parameter research.
-
-```bash
-quanttradeai agent run --sweep <sweep_name> -c config/project.yaml --mode backtest --max-concurrency 4
-```
-
-## Scoreboard
-
-Rank runs with the scoreboard before choosing a winner.
-
-```bash
-quanttradeai runs list --scoreboard --sort-by net_sharpe
-```
-
-Use the metric that matches the user's goal when they specify one.
-
-## Compare
-
-Compare top runs directly before making a recommendation.
-
-```bash
-quanttradeai runs list --compare agent/backtest/<run_a> --compare agent/backtest/<run_b> --sort-by net_sharpe
-```
-
-## Promotion
-
-Promote only successful runs after reviewing artifacts.
-
-```bash
-quanttradeai promote --run agent/backtest/<winning_run_id> -c config/project.yaml
-```
-
-For research model promotion, use the research run id requested by the CLI output or artifacts.
-
-## Paper Mode
-
-Paper mode is the next step after a successful backtest and promotion.
-
-```bash
-quanttradeai agent run --agent <agent_name> -c config/project.yaml --mode paper
-```
-
-Prefer replay-backed paper mode unless the human explicitly asks for broker-backed behavior.
-
-## Deployment Preparation
-
-If the user asks to deploy, clarify whether they mean a deployment bundle or actual live trading. Preparing a deployment bundle is not the same as starting live trading. Keep live mode gated on explicit approval.
-"""
-
-
-CLAUDE_ARTIFACTS_MD_CONTENT = """# QuantTradeAI Artifacts
-
-Use JSON artifacts as the source of truth. Do not rely only on terminal output.
-
-## Reading Order
-
-1. `summary.json`
-2. `summary.json.run_result`
-3. `metrics.json`
-4. `scoreboard.json`
-5. `results.json`
-6. `decisions.jsonl`
-7. `executions.jsonl`
-8. `resolved_project_config.yaml`
-
-## Single Runs
-
-For single runs, read `summary.json.run_result` first, then `metrics.json`. Use `resolved_project_config.yaml` to confirm what settings actually ran.
-
-## Batch And Sweeps
-
-For batch or sweep results, read `scoreboard.json` for rankings and `results.json` for run details. Compare the top candidates before recommending a winner.
-
-## LLM And Hybrid Runs
-
-Inspect prompt samples only when needed to explain a decision, debug behavior, or verify prompt wiring. Avoid reading huge files unless necessary.
-
-## Large Files
-
-Prefer compact summaries and JSON records. Avoid loading full logs, large JSONL files, or generated data unless a specific question requires it.
-"""
-
-
-CLAUDE_SAFETY_MD_CONTENT = """# QuantTradeAI Safety
-
-- Backtest mode is safe by default.
-- Replay-backed paper mode is allowed unless the user restricts it.
-- Live mode requires explicit human approval.
-- Broker-backed execution requires explicit human approval.
-- Never promote to live unless the user asks.
-- Never run live commands just because a previous step succeeded.
-- If the user asks for "deploy", clarify whether they mean generate a deployment bundle or actually live trade.
-- Prefer simulated and replay workflows first.
-"""
-
-
-INIT_CONTEXT_FILES = {
-    "AGENTS.md": AGENTS_MD_CONTENT,
-    "CLAUDE.md": CLAUDE_MD_CONTENT,
-    ".claude/skills/quanttradeai-research/SKILL.md": CLAUDE_SKILL_MD_CONTENT,
-    ".claude/skills/quanttradeai-research/workflow.md": CLAUDE_WORKFLOW_MD_CONTENT,
-    ".claude/skills/quanttradeai-research/artifacts.md": CLAUDE_ARTIFACTS_MD_CONTENT,
-    ".claude/skills/quanttradeai-research/safety.md": CLAUDE_SAFETY_MD_CONTENT,
-}
+"""Package-resource backed workspace guidance files for `quanttradeai init`."""
+
+from __future__ import annotations
+
+from importlib import resources
+from importlib.resources.abc import Traversable
+from pathlib import Path, PurePosixPath
+from typing import Iterator
+
+
+_TEMPLATE_ROOT_PARTS = ("templates", "workspace_context")
+_PREFERRED_TEMPLATE_ORDER = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".claude/skills/quanttradeai-research/SKILL.md",
+    ".claude/skills/quanttradeai-research/workflow.md",
+    ".claude/skills/quanttradeai-research/artifacts.md",
+    ".claude/skills/quanttradeai-research/safety.md",
+)
+
+
+def _template_root() -> Traversable:
+    root = resources.files("quanttradeai")
+    for part in _TEMPLATE_ROOT_PARTS:
+        root = root.joinpath(part)
+    return root
+
+
+def _normalize_template_path(relative_path: str | PurePosixPath) -> PurePosixPath:
+    path = PurePosixPath(str(relative_path))
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"Invalid init context template path: {relative_path!r}")
+    return path
+
+
+def _walk_template_files(root: Traversable, prefix: PurePosixPath) -> Iterator[str]:
+    for child in sorted(root.iterdir(), key=lambda item: item.name.lower()):
+        child_path = prefix / child.name
+        if child.is_dir():
+            yield from _walk_template_files(child, child_path)
+        elif child.is_file():
+            yield child_path.as_posix()
+
+
+def iter_init_context_templates() -> tuple[str, ...]:
+    """Return template-relative paths copied into initialized workspaces."""
+
+    discovered = tuple(_walk_template_files(_template_root(), PurePosixPath()))
+    preferred_order = {
+        relative_path: index
+        for index, relative_path in enumerate(_PREFERRED_TEMPLATE_ORDER)
+    }
+    return tuple(
+        sorted(
+            discovered,
+            key=lambda relative_path: (
+                preferred_order.get(relative_path, len(preferred_order)),
+                relative_path,
+            ),
+        )
+    )
+
+
+def read_init_context_template(relative_path: str | PurePosixPath) -> str:
+    """Read one init context template by template-relative path."""
+
+    path = _normalize_template_path(relative_path)
+    resource = _template_root()
+    for part in path.parts:
+        resource = resource.joinpath(part)
+    if not resource.is_file():
+        raise FileNotFoundError(f"Unknown init context template: {path.as_posix()}")
+    return resource.read_text(encoding="utf-8")
+
+
+def write_init_context_files(workspace: Path, force: bool) -> None:
+    """Copy all init context templates into a workspace."""
+
+    for relative_path in iter_init_context_templates():
+        output_path = workspace / Path(*PurePosixPath(relative_path).parts)
+        if output_path.exists() and not force:
+            continue
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        content = read_init_context_template(relative_path).rstrip() + "\n"
+        output_path.write_text(content, encoding="utf-8")

--- a/quanttradeai/templates/workspace_context/.claude/skills/quanttradeai-research/SKILL.md
+++ b/quanttradeai/templates/workspace_context/.claude/skills/quanttradeai-research/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: quanttradeai-research
+description: Use QuantTradeAI CLI and config/project.yaml to research, backtest, sweep, compare, promote, paper trade, or prepare deployment for trading strategies. Trigger when the user asks to test strategy ideas, find the best strategy, optimize parameters, compare trading agents, inspect results, or move a successful backtest toward paper trading.
+---
+
+# QuantTradeAI Research Skill
+
+Use this skill to operate a QuantTradeAI workspace through YAML and CLI commands.
+
+## Primary Interface
+
+* Edit `config/project.yaml`.
+* Run `quanttradeai` CLI commands.
+* Read generated JSON artifacts.
+* Avoid custom scripts unless the workflow cannot be expressed through QuantTradeAI config.
+
+## Default Loop
+
+1. Inspect `config/project.yaml`.
+2. Translate the user's research objective into symbols, features, agents, sweeps, or risk settings.
+3. Run validation.
+4. Run backtests, batches, or sweeps.
+5. Inspect artifacts before making claims.
+6. Compare top candidates.
+7. Recommend a winner or next experiment.
+8. Promote only after a successful run and artifact review.
+
+## Start Here
+
+For detailed commands and flow, read `workflow.md`.
+
+For artifact interpretation, read `artifacts.md`.
+
+For live-trading boundaries, read `safety.md`.
+
+## Strong Defaults
+
+* Use backtest mode for research.
+* Use replay-backed paper mode only after successful backtest/promotion.
+* Use `net_sharpe` as the default backtest ranking metric unless the human asks for another objective.
+* Prefer simple reproducible YAML changes over complex one-off code.
+
+## Output To The Human
+
+Report:
+
+* YAML changes made
+* commands run
+* pass/fail status
+* best run metrics
+* closest alternatives
+* risks or caveats
+* recommended next action

--- a/quanttradeai/templates/workspace_context/.claude/skills/quanttradeai-research/artifacts.md
+++ b/quanttradeai/templates/workspace_context/.claude/skills/quanttradeai-research/artifacts.md
@@ -1,0 +1,64 @@
+# QuantTradeAI Artifacts
+
+QuantTradeAI writes machine-readable artifacts for every meaningful run. Treat them as the source of truth.
+
+## Single Run Reading Order
+
+1. `summary.json`
+2. `summary.json.run_result`
+3. `metrics.json`
+4. `resolved_project_config.yaml`
+
+Use `summary.json.run_result` for the compact result contract. Use `metrics.json` for detailed values. Use `resolved_project_config.yaml` to verify the exact config that ran.
+
+## Batch And Sweep Reading Order
+
+1. batch `summary.json`
+2. batch `scoreboard.json`
+3. batch `results.json`
+4. top child run `summary.json`
+5. top child run `metrics.json`
+6. top child run `resolved_project_config.yaml`
+
+Use `scoreboard.json` to rank candidates. Use `results.json` to map candidates to run IDs, run directories, parameters, failures, and artifacts.
+
+## Important Files
+
+* `summary.json`: run metadata, status, artifacts, and `run_result`
+* `summary.json.run_result`: compact machine-readable result summary
+* `metrics.json`: detailed metrics
+* `scoreboard.json`: ranked batch/sweep records
+* `results.json`: batch/sweep child run details
+* `resolved_project_config.yaml`: exact config used at runtime
+* `decisions.jsonl`: agent decisions
+* `executions.jsonl`: simulated, paper, or live executions
+* `prompt_samples.json`: sampled prompt payloads for LLM/hybrid agents
+* `replay_manifest.json`: replay-backed paper run details
+
+## Interpretation Rules
+
+* Do not declare a winner from terminal output alone.
+* Do not declare a winner from one metric alone if other risk metrics are poor.
+* Check status and failures before trusting rankings.
+* Check the resolved config before comparing runs.
+* Prefer concise JSON summaries over large logs.
+* Read JSONL files only when decision-level or execution-level explanation is needed.
+* For LLM/hybrid agents, inspect prompt samples only when debugging prompt/context behavior.
+
+## Default Ranking Guidance
+
+For backtests:
+
+* Start with `net_sharpe`
+* Check `net_pnl`
+* Check `net_mdd` or drawdown fields
+* Check trade/execution count if available
+* Watch for suspiciously sparse or overfit results
+
+For paper/live:
+
+* Start with `total_pnl`
+* Check portfolio value
+* Check risk status
+* Check execution count
+* Check failures and warnings

--- a/quanttradeai/templates/workspace_context/.claude/skills/quanttradeai-research/safety.md
+++ b/quanttradeai/templates/workspace_context/.claude/skills/quanttradeai-research/safety.md
@@ -1,0 +1,60 @@
+# QuantTradeAI Safety
+
+QuantTradeAI can run research, paper workflows, deployment bundle generation, and live trading workflows. Treat these differently.
+
+## Safe By Default
+
+Allowed unless the human says otherwise:
+
+* validate YAML
+* edit `config/project.yaml`
+* run backtests
+* run backtest sweeps
+* inspect artifacts
+* compare runs
+* recommend winners
+* run replay-backed paper mode after a successful backtest/promotion
+
+## Requires Explicit Human Approval
+
+Do not do these unless the human clearly asks:
+
+* run `--mode live`
+* promote a paper run to live
+* use broker-backed execution
+* submit real or broker-backed orders
+* generate a live deployment bundle
+* run all live agents
+* use `--acknowledge-live`
+
+## Deployment Language
+
+If the human says "deploy", clarify the intended meaning.
+
+Possible meanings:
+
+1. Generate a local/docker/render deployment bundle.
+2. Run a paper agent.
+3. Promote an agent to live.
+4. Start live trading.
+
+Only the first meaning is non-live deployment preparation. The others require explicit approval if they involve live or broker-backed behavior.
+
+## Hard Rules
+
+* Never run live mode because a backtest succeeded.
+* Never use broker credentials unless explicitly asked.
+* Never treat paper success as approval for live trading.
+* Never hide failed runs or warnings.
+* Always report safety assumptions in the final answer.
+
+## Preferred Path
+
+Research request:
+backtest -> compare -> recommend next experiment or winner
+
+Paper request:
+successful backtest -> promote to paper -> replay-backed paper run
+
+Live request:
+ask for explicit confirmation -> verify config/risk/broker settings -> only then run live-related command

--- a/quanttradeai/templates/workspace_context/.claude/skills/quanttradeai-research/workflow.md
+++ b/quanttradeai/templates/workspace_context/.claude/skills/quanttradeai-research/workflow.md
@@ -1,0 +1,148 @@
+# QuantTradeAI Workflow
+
+## 1. Inspect The Workspace
+
+Start by reading:
+
+* `config/project.yaml`
+* `AGENTS.md`
+* relevant skill files if needed
+
+Identify:
+
+* symbols
+* date windows
+* timeframe
+* features
+* agents
+* sweeps
+* risk settings
+* deployment mode
+
+## 2. Edit YAML First
+
+Prefer changing `config/project.yaml`.
+
+Good YAML edits include:
+
+* changing symbols/date windows
+* adding or adjusting feature definitions
+* adding rule/model/LLM/hybrid agents
+* adding sweeps
+* changing risk limits
+* changing paper/backtest settings
+
+Avoid writing custom scripts unless QuantTradeAI cannot express the requested workflow.
+
+## 3. Validate After Every YAML Change
+
+```bash
+quanttradeai validate -c config/project.yaml
+```
+
+If validation fails, fix the YAML before running experiments.
+
+## 4. Run Strategy Backtests
+
+To run every configured agent:
+
+```bash
+quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
+```
+
+To run one agent:
+
+```bash
+quanttradeai agent run --agent <agent_name> -c config/project.yaml --mode backtest
+```
+
+## 5. Run Sweeps
+
+Use sweeps for parameter search.
+
+```bash
+quanttradeai agent run --sweep <sweep_name> -c config/project.yaml --mode backtest --max-concurrency 4
+```
+
+Sweeps are backtest-only in the current product stage.
+
+## 6. Rank Runs
+
+Use the scoreboard before selecting a winner.
+
+```bash
+quanttradeai runs list --scoreboard --sort-by net_sharpe
+```
+
+Default ranking:
+
+* backtest: `net_sharpe`
+* paper/live: `total_pnl`
+
+If the human specifies a goal like lower drawdown, higher PnL, or fewer trades, use that goal when judging results.
+
+## 7. Compare Top Runs
+
+Compare finalists before recommending a winner.
+
+```bash
+quanttradeai runs list --compare agent/backtest/<run_a> --compare agent/backtest/<run_b> --sort-by net_sharpe
+```
+
+Review metric differences and config deltas.
+
+## 8. Promote A Winner
+
+Promote only successful runs after artifact review.
+
+```bash
+quanttradeai promote --run agent/backtest/<winning_run_id> -c config/project.yaml
+```
+
+For research model promotion:
+
+```bash
+quanttradeai promote --run research/<winning_run_id> -c config/project.yaml
+```
+
+## 9. Run Paper Mode
+
+After backtest promotion, use paper mode.
+
+```bash
+quanttradeai agent run --agent <agent_name> -c config/project.yaml --mode paper
+```
+
+Prefer replay-backed paper mode unless the human explicitly asks for broker-backed execution.
+
+## 10. Deployment Preparation
+
+To generate a deployment bundle:
+
+```bash
+quanttradeai deploy --agent <agent_name> -c config/project.yaml --target local
+quanttradeai deploy --agent <agent_name> -c config/project.yaml --target docker-compose
+quanttradeai deploy --agent <agent_name> -c config/project.yaml --target render
+```
+
+Generating a deployment bundle is not the same as starting live trading.
+
+If the human asks to "deploy", clarify whether they mean:
+
+* generate a bundle
+* run paper
+* promote to live
+* actually start live trading
+
+## 11. Final Report
+
+When done, report:
+
+* what was changed
+* commands run
+* artifact locations
+* winning run
+* key metrics
+* closest alternatives
+* risks/caveats
+* next recommended step

--- a/quanttradeai/templates/workspace_context/AGENTS.md
+++ b/quanttradeai/templates/workspace_context/AGENTS.md
@@ -1,0 +1,97 @@
+# QuantTradeAI Workspace
+
+This is a QuantTradeAI workspace for agent-driven quant research.
+
+QuantTradeAI is operated through `config/project.yaml` and the `quanttradeai` CLI. A human gives the research objective. You, the coding agent, should translate that objective into YAML changes, run experiments, inspect machine-readable artifacts, and report evidence-backed results.
+
+## Primary Interface
+
+- Treat `config/project.yaml` as the canonical project file.
+- Prefer editing YAML and running `quanttradeai` CLI commands over writing custom research scripts.
+- Run `quanttradeai validate -c config/project.yaml` after every YAML change.
+- Do not edit QuantTradeAI package/framework internals unless the human explicitly asks to modify QuantTradeAI itself.
+- Keep experiments reproducible. Prefer checked-in YAML changes over ad hoc terminal-only state.
+
+## Default Research Loop
+
+1. Read `config/project.yaml`.
+2. Identify the current symbols, dates, features, agents, sweeps, risk settings, and deployment mode.
+3. Modify YAML to express the user's requested strategy research.
+4. Validate the project.
+5. Run backtests, batches, or sweeps.
+6. Read JSON artifacts before judging results.
+7. Compare top candidates.
+8. Recommend the next experiment, winner, or promotion step with metric evidence.
+
+## Common Commands
+
+```bash
+quanttradeai validate -c config/project.yaml
+quanttradeai agent run --all -c config/project.yaml --mode backtest --max-concurrency 4
+quanttradeai agent run --sweep <sweep_name> -c config/project.yaml --mode backtest --max-concurrency 4
+quanttradeai runs list --scoreboard --sort-by net_sharpe
+quanttradeai runs list --compare agent/backtest/<run_a> --compare agent/backtest/<run_b> --sort-by net_sharpe
+quanttradeai promote --run agent/backtest/<winning_run_id> -c config/project.yaml
+quanttradeai agent run --agent <agent_name> -c config/project.yaml --mode paper
+```
+
+Use `research run` when the project is training/promoting model artifacts. Use `agent run` when comparing deployable rule/model/LLM/hybrid agents.
+
+## Artifact Reading Order
+
+Do not rely only on terminal output.
+
+For a single run:
+
+1. `summary.json`
+2. `summary.json.run_result`
+3. `metrics.json`
+4. `resolved_project_config.yaml`
+
+For batch or sweep runs:
+
+1. batch `summary.json`
+2. batch `scoreboard.json`
+3. batch `results.json`
+4. top child run `summary.json`
+5. top child run `metrics.json`
+
+Use `resolved_project_config.yaml` to confirm what actually ran. Use `decisions.jsonl`, `executions.jsonl`, and prompt samples only when needed to explain behavior or debug a run.
+
+## Strategy Research Defaults
+
+* Prefer `strategy-lab` style workflows for early exploration.
+* Prefer backtest sweeps before paper runs.
+* Prefer simple explainable strategy variants before adding complexity.
+* Use `net_sharpe` for default backtest ranking unless the human specifies another objective.
+* Consider drawdown, total PnL, execution count, failure count, and overfitting risk before declaring a winner.
+* If the requested strategy cannot be represented cleanly in the current YAML, explain the gap before writing custom code.
+
+## Safety Rules
+
+* Backtest mode is safe by default.
+* Replay-backed paper mode is allowed unless the human restricts it.
+* Live mode requires explicit human approval.
+* Broker-backed execution requires explicit human approval.
+* Never run `--mode live` just because a backtest or paper run succeeded.
+* Never promote to live unless the human explicitly asks.
+* If the human says "deploy", clarify whether they mean generating a deployment bundle or starting live trading.
+
+## Response Expectations
+
+When reporting back:
+
+* State what YAML/config changed.
+* State which commands ran and whether they passed.
+* Summarize the best run and closest alternatives using artifact metrics.
+* Mention failed runs or validation warnings.
+* Recommend the next concrete step.
+* Be explicit about assumptions and limitations.
+
+## More Detailed Skill Guidance
+
+Claude Code users can use the project skill at:
+
+`.claude/skills/quanttradeai-research/SKILL.md`
+
+Other coding agents should follow this `AGENTS.md` file and may read the skill files as reference documentation.

--- a/quanttradeai/templates/workspace_context/CLAUDE.md
+++ b/quanttradeai/templates/workspace_context/CLAUDE.md
@@ -1,0 +1,9 @@
+@AGENTS.md
+
+## Claude Code
+
+Follow `AGENTS.md` as the main QuantTradeAI operating guide.
+
+Use `.claude/skills/quanttradeai-research/SKILL.md` when the user asks to research, test, compare, optimize, sweep, paper trade, or prepare deployment for trading strategies.
+
+Live trading and broker-backed execution require explicit human approval.

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -7,10 +7,22 @@ import pytest
 from typer.testing import CliRunner
 
 from quanttradeai.cli import PROJECT_TEMPLATES, _project_to_runtime_configs, app
+from quanttradeai.init_context import (
+    iter_init_context_templates,
+    read_init_context_template,
+    write_init_context_files,
+)
 from quanttradeai.utils.project_config import compile_research_runtime_configs
 
 
 runner = CliRunner()
+
+
+def _skill_frontmatter(markdown: str) -> dict:
+    lines = markdown.splitlines()
+    assert lines[0] == "---"
+    closing_index = lines[1:].index("---") + 1
+    return yaml.safe_load("\n".join(lines[1:closing_index]))
 
 
 def test_project_to_runtime_configs_maps_custom_features_to_supported_keys():
@@ -171,23 +183,36 @@ def test_init_named_workspace_writes_agent_context_and_metadata(tmp_path: Path):
     for relative_path in expected_files:
         assert (workspace / relative_path).is_file()
 
+    for relative_path in iter_init_context_templates():
+        rendered = (workspace / relative_path).read_text(encoding="utf-8")
+        expected = read_init_context_template(relative_path).rstrip() + "\n"
+        assert rendered == expected
+
     agents_text = (workspace / "AGENTS.md").read_text(encoding="utf-8")
     assert "This is a QuantTradeAI workspace" in agents_text
     assert "config/project.yaml" in agents_text
-    assert "Never run `live` mode" in agents_text
+    assert "quanttradeai validate -c config/project.yaml" in agents_text
     assert "summary.json.run_result" in agents_text
     assert "scoreboard.json" in agents_text
-    assert "Do not edit QuantTradeAI package or framework internals" in agents_text
+    assert "Live mode requires explicit human approval" in agents_text
+    assert "Broker-backed execution requires explicit human approval" in agents_text
+    assert "Do not edit QuantTradeAI package/framework internals" in agents_text
 
     claude_text = (workspace / "CLAUDE.md").read_text(encoding="utf-8")
     assert claude_text.startswith("@AGENTS.md")
     assert ".claude/skills/quanttradeai-research/SKILL.md" in claude_text
+    assert "broker-backed execution require explicit human approval" in claude_text
 
     skill_text = (
         workspace / ".claude/skills/quanttradeai-research/SKILL.md"
     ).read_text(encoding="utf-8")
-    assert "name: quanttradeai-research" in skill_text
-    assert "description: Use QuantTradeAI CLI" in skill_text
+    skill_metadata = _skill_frontmatter(skill_text)
+    assert skill_metadata["name"] == "quanttradeai-research"
+    assert skill_metadata["description"].startswith(
+        "Use QuantTradeAI CLI and config/project.yaml"
+    )
+    assert "find the best strategy" in skill_metadata["description"]
+    assert "allowed-tools" not in skill_metadata
 
     metadata = yaml.safe_load(
         (workspace / ".quanttradeai/workspace.yaml").read_text(encoding="utf-8")
@@ -203,6 +228,34 @@ def test_init_named_workspace_writes_agent_context_and_metadata(tmp_path: Path):
         },
         "created_by": "quanttradeai",
     }
+
+
+def test_init_context_resource_loader_works_from_temp_directory(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    template_paths = iter_init_context_templates()
+
+    assert template_paths == (
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".claude/skills/quanttradeai-research/SKILL.md",
+        ".claude/skills/quanttradeai-research/workflow.md",
+        ".claude/skills/quanttradeai-research/artifacts.md",
+        ".claude/skills/quanttradeai-research/safety.md",
+    )
+    assert read_init_context_template("AGENTS.md").startswith(
+        "# QuantTradeAI Workspace"
+    )
+
+    workspace = tmp_path / "workspace"
+    write_init_context_files(workspace, force=False)
+
+    assert (workspace / "AGENTS.md").is_file()
+    assert (
+        workspace / ".claude" / "skills" / "quanttradeai-research" / "SKILL.md"
+    ).is_file()
 
 
 def test_validate_passes_for_generated_templates(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Move generated AGENTS.md, CLAUDE.md, and QuantTradeAI skill content out of Python string constants into package templates.
- Add an importlib.resources-backed init context loader while preserving the existing generated workspace paths and CLI UX.
- Update init tests to verify template output, key usage guidance, YAML frontmatter, and temp-directory resource loading.
- Include the template tree in both wheel and source distribution package data.

## Validation
- make lint.format.test
- Pre-commit hook: format, lint, test

## Notes
- Branch name uses the `feat/` prefix because this adds a reusable package-template initialization path for generated workspace context.