### PR TITLE
Fix init package pinning and add doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,11 @@ QuantTradeAI provides:
 
 ## Quickstart
 
-> [!NOTE]
-> Package publishing is being stabilized. Until PyPI is available, use the [local development setup](#local-development) below.
-
 ```bash
-pip install quanttradeai
-quanttradeai init my-lab
+uvx quanttradeai init my-lab
 cd my-lab
 uv sync
+uv run quanttradeai doctor
 ```
 
 Open `my-lab` in Claude Code, Cursor, Codex, or another coding agent and ask:
@@ -115,7 +112,7 @@ More details: [Agent Plugins](docs/plugins.md).
 ```text
 my-lab/
 |-- config/project.yaml             # canonical project config
-|-- pyproject.toml                  # uv project with local QuantTradeAI dependency
+|-- pyproject.toml                  # uv project pinned to the released QuantTradeAI package
 |-- .python-version
 |-- .env.example
 |-- .gitignore
@@ -195,9 +192,18 @@ poetry install --with dev
 Initialize a workspace and open it in your coding agent:
 
 ```bash
-quanttradeai init my-lab
+poetry run quanttradeai init my-lab --quanttradeai-version 0.1.0
 cd my-lab
 uv sync
+uv run quanttradeai doctor
+```
+
+Generated workspaces always pin `quanttradeai==<version>` in `pyproject.toml`.
+When testing local source changes from a generated workspace, keep that generated
+pin intact and install the checkout into the workspace environment explicitly:
+
+```bash
+uv pip install --reinstall -e ..
 ```
 
 Dev commands:

--- a/README.md
+++ b/README.md
@@ -192,15 +192,17 @@ poetry install --with dev
 Initialize a workspace and open it in your coding agent:
 
 ```bash
-poetry run quanttradeai init my-lab --quanttradeai-version 0.1.0
+poetry run quanttradeai init my-lab
 cd my-lab
 uv sync
 uv run quanttradeai doctor
 ```
 
 Generated workspaces always pin `quanttradeai==<version>` in `pyproject.toml`.
-When testing local source changes from a generated workspace, keep that generated
-pin intact and install the checkout into the workspace environment explicitly:
+Use `uvx quanttradeai@<version> init my-lab` when you need to generate a
+workspace from a specific published package version. When testing local source
+changes from a generated workspace, keep the generated pin intact and install the
+checkout into the workspace environment explicitly:
 
 ```bash
 uv pip install --reinstall -e ..

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -10,16 +10,17 @@ It is designed for two users at the same time:
 ## Mental Model
 
 ```text
-init -> validate -> run -> inspect artifacts -> promote/deploy
+init -> doctor -> validate -> run -> inspect artifacts -> promote/deploy
 ```
 
-Start with a generated workspace, edit `config/project.yaml`, validate it, run research or agents, inspect the `runs/` artifacts, then promote or package the result when it is ready.
+Start with a generated workspace, run `doctor` to catch setup issues, edit `config/project.yaml`, validate it, run research or agents, inspect the `runs/` artifacts, then promote or package the result when it is ready.
 
 ## Command Families
 
 QuantTradeAI keeps the command surface intentionally compact:
 
 - **Workspace** commands create the local project structure.
+- **Doctor** checks run a read-only workspace health check with stable text and JSON output.
 - **Validation** commands check the canonical project YAML and emit resolved config artifacts.
 - **Research** commands train and evaluate model workflows.
 - **Agent** commands run YAML-defined trading agents in `backtest`, `paper`, or `live` mode.

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -1,0 +1,52 @@
+# Doctor Command
+
+`quanttradeai doctor` is a read-only health check for coding agents. Run it
+after `quanttradeai init` and `uv sync`, before asking an agent to run research,
+paper, or live workflows.
+
+## Syntax
+
+```bash
+quanttradeai doctor
+quanttradeai doctor -c config/project.yaml
+quanttradeai doctor --json
+```
+
+## What It Checks
+
+- Workspace files: `config/project.yaml`, `pyproject.toml`, and generated metadata.
+- Python and uv environment readiness.
+- Installed QuantTradeAI version and the workspace `quanttradeai==<version>` pin.
+- Project dependency and `.quanttradeai/workspace.yaml` consistency.
+- Project YAML validity using the same read-only validation rules as runtime commands.
+- Required symbols, features, profiles, and enabled workflows.
+- Output path writability for `data/`, `models/`, `reports/`, and `runs/` without creating files.
+- Credentials needed by configured LLM or Alpaca-backed agents.
+- Paper/live safety defaults, including replay-backed paper mode and live risk settings.
+
+## Exit Codes
+
+| Code | Meaning |
+|---:|---|
+| `0` | No error diagnostics. Warnings may be present. |
+| `1` | One or more health-check errors were found. |
+| `2` | CLI usage error from Typer, such as an invalid option. |
+
+## JSON Output
+
+Use `--json` when another agent or script needs deterministic diagnostics:
+
+```bash
+quanttradeai doctor --json
+```
+
+The payload includes:
+
+- `status`: `ok` or `error`
+- `exit_code`: deterministic process exit code
+- `summary`: check, error, and warning counts
+- `checks`: stable high-level check statuses
+- `diagnostics`: actionable items with `severity`, `code`, `message`, `action`, and optional `path`
+
+`doctor` does not write validation reports, create output directories, modify
+`.env`, or change project files.

--- a/docs/cli/workspace.md
+++ b/docs/cli/workspace.md
@@ -25,7 +25,7 @@ quanttradeai init my-strategy-lab
 quanttradeai init --template research
 quanttradeai init my-agent-lab --template rule-agent
 quanttradeai init --force
-quanttradeai init my-lab --quanttradeai-version 0.1.0
+uvx quanttradeai@0.1.0 init my-lab
 ```
 
 ## Options
@@ -35,7 +35,6 @@ quanttradeai init my-lab --quanttradeai-version 0.1.0
 | `[PROJECT_DIR]` | current directory | No | Workspace directory to initialize. If omitted, QuantTradeAI initializes the current working directory. |
 | `--template TEXT` | `strategy-lab` | No | Project template to write into `config/project.yaml`. |
 | `--force` | `false` | No | Overwrite generated files that are protected by the initializer. |
-| `--quanttradeai-version TEXT` | installed package version | No | Exact QuantTradeAI package version to pin in the generated uv project. Intended for contributor testing of release or pre-release package versions. Local paths and `file://` URLs are rejected. |
 
 ## Supported Templates
 
@@ -57,8 +56,9 @@ The current CLI supports these template names:
 It does not read an existing project config to infer project name, symbols, or agent names.
 
 It also does not search for a local QuantTradeAI source checkout. The generated
-`pyproject.toml` always uses an exact package dependency such as
-`quanttradeai==0.1.0`.
+`pyproject.toml` pins the QuantTradeAI package version that is running `init`,
+for example `quanttradeai==0.1.0`. Use `uvx quanttradeai@<version> init ...`
+to choose a specific published version.
 
 ## Writes
 

--- a/docs/cli/workspace.md
+++ b/docs/cli/workspace.md
@@ -7,7 +7,7 @@
 Use this command before editing project YAML by hand. It gives humans and coding agents the same baseline files:
 
 - a canonical project config at `config/project.yaml`
-- a disposable uv project pinned to the local QuantTradeAI checkout
+- a disposable uv project pinned to the released QuantTradeAI package version
 - minimal agent-facing context files
 - workspace metadata under `.quanttradeai/`
 
@@ -25,6 +25,7 @@ quanttradeai init my-strategy-lab
 quanttradeai init --template research
 quanttradeai init my-agent-lab --template rule-agent
 quanttradeai init --force
+quanttradeai init my-lab --quanttradeai-version 0.1.0
 ```
 
 ## Options
@@ -34,6 +35,7 @@ quanttradeai init --force
 | `[PROJECT_DIR]` | current directory | No | Workspace directory to initialize. If omitted, QuantTradeAI initializes the current working directory. |
 | `--template TEXT` | `strategy-lab` | No | Project template to write into `config/project.yaml`. |
 | `--force` | `false` | No | Overwrite generated files that are protected by the initializer. |
+| `--quanttradeai-version TEXT` | installed package version | No | Exact QuantTradeAI package version to pin in the generated uv project. Intended for contributor testing of release or pre-release package versions. Local paths and `file://` URLs are rejected. |
 
 ## Supported Templates
 
@@ -53,6 +55,10 @@ The current CLI supports these template names:
 `init` reads package templates embedded in `quanttradeai/templates/workspace_context/`.
 
 It does not read an existing project config to infer project name, symbols, or agent names.
+
+It also does not search for a local QuantTradeAI source checkout. The generated
+`pyproject.toml` always uses an exact package dependency such as
+`quanttradeai==0.1.0`.
 
 ## Writes
 
@@ -88,7 +94,15 @@ After that, edit `config/project.yaml`, then run:
 
 ```bash
 uv sync
+uv run quanttradeai doctor
 uv run quanttradeai validate -c config/project.yaml
+```
+
+For local source contribution, keep the generated package pin intact. After
+`uv sync`, install your checkout into the workspace environment explicitly:
+
+```bash
+uv pip install --reinstall -e <path-to-QuantTradeAI-checkout>
 ```
 
 ## Common Mistakes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,7 +125,7 @@ quanttradeai init my-research-lab --template research
 git clone https://github.com/AKKI0511/QuantTradeAI.git
 cd QuantTradeAI
 poetry install --with dev
-poetry run quanttradeai init my-lab --quanttradeai-version 0.1.0
+poetry run quanttradeai init my-lab
 cd my-lab
 uv sync
 uv run quanttradeai doctor
@@ -133,9 +133,10 @@ uv run quanttradeai doctor
 
 Open the generated `my-lab` folder in your coding agent.
 
-To test local source changes from that generated workspace, keep the generated
-`quanttradeai==<version>` dependency pin and install the checkout into `.venv`
-explicitly:
+Use `uvx quanttradeai@<version> init my-lab` when you need a workspace generated
+from a specific published package version. To test local source changes from
+that generated workspace, keep the generated `quanttradeai==<version>` pin and
+install the checkout into `.venv` explicitly:
 
 ```bash
 uv pip install --reinstall -e ..

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,9 +40,10 @@ See [Agent Plugins](plugins.md) for provider-specific install, validation, and u
 ## Create A Workspace
 
 ```bash
-quanttradeai init my-lab
+uvx quanttradeai init my-lab
 cd my-lab
 uv sync
+uv run quanttradeai doctor
 ```
 
 To initialize the current directory instead:
@@ -67,7 +68,7 @@ CLAUDE.md
 | Path | Purpose |
 | :--- | :--- |
 | `config/project.yaml` | Canonical project config for data, features, research settings, agents, sweeps, and execution defaults. |
-| `pyproject.toml` | Disposable uv project metadata with QuantTradeAI pinned as a local dependency. |
+| `pyproject.toml` | Disposable uv project metadata with QuantTradeAI pinned to the released package version. |
 | `.python-version` | Python version hint for uv-managed environments. |
 | `.env.example` | Optional environment variable placeholders; copy to `.env` only for local secrets. |
 | `.gitignore` | Ignores local virtualenvs, secrets, and generated run/output directories. |
@@ -124,12 +125,21 @@ quanttradeai init my-research-lab --template research
 git clone https://github.com/AKKI0511/QuantTradeAI.git
 cd QuantTradeAI
 poetry install --with dev
-poetry run quanttradeai init my-lab
+poetry run quanttradeai init my-lab --quanttradeai-version 0.1.0
 cd my-lab
 uv sync
+uv run quanttradeai doctor
 ```
 
 Open the generated `my-lab` folder in your coding agent.
+
+To test local source changes from that generated workspace, keep the generated
+`quanttradeai==<version>` dependency pin and install the checkout into `.venv`
+explicitly:
+
+```bash
+uv pip install --reinstall -e ..
+```
 
 ## Where To Go Next
 

--- a/quanttradeai/__init__.py
+++ b/quanttradeai/__init__.py
@@ -37,7 +37,9 @@ _EXPORT_MAP = {
     "BacktestEngine": ("quanttradeai.backtest", "BacktestEngine"),
 }
 
-__all__ = list(_EXPORT_MAP)
+__version__ = "0.1.0"
+
+__all__ = [*_EXPORT_MAP, "__version__"]
 
 
 def __getattr__(name: str):

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -12,12 +12,15 @@ import re
 import shutil
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
+from importlib import metadata
 from pathlib import Path
 from typing import Any, Optional
 
 import typer
 import yaml
 
+from . import __version__ as PACKAGE_VERSION
+from .doctor import doctor_workspace, render_doctor_text
 from .init_context import iter_init_context_templates, write_init_context_files
 from .utils.config_validator import validate_project_config
 from .utils.project_paths import infer_project_root
@@ -728,27 +731,33 @@ def _normalize_workspace_project_name(workspace: Path) -> str:
     return normalized or "quanttradeai-workspace"
 
 
-def _quanttradeai_source_root() -> Path:
-    package_dir = Path(__file__).resolve().parent
-    for candidate in package_dir.parents:
-        pyproject_path = candidate / "pyproject.toml"
-        package_init = candidate / "quanttradeai" / "__init__.py"
-        if not pyproject_path.is_file() or not package_init.is_file():
-            continue
-        pyproject_text = pyproject_path.read_text(encoding="utf-8")
-        if re.search(r'(?m)^name\s*=\s*["\']quanttradeai["\']', pyproject_text):
-            return candidate
+def _installed_quanttradeai_version() -> str:
+    try:
+        return metadata.version("quanttradeai")
+    except metadata.PackageNotFoundError:
+        return PACKAGE_VERSION
 
-    raise RuntimeError(
-        "Could not find the local QuantTradeAI source checkout needed for the "
-        "generated uv project dependency. Run init from a local QuantTradeAI "
-        "checkout, for example with `poetry run quanttradeai init <workspace>`."
+
+def _normalize_quanttradeai_version(version: str | None) -> str:
+    candidate = (
+        _installed_quanttradeai_version() if version is None else str(version).strip()
     )
+    if not candidate:
+        raise ValueError("QuantTradeAI package version must not be blank.")
+    if re.search(r"[\\/: \t\r\n]", candidate) or candidate.startswith((".", "~")):
+        raise ValueError(
+            "QuantTradeAI package version must be a version like 0.1.0. "
+            "Local paths and file URLs are not supported in generated workspaces."
+        )
+    return candidate
 
 
-def _render_workspace_pyproject(workspace: Path, source_root: Path) -> str:
+def _quanttradeai_dependency_spec(version: str) -> str:
+    return f"quanttradeai=={version}"
+
+
+def _render_workspace_pyproject(workspace: Path, quanttradeai_dependency: str) -> str:
     project_name = _normalize_workspace_project_name(workspace)
-    dependency = f"quanttradeai @ {source_root.as_uri()}"
     return f"""
 [project]
 name = {json.dumps(project_name)}
@@ -756,7 +765,7 @@ version = "0.1.0"
 description = "Disposable QuantTradeAI project workspace"
 requires-python = ">=3.11,<4.0"
 dependencies = [
-    {json.dumps(dependency)},
+    {json.dumps(quanttradeai_dependency)},
 ]
 
 [tool.uv]
@@ -791,11 +800,13 @@ runs/
 
 
 def _write_workspace_project_files(
-    workspace: Path, source_root: Path, force: bool
+    workspace: Path, quanttradeai_dependency: str, force: bool
 ) -> None:
     files = {
         workspace
-        / "pyproject.toml": _render_workspace_pyproject(workspace, source_root),
+        / "pyproject.toml": _render_workspace_pyproject(
+            workspace, quanttradeai_dependency
+        ),
         workspace / ".python-version": "3.11\n",
         workspace / ".env.example": _render_workspace_env_example(),
         workspace / ".gitignore": _render_workspace_gitignore(),
@@ -893,7 +904,10 @@ def _write_agent_context_files(workspace: Path, force: bool) -> None:
 
 
 def _write_workspace_metadata(
-    workspace: Path, template_name: str, source_root: Path
+    workspace: Path,
+    template_name: str,
+    quanttradeai_dependency: str,
+    quanttradeai_version: str,
 ) -> None:
     metadata = {
         "version": 2,
@@ -902,7 +916,8 @@ def _write_workspace_metadata(
         "python_project": {
             "manager": "uv",
             "pyproject": "pyproject.toml",
-            "quanttradeai_dependency": source_root.as_uri(),
+            "quanttradeai_dependency": quanttradeai_dependency,
+            "quanttradeai_version": quanttradeai_version,
         },
         "agent_context": {
             "agents_md": "AGENTS.md",
@@ -1963,6 +1978,14 @@ def cmd_init(
         "strategy-lab", "--template", help="Project template to initialize"
     ),
     force: bool = typer.Option(False, "--force", help="Overwrite generated files"),
+    quanttradeai_version: Optional[str] = typer.Option(
+        None,
+        "--quanttradeai-version",
+        help=(
+            "QuantTradeAI package version to pin in the generated uv project. "
+            "Defaults to the installed package version."
+        ),
+    ),
 ):
     """Initialize a QuantTradeAI workspace."""
 
@@ -1983,25 +2006,28 @@ def cmd_init(
     overwrite_guard_paths = _init_overwrite_guard_paths(project_config_path)
 
     try:
-        source_root = _quanttradeai_source_root()
+        pinned_version = _normalize_quanttradeai_version(quanttradeai_version)
+        quanttradeai_dependency = _quanttradeai_dependency_spec(pinned_version)
         _check_can_write(
             owned_paths,
             force=force,
             overwrite_guard_paths=overwrite_guard_paths,
         )
-    except RuntimeError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(code=1)
     except ValueError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1)
 
     workspace.mkdir(parents=True, exist_ok=True)
     _write_project_template(normalized, project_config_path)
-    _write_workspace_project_files(workspace, source_root, force=force)
+    _write_workspace_project_files(workspace, quanttradeai_dependency, force=force)
     _write_agent_context_files(workspace, force=force)
     _remove_legacy_generated_skills(workspace, force=force)
-    _write_workspace_metadata(workspace, normalized, source_root)
+    _write_workspace_metadata(
+        workspace,
+        normalized,
+        quanttradeai_dependency,
+        pinned_version,
+    )
     _write_template_assets(normalized, project_config_path, force)
 
     typer.echo(f"Initialized QuantTradeAI workspace at {workspace}")
@@ -2052,6 +2078,28 @@ def cmd_validate(
             typer.echo(f"Warning: {warning}", err=True)
 
     typer.echo(json.dumps(result, indent=2))
+
+
+@app.command("doctor")
+def cmd_doctor(
+    config: str = typer.Option(
+        "config/project.yaml", "-c", "--config", help="Path to project config YAML"
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON diagnostics.",
+    ),
+):
+    """Run a read-only workspace health check."""
+
+    result = doctor_workspace(config_path=config)
+    if json_output:
+        typer.echo(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    else:
+        typer.echo(render_doctor_text(result))
+    if result["exit_code"]:
+        raise typer.Exit(code=int(result["exit_code"]))
 
 
 if __name__ == "__main__":

--- a/quanttradeai/cli.py
+++ b/quanttradeai/cli.py
@@ -738,22 +738,8 @@ def _installed_quanttradeai_version() -> str:
         return PACKAGE_VERSION
 
 
-def _normalize_quanttradeai_version(version: str | None) -> str:
-    candidate = (
-        _installed_quanttradeai_version() if version is None else str(version).strip()
-    )
-    if not candidate:
-        raise ValueError("QuantTradeAI package version must not be blank.")
-    if re.search(r"[\\/: \t\r\n]", candidate) or candidate.startswith((".", "~")):
-        raise ValueError(
-            "QuantTradeAI package version must be a version like 0.1.0. "
-            "Local paths and file URLs are not supported in generated workspaces."
-        )
-    return candidate
-
-
-def _quanttradeai_dependency_spec(version: str) -> str:
-    return f"quanttradeai=={version}"
+def _quanttradeai_dependency_spec() -> str:
+    return f"quanttradeai=={_installed_quanttradeai_version()}"
 
 
 def _render_workspace_pyproject(workspace: Path, quanttradeai_dependency: str) -> str:
@@ -907,7 +893,6 @@ def _write_workspace_metadata(
     workspace: Path,
     template_name: str,
     quanttradeai_dependency: str,
-    quanttradeai_version: str,
 ) -> None:
     metadata = {
         "version": 2,
@@ -917,7 +902,6 @@ def _write_workspace_metadata(
             "manager": "uv",
             "pyproject": "pyproject.toml",
             "quanttradeai_dependency": quanttradeai_dependency,
-            "quanttradeai_version": quanttradeai_version,
         },
         "agent_context": {
             "agents_md": "AGENTS.md",
@@ -1978,14 +1962,6 @@ def cmd_init(
         "strategy-lab", "--template", help="Project template to initialize"
     ),
     force: bool = typer.Option(False, "--force", help="Overwrite generated files"),
-    quanttradeai_version: Optional[str] = typer.Option(
-        None,
-        "--quanttradeai-version",
-        help=(
-            "QuantTradeAI package version to pin in the generated uv project. "
-            "Defaults to the installed package version."
-        ),
-    ),
 ):
     """Initialize a QuantTradeAI workspace."""
 
@@ -2006,8 +1982,7 @@ def cmd_init(
     overwrite_guard_paths = _init_overwrite_guard_paths(project_config_path)
 
     try:
-        pinned_version = _normalize_quanttradeai_version(quanttradeai_version)
-        quanttradeai_dependency = _quanttradeai_dependency_spec(pinned_version)
+        quanttradeai_dependency = _quanttradeai_dependency_spec()
         _check_can_write(
             owned_paths,
             force=force,
@@ -2026,7 +2001,6 @@ def cmd_init(
         workspace,
         normalized,
         quanttradeai_dependency,
-        pinned_version,
     )
     _write_template_assets(normalized, project_config_path, force)
 

--- a/quanttradeai/doctor.py
+++ b/quanttradeai/doctor.py
@@ -1,0 +1,889 @@
+"""Read-only workspace health checks for QuantTradeAI."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tomllib
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from quanttradeai import __version__ as PACKAGE_VERSION
+from quanttradeai.utils.config_validator import validate_project_config_readonly
+from quanttradeai.utils.project_paths import infer_project_root
+
+
+DOCTOR_EXIT_OK = 0
+DOCTOR_EXIT_ERROR = 1
+QUANTTRADEAI_DEPENDENCY_RE = re.compile(
+    r"^\s*quanttradeai\s*==\s*([A-Za-z0-9][A-Za-z0-9.!+_-]*)\s*$",
+    re.IGNORECASE,
+)
+LLM_PROVIDER_ENV = {
+    "openai": ("OPENAI_API_KEY",),
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    "google": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+}
+
+
+def _installed_quanttradeai_version() -> str:
+    try:
+        return metadata.version("quanttradeai")
+    except metadata.PackageNotFoundError:
+        return PACKAGE_VERSION
+
+
+def _diagnostic(
+    diagnostics: list[dict[str, Any]],
+    *,
+    severity: str,
+    code: str,
+    message: str,
+    action: str,
+    path: str | None = None,
+) -> None:
+    item = {
+        "severity": severity,
+        "code": code,
+        "message": message,
+        "action": action,
+    }
+    if path:
+        item["path"] = path
+    diagnostics.append(item)
+
+
+def _check(
+    checks: list[dict[str, str]],
+    *,
+    name: str,
+    status: str,
+    summary: str,
+) -> None:
+    checks.append({"name": name, "status": status, "summary": summary})
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _read_pyproject(
+    pyproject_path: Path,
+    diagnostics: list[dict[str, Any]],
+    root: Path,
+) -> dict[str, Any] | None:
+    if not pyproject_path.exists():
+        _diagnostic(
+            diagnostics,
+            severity="warning",
+            code="workspace.pyproject_missing",
+            message="pyproject.toml was not found in the workspace root.",
+            action="Run `quanttradeai init` from the workspace root, or add the generated pyproject.toml.",
+            path=_relative(pyproject_path, root),
+        )
+        return None
+    if not pyproject_path.is_file():
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="workspace.pyproject_not_file",
+            message="pyproject.toml exists but is not a regular file.",
+            action="Replace it with the generated QuantTradeAI pyproject.toml.",
+            path=_relative(pyproject_path, root),
+        )
+        return None
+    try:
+        return tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="workspace.pyproject_invalid",
+            message=f"pyproject.toml is not valid TOML: {exc}",
+            action="Fix pyproject.toml syntax, then rerun `quanttradeai doctor`.",
+            path=_relative(pyproject_path, root),
+        )
+        return None
+
+
+def _read_workspace_metadata(
+    metadata_path: Path,
+    diagnostics: list[dict[str, Any]],
+    root: Path,
+    *,
+    source_checkout: bool,
+) -> dict[str, Any] | None:
+    if not metadata_path.exists():
+        if not source_checkout:
+            _diagnostic(
+                diagnostics,
+                severity="warning",
+                code="workspace.metadata_missing",
+                message=".quanttradeai/workspace.yaml was not found.",
+                action="Run `quanttradeai init --force` only if this directory should be regenerated as a QuantTradeAI workspace.",
+                path=_relative(metadata_path, root),
+            )
+        return None
+    if not metadata_path.is_file():
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="workspace.metadata_not_file",
+            message=".quanttradeai/workspace.yaml exists but is not a regular file.",
+            action="Replace it with generated workspace metadata.",
+            path=_relative(metadata_path, root),
+        )
+        return None
+    try:
+        payload = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="workspace.metadata_invalid",
+            message=f".quanttradeai/workspace.yaml is not valid YAML: {exc}",
+            action="Regenerate workspace metadata with `quanttradeai init --force` after preserving local changes.",
+            path=_relative(metadata_path, root),
+        )
+        return None
+    if not isinstance(payload, dict):
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="workspace.metadata_invalid",
+            message=".quanttradeai/workspace.yaml must contain a YAML mapping.",
+            action="Regenerate workspace metadata with `quanttradeai init --force` after preserving local changes.",
+            path=_relative(metadata_path, root),
+        )
+        return None
+    return payload
+
+
+def _dependency_name(requirement: str) -> str:
+    name = re.split(r"[<>=!~ @\[]", requirement.strip(), maxsplit=1)[0]
+    return name.lower().replace("_", "-")
+
+
+def _find_quanttradeai_dependency(dependencies: Any) -> str | None:
+    if not isinstance(dependencies, list):
+        return None
+    for dependency in dependencies:
+        if (
+            isinstance(dependency, str)
+            and _dependency_name(dependency) == "quanttradeai"
+        ):
+            return dependency.strip()
+    return None
+
+
+def _looks_like_local_dependency(dependency: str) -> bool:
+    normalized = dependency.lower()
+    return bool(
+        "file://" in normalized
+        or re.search(r"@\s*file:", dependency, re.IGNORECASE)
+        or re.search(r"@\s*(?:\.{1,2}[\\/]|/|[A-Za-z]:[\\/])", dependency)
+    )
+
+
+def _check_package_metadata(
+    *,
+    pyproject: dict[str, Any] | None,
+    workspace_metadata: dict[str, Any] | None,
+    root: Path,
+    diagnostics: list[dict[str, Any]],
+) -> tuple[bool, str, str | None]:
+    installed_version = _installed_quanttradeai_version()
+    project = dict((pyproject or {}).get("project") or {})
+    project_name = str(project.get("name") or "").strip()
+    pyproject_version = project.get("version")
+    source_checkout = (
+        project_name == "quanttradeai" and (root / "quanttradeai").is_dir()
+    )
+    pinned_dependency: str | None = None
+
+    if source_checkout:
+        if pyproject_version and str(pyproject_version) != installed_version:
+            _diagnostic(
+                diagnostics,
+                severity="warning",
+                code="package.version_mismatch",
+                message=(
+                    "The source checkout pyproject version differs from the imported "
+                    f"QuantTradeAI version ({pyproject_version} != {installed_version})."
+                ),
+                action="Reinstall the editable package or update version metadata before release testing.",
+                path="pyproject.toml",
+            )
+        return True, installed_version, None
+
+    dependencies = project.get("dependencies")
+    pinned_dependency = _find_quanttradeai_dependency(dependencies)
+    if pinned_dependency is None:
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="package.dependency_missing",
+            message="Workspace pyproject.toml does not declare a QuantTradeAI dependency.",
+            action="Regenerate with `quanttradeai init --force` or add `quanttradeai==<version>` to project.dependencies.",
+            path="pyproject.toml",
+        )
+    elif _looks_like_local_dependency(pinned_dependency):
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="package.dependency_local",
+            message="Workspace pyproject.toml depends on a local QuantTradeAI checkout.",
+            action="Replace the dependency with an exact released package pin such as `quanttradeai==0.1.0`.",
+            path="pyproject.toml",
+        )
+    else:
+        match = QUANTTRADEAI_DEPENDENCY_RE.fullmatch(pinned_dependency)
+        if not match:
+            _diagnostic(
+                diagnostics,
+                severity="error",
+                code="package.dependency_unpinned",
+                message="Workspace pyproject.toml must pin QuantTradeAI with `quanttradeai==<version>`.",
+                action="Regenerate with `quanttradeai init --force` or change the dependency to an exact version pin.",
+                path="pyproject.toml",
+            )
+        elif match.group(1) != installed_version:
+            _diagnostic(
+                diagnostics,
+                severity="error",
+                code="package.version_mismatch",
+                message=(
+                    "The installed QuantTradeAI CLI version does not match the workspace pin "
+                    f"({installed_version} != {match.group(1)})."
+                ),
+                action="Run `uv sync` and then `uv run quanttradeai doctor`, or update the workspace pin intentionally.",
+                path="pyproject.toml",
+            )
+
+    python_project = dict((workspace_metadata or {}).get("python_project") or {})
+    metadata_dependency = python_project.get("quanttradeai_dependency")
+    if (
+        metadata_dependency
+        and pinned_dependency
+        and metadata_dependency != pinned_dependency
+    ):
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="package.metadata_mismatch",
+            message=".quanttradeai/workspace.yaml disagrees with pyproject.toml about the QuantTradeAI dependency.",
+            action="Regenerate workspace metadata with `quanttradeai init --force` after preserving local changes.",
+            path=".quanttradeai/workspace.yaml",
+        )
+    if isinstance(metadata_dependency, str) and _looks_like_local_dependency(
+        metadata_dependency
+    ):
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="package.metadata_local",
+            message=".quanttradeai/workspace.yaml records a local QuantTradeAI checkout dependency.",
+            action="Regenerate with a released package pin using the fixed `quanttradeai init`.",
+            path=".quanttradeai/workspace.yaml",
+        )
+
+    metadata_version = python_project.get("quanttradeai_version")
+    if (
+        metadata_version
+        and pinned_dependency
+        and QUANTTRADEAI_DEPENDENCY_RE.fullmatch(pinned_dependency)
+    ):
+        pinned_version = QUANTTRADEAI_DEPENDENCY_RE.fullmatch(pinned_dependency).group(
+            1
+        )
+        if str(metadata_version) != pinned_version:
+            _diagnostic(
+                diagnostics,
+                severity="error",
+                code="package.metadata_version_mismatch",
+                message=".quanttradeai/workspace.yaml records a different QuantTradeAI version than pyproject.toml.",
+                action="Regenerate workspace metadata with `quanttradeai init --force` after preserving local changes.",
+                path=".quanttradeai/workspace.yaml",
+            )
+
+    return source_checkout, installed_version, pinned_dependency
+
+
+def _uv_version() -> str | None:
+    executable = shutil.which("uv")
+    if executable is None:
+        return None
+    try:
+        result = subprocess.run(
+            [executable, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    return (result.stdout or result.stderr).strip() or "unknown"
+
+
+def _check_python_and_uv(
+    *,
+    root: Path,
+    source_checkout: bool,
+    diagnostics: list[dict[str, Any]],
+) -> dict[str, Any]:
+    python_version = ".".join(str(part) for part in sys.version_info[:3])
+    if sys.version_info < (3, 11):
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="environment.python_unsupported",
+            message=f"Python {python_version} is active, but QuantTradeAI requires Python 3.11 or newer.",
+            action="Switch to Python 3.11+ and rerun `uv sync`.",
+        )
+
+    python_version_file = root / ".python-version"
+    if python_version_file.is_file():
+        requested = python_version_file.read_text(encoding="utf-8").strip()
+        if requested and not python_version.startswith(requested):
+            _diagnostic(
+                diagnostics,
+                severity="warning",
+                code="environment.python_version_file_mismatch",
+                message=f".python-version requests {requested}, but the active Python is {python_version}.",
+                action="Use the requested Python version or update .python-version intentionally.",
+                path=".python-version",
+            )
+
+    uv = _uv_version()
+    if uv is None:
+        _diagnostic(
+            diagnostics,
+            severity="warning",
+            code="environment.uv_missing",
+            message="uv was not found on PATH.",
+            action="Install uv before running workspace commands such as `uv sync`.",
+        )
+
+    if not source_checkout and not (root / ".venv").exists():
+        _diagnostic(
+            diagnostics,
+            severity="warning",
+            code="environment.venv_missing",
+            message="The workspace .venv directory does not exist yet.",
+            action="Run `uv sync` in the workspace before running research or agent commands.",
+            path=".venv",
+        )
+
+    return {
+        "python": python_version,
+        "executable": sys.executable,
+        "uv": uv,
+        "virtual_env": os.environ.get("VIRTUAL_ENV"),
+    }
+
+
+def _nearest_existing_parent(path: Path) -> Path | None:
+    current = path
+    while not current.exists():
+        if current.parent == current:
+            return None
+        current = current.parent
+    return current
+
+
+def _check_output_paths(
+    *,
+    root: Path,
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    for relative_path in ("data", "models", "reports", "runs"):
+        path = root / relative_path
+        if path.exists() and not path.is_dir():
+            _diagnostic(
+                diagnostics,
+                severity="error",
+                code="outputs.path_not_directory",
+                message=f"{relative_path}/ exists but is not a directory.",
+                action=f"Move or remove {relative_path} so QuantTradeAI can write output artifacts there.",
+                path=relative_path,
+            )
+            continue
+        access_target = path if path.exists() else _nearest_existing_parent(path)
+        if access_target is None or not os.access(access_target, os.W_OK):
+            _diagnostic(
+                diagnostics,
+                severity="error",
+                code="outputs.not_writable",
+                message=f"QuantTradeAI cannot write to {relative_path}/ or its nearest existing parent.",
+                action=f"Fix filesystem permissions for {relative_path}/ before running workflows.",
+                path=relative_path,
+            )
+
+
+def _missing_env_vars(env: Mapping[str, str], names: tuple[str, ...]) -> list[str]:
+    return [name for name in names if not str(env.get(name) or "").strip()]
+
+
+def _check_required_config(
+    *,
+    resolved: dict[str, Any],
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    data = dict(resolved.get("data") or {})
+    features = dict(resolved.get("features") or {})
+    research = dict(resolved.get("research") or {})
+    agents = list(resolved.get("agents") or [])
+    project = dict(resolved.get("project") or {})
+    profiles = dict(resolved.get("profiles") or {})
+
+    profile = str(project.get("profile") or "").strip()
+    if profile and profile not in profiles:
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="config.profile_unknown",
+            message=f"project.profile references unknown profile '{profile}'.",
+            action="Set project.profile to one of the keys under profiles.",
+            path="config/project.yaml",
+        )
+    if not data.get("symbols"):
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="config.symbols_missing",
+            message="data.symbols is empty.",
+            action="Add at least one ticker to data.symbols.",
+            path="config/project.yaml",
+        )
+    if not (features.get("definitions") or []):
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="config.features_missing",
+            message="features.definitions is empty.",
+            action="Add at least one reusable feature definition.",
+            path="config/project.yaml",
+        )
+    if not bool(research.get("enabled", False)) and not agents:
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="config.no_workflow_enabled",
+            message="The project has no enabled research workflow and no agents.",
+            action="Enable research.enabled or define at least one agent.",
+            path="config/project.yaml",
+        )
+
+
+def _check_credentials(
+    *,
+    resolved: dict[str, Any],
+    env: Mapping[str, str],
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    data_streaming = dict((resolved.get("data") or {}).get("streaming") or {})
+    replay_enabled = bool(
+        dict(data_streaming.get("replay") or {}).get("enabled", False)
+    )
+    agents = list(resolved.get("agents") or [])
+
+    for agent in agents:
+        agent_name = str(agent.get("name") or "<unnamed>")
+        agent_kind = str(agent.get("kind") or "").strip().lower()
+        agent_mode = str(agent.get("mode") or "").strip().lower()
+        llm_cfg = dict(agent.get("llm") or {})
+        if agent_kind in {"llm", "hybrid"}:
+            provider = str(llm_cfg.get("provider") or "").strip().lower()
+            if not provider:
+                _diagnostic(
+                    diagnostics,
+                    severity="error",
+                    code="credentials.llm_provider_missing",
+                    message=f"Agent '{agent_name}' does not configure llm.provider.",
+                    action="Set llm.provider and the matching provider credential environment variable.",
+                    path="config/project.yaml",
+                )
+            elif provider in LLM_PROVIDER_ENV:
+                candidates = LLM_PROVIDER_ENV[provider]
+                if all(not str(env.get(name) or "").strip() for name in candidates):
+                    _diagnostic(
+                        diagnostics,
+                        severity="error",
+                        code="credentials.llm_missing",
+                        message=(
+                            f"Agent '{agent_name}' uses provider '{provider}' but none "
+                            f"of these environment variables are set: {', '.join(candidates)}."
+                        ),
+                        action="Set the provider API key in the environment before running this agent.",
+                        path="config/project.yaml",
+                    )
+            else:
+                _diagnostic(
+                    diagnostics,
+                    severity="warning",
+                    code="credentials.llm_provider_unknown",
+                    message=f"Agent '{agent_name}' uses unrecognized llm.provider '{provider}'.",
+                    action="Verify the provider's required environment variables before running the agent.",
+                    path="config/project.yaml",
+                )
+
+        execution_backend = (
+            str(dict(agent.get("execution") or {}).get("backend") or "simulated")
+            .strip()
+            .lower()
+        )
+        uses_alpaca_backend = execution_backend == "alpaca"
+        uses_realtime_alpaca = (
+            agent_mode == "live"
+            and str(data_streaming.get("provider") or "").strip().lower() == "alpaca"
+        )
+        if uses_alpaca_backend or (uses_realtime_alpaca and not replay_enabled):
+            missing = _missing_env_vars(env, ("ALPACA_API_KEY", "ALPACA_API_SECRET"))
+            if missing:
+                _diagnostic(
+                    diagnostics,
+                    severity="error",
+                    code="credentials.alpaca_missing",
+                    message=(
+                        f"Agent '{agent_name}' needs Alpaca credentials but these "
+                        f"environment variables are missing: {', '.join(missing)}."
+                    ),
+                    action="Set ALPACA_API_KEY and ALPACA_API_SECRET before running Alpaca-backed paper or live workflows.",
+                    path="config/project.yaml",
+                )
+
+
+def _check_safety_defaults(
+    *,
+    resolved: dict[str, Any],
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    agents = list(resolved.get("agents") or [])
+    live_agents = [
+        agent
+        for agent in agents
+        if str(agent.get("mode") or "").strip().lower() == "live"
+    ]
+    paper_agents = [
+        agent
+        for agent in agents
+        if str(agent.get("mode") or "").strip().lower() == "paper"
+    ]
+    risk = dict(resolved.get("risk") or {})
+    position_manager = dict(resolved.get("position_manager") or {})
+    data_streaming = dict((resolved.get("data") or {}).get("streaming") or {})
+    replay_enabled = bool(
+        dict(data_streaming.get("replay") or {}).get("enabled", False)
+    )
+
+    if live_agents:
+        drawdown = dict(risk.get("drawdown_protection") or {})
+        if not risk:
+            _diagnostic(
+                diagnostics,
+                severity="error",
+                code="safety.live_risk_missing",
+                message="At least one agent is configured for live mode but top-level risk is missing.",
+                action="Add a top-level risk section with drawdown protection before live runs.",
+                path="config/project.yaml",
+            )
+        elif drawdown.get("enabled") is not True:
+            _diagnostic(
+                diagnostics,
+                severity="error",
+                code="safety.drawdown_disabled",
+                message="Live mode is configured but risk.drawdown_protection.enabled is not true.",
+                action="Enable drawdown protection or keep agents in paper mode.",
+                path="config/project.yaml",
+            )
+        if not position_manager:
+            _diagnostic(
+                diagnostics,
+                severity="error",
+                code="safety.position_manager_missing",
+                message="At least one agent is configured for live mode but position_manager is missing.",
+                action="Add top-level position_manager settings before live runs.",
+                path="config/project.yaml",
+            )
+        elif str(position_manager.get("mode") or "").strip().lower() != "live":
+            _diagnostic(
+                diagnostics,
+                severity="warning",
+                code="safety.position_manager_mode",
+                message="Live agents are configured but position_manager.mode is not live.",
+                action="Set position_manager.mode: live before live operation.",
+                path="config/project.yaml",
+            )
+
+        for agent in live_agents:
+            agent_name = str(agent.get("name") or "<unnamed>")
+            agent_risk = dict(agent.get("risk") or {})
+            if "max_position_pct" not in agent_risk:
+                _diagnostic(
+                    diagnostics,
+                    severity="error",
+                    code="safety.agent_position_limit_missing",
+                    message=f"Live agent '{agent_name}' does not set risk.max_position_pct.",
+                    action="Add a per-agent max_position_pct limit before live operation.",
+                    path="config/project.yaml",
+                )
+
+    if paper_agents and data_streaming.get("enabled") and not replay_enabled:
+        _diagnostic(
+            diagnostics,
+            severity="warning",
+            code="safety.paper_replay_disabled",
+            message="Paper agents are configured but data.streaming.replay.enabled is not true.",
+            action="Prefer replay-backed paper mode unless you intentionally need realtime paper data.",
+            path="config/project.yaml",
+        )
+
+
+def doctor_workspace(
+    *,
+    workspace: Path | str | None = None,
+    config_path: Path | str = "config/project.yaml",
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Run read-only health checks for the current QuantTradeAI workspace."""
+
+    env = env or os.environ
+    cwd = Path.cwd().resolve() if workspace is None else Path(workspace).resolve()
+    requested_config = Path(config_path).expanduser()
+    config_abs = (
+        requested_config if requested_config.is_absolute() else cwd / requested_config
+    )
+    root = infer_project_root(config_abs)
+    diagnostics: list[dict[str, Any]] = []
+    checks: list[dict[str, str]] = []
+
+    pyproject_path = root / "pyproject.toml"
+    pyproject = _read_pyproject(pyproject_path, diagnostics, root)
+    project = dict((pyproject or {}).get("project") or {})
+    source_checkout = (
+        str(project.get("name") or "").strip() == "quanttradeai"
+        and (root / "quanttradeai").is_dir()
+    )
+    metadata_path = root / ".quanttradeai" / "workspace.yaml"
+    workspace_metadata = _read_workspace_metadata(
+        metadata_path,
+        diagnostics,
+        root,
+        source_checkout=source_checkout,
+    )
+
+    source_checkout, installed_version, pinned_dependency = _check_package_metadata(
+        pyproject=pyproject,
+        workspace_metadata=workspace_metadata,
+        root=root,
+        diagnostics=diagnostics,
+    )
+
+    if not config_abs.exists():
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="workspace.config_missing",
+            message=f"Project config was not found at {_relative(config_abs, root)}.",
+            action="Run `quanttradeai init` or pass the correct path with `--config`.",
+            path=_relative(config_abs, root),
+        )
+        validation: dict[str, Any] | None = None
+    elif not config_abs.is_file():
+        _diagnostic(
+            diagnostics,
+            severity="error",
+            code="workspace.config_not_file",
+            message=f"Project config path is not a regular file: {_relative(config_abs, root)}.",
+            action="Replace it with a valid config/project.yaml file.",
+            path=_relative(config_abs, root),
+        )
+        validation = None
+    else:
+        try:
+            validation = validate_project_config_readonly(config_abs)
+        except Exception as exc:
+            _diagnostic(
+                diagnostics,
+                severity="error",
+                code="project.config_invalid",
+                message=f"config/project.yaml failed validation: {exc}",
+                action="Fix the reported project YAML issue, then rerun `quanttradeai doctor`.",
+                path=_relative(config_abs, root),
+            )
+            validation = None
+
+    environment = _check_python_and_uv(
+        root=root,
+        source_checkout=source_checkout,
+        diagnostics=diagnostics,
+    )
+    _check_output_paths(root=root, diagnostics=diagnostics)
+
+    if validation is not None:
+        for warning in validation.get("warnings") or []:
+            _diagnostic(
+                diagnostics,
+                severity="warning",
+                code="project.config_warning",
+                message=str(warning),
+                action="Update config/project.yaml to use the canonical setting.",
+                path=_relative(config_abs, root),
+            )
+        resolved = dict(validation.get("resolved") or {})
+        _check_required_config(resolved=resolved, diagnostics=diagnostics)
+        _check_credentials(resolved=resolved, env=env, diagnostics=diagnostics)
+        _check_safety_defaults(resolved=resolved, diagnostics=diagnostics)
+
+    error_count = sum(1 for item in diagnostics if item["severity"] == "error")
+    warning_count = sum(1 for item in diagnostics if item["severity"] == "warning")
+
+    _check(
+        checks,
+        name="workspace",
+        status=(
+            "failed"
+            if any(
+                d["code"].startswith("workspace.") and d["severity"] == "error"
+                for d in diagnostics
+            )
+            else "passed"
+        ),
+        summary="Workspace files are present and readable.",
+    )
+    _check(
+        checks,
+        name="environment",
+        status=(
+            "failed"
+            if any(
+                d["code"].startswith("environment.") and d["severity"] == "error"
+                for d in diagnostics
+            )
+            else "passed"
+        ),
+        summary="Python and uv environment checked.",
+    )
+    _check(
+        checks,
+        name="package",
+        status=(
+            "failed"
+            if any(
+                d["code"].startswith("package.") and d["severity"] == "error"
+                for d in diagnostics
+            )
+            else "passed"
+        ),
+        summary="QuantTradeAI package metadata checked.",
+    )
+    _check(
+        checks,
+        name="project_config",
+        status=(
+            "failed"
+            if any(
+                (d["code"].startswith("project.") or d["code"].startswith("config."))
+                and d["severity"] == "error"
+                for d in diagnostics
+            )
+            else "passed"
+        ),
+        summary="Project YAML validated read-only.",
+    )
+    _check(
+        checks,
+        name="outputs",
+        status=(
+            "failed"
+            if any(
+                d["code"].startswith("outputs.") and d["severity"] == "error"
+                for d in diagnostics
+            )
+            else "passed"
+        ),
+        summary="Output paths checked without creating files.",
+    )
+    _check(
+        checks,
+        name="credentials",
+        status=(
+            "failed"
+            if any(
+                d["code"].startswith("credentials.") and d["severity"] == "error"
+                for d in diagnostics
+            )
+            else "passed"
+        ),
+        summary="Relevant credential environment variables checked.",
+    )
+    _check(
+        checks,
+        name="safety",
+        status=(
+            "failed"
+            if any(
+                d["code"].startswith("safety.") and d["severity"] == "error"
+                for d in diagnostics
+            )
+            else "passed"
+        ),
+        summary="Paper/live safety defaults checked.",
+    )
+
+    exit_code = DOCTOR_EXIT_ERROR if error_count else DOCTOR_EXIT_OK
+    return {
+        "status": "error" if error_count else "ok",
+        "exit_code": exit_code,
+        "workspace": str(root),
+        "config_path": str(config_abs),
+        "source_checkout": source_checkout,
+        "package": {
+            "installed_version": installed_version,
+            "workspace_dependency": pinned_dependency,
+        },
+        "environment": environment,
+        "summary": {
+            "checks": len(checks),
+            "errors": error_count,
+            "warnings": warning_count,
+        },
+        "checks": checks,
+        "diagnostics": diagnostics,
+    }
+
+
+def render_doctor_text(result: Mapping[str, Any]) -> str:
+    """Render concise text diagnostics for humans and coding agents."""
+
+    summary = dict(result.get("summary") or {})
+    diagnostics = list(result.get("diagnostics") or [])
+    lines = [
+        "QuantTradeAI doctor: "
+        f"{str(result.get('status', 'unknown')).upper()} "
+        f"({summary.get('errors', 0)} errors, {summary.get('warnings', 0)} warnings)",
+        f"workspace: {result.get('workspace')}",
+        f"config: {result.get('config_path')}",
+    ]
+    if not diagnostics:
+        lines.append("All required checks passed.")
+        return "\n".join(lines)
+
+    for item in diagnostics:
+        location = f" ({item['path']})" if item.get("path") else ""
+        lines.append(
+            f"[{item['severity']}] {item['code']}{location}: {item['message']}"
+        )
+        lines.append(f"  action: {item['action']}")
+    return "\n".join(lines)

--- a/quanttradeai/doctor.py
+++ b/quanttradeai/doctor.py
@@ -297,25 +297,6 @@ def _check_package_metadata(
             path=".quanttradeai/workspace.yaml",
         )
 
-    metadata_version = python_project.get("quanttradeai_version")
-    if (
-        metadata_version
-        and pinned_dependency
-        and QUANTTRADEAI_DEPENDENCY_RE.fullmatch(pinned_dependency)
-    ):
-        pinned_version = QUANTTRADEAI_DEPENDENCY_RE.fullmatch(pinned_dependency).group(
-            1
-        )
-        if str(metadata_version) != pinned_version:
-            _diagnostic(
-                diagnostics,
-                severity="error",
-                code="package.metadata_version_mismatch",
-                message=".quanttradeai/workspace.yaml records a different QuantTradeAI version than pyproject.toml.",
-                action="Regenerate workspace metadata with `quanttradeai init --force` after preserving local changes.",
-                path=".quanttradeai/workspace.yaml",
-            )
-
     return source_checkout, installed_version, pinned_dependency
 
 

--- a/quanttradeai/templates/workspace_context/AGENTS.md
+++ b/quanttradeai/templates/workspace_context/AGENTS.md
@@ -5,7 +5,7 @@ This is a disposable QuantTradeAI project workspace. Keep project-specific state
 ## Local Project Files
 
 - `config/project.yaml` is the canonical project config.
-- `pyproject.toml` pins QuantTradeAI as a local uv dependency.
+- `pyproject.toml` pins QuantTradeAI to an exact released package version.
 - `.env.example` documents optional local environment variables. Keep real secrets in `.env` or exported environment variables.
 - `runs/`, `reports/`, `data/`, and `models/` are local outputs.
 
@@ -13,6 +13,7 @@ This is a disposable QuantTradeAI project workspace. Keep project-specific state
 
 ```bash
 uv sync
+uv run quanttradeai doctor
 uv run quanttradeai validate -c config/project.yaml
 uv run quanttradeai agent run --all -c config/project.yaml --mode backtest
 ```

--- a/quanttradeai/utils/config_validator.py
+++ b/quanttradeai/utils/config_validator.py
@@ -599,13 +599,13 @@ def _merge_preserving_unknown(raw_value: Any, validated_value: Any) -> Any:
     return validated_value
 
 
-def validate_project_config(
+def validate_project_config_readonly(
     config_path: Path | str = "config/project.yaml",
     *,
-    output_dir: Path | str = "reports/config_validation",
     project_config_override: dict[str, Any] | None = None,
-    timestamp_subdir: bool = True,
 ) -> Dict:
+    """Validate project config and return resolved data without writing artifacts."""
+
     if project_config_override is not None:
         raw, compatibility_warnings = normalize_live_risk_compatibility(
             deepcopy(project_config_override)
@@ -653,6 +653,30 @@ def validate_project_config(
 
     summary = _render_project_summary(resolved=resolved, warnings=warnings)
 
+    return {
+        "config_path": loaded_source_path,
+        "raw": raw,
+        "resolved": resolved,
+        "summary": summary,
+        "warnings": warnings,
+    }
+
+
+def validate_project_config(
+    config_path: Path | str = "config/project.yaml",
+    *,
+    output_dir: Path | str = "reports/config_validation",
+    project_config_override: dict[str, Any] | None = None,
+    timestamp_subdir: bool = True,
+) -> Dict:
+    validation = validate_project_config_readonly(
+        config_path=config_path,
+        project_config_override=project_config_override,
+    )
+    resolved = validation["resolved"]
+    summary = validation["summary"]
+    warnings = validation["warnings"]
+
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     run_dir = Path(output_dir) / timestamp if timestamp_subdir else Path(output_dir)
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -667,7 +691,7 @@ def validate_project_config(
 
     result = {
         "timestamp": timestamp,
-        "config_path": loaded_source_path,
+        "config_path": validation["config_path"],
         "all_passed": True,
         "summary": summary,
         "warnings": warnings,

--- a/roadmap.md
+++ b/roadmap.md
@@ -360,7 +360,7 @@ Status on 2026-04-17:
 Goal:
 Make running many agents and many experiments on one machine easy and trustworthy.
 
-Status on 2026-05-02:
+Status on 2026-07-01:
 
 - `quanttradeai runs list --scoreboard` is implemented for local research and agent runs, with metric-aware sorting via `--sort-by` and additive JSON scoreboard payloads.
 - `quanttradeai runs list --compare <run_id> --compare <run_id>` is implemented for same-family research and agent runs, loading `summary.json`, `metrics.json`, and `resolved_project_config.yaml` to show metric tables plus compact config deltas before promotion.
@@ -370,7 +370,8 @@ Status on 2026-05-02:
 - `quanttradeai research run -c config/project.yaml --sweep <name>` is implemented for research parameter sweeps defined under `sweeps:` in `config/project.yaml`, with deterministic variant expansion, bounded concurrency, preserved child research runs, and sparse batch scoreboards under `runs/research/batches/...`.
 - `quanttradeai promote --run agent/backtest/<sweep_child_run_id> -c config/project.yaml` is implemented for materializing a winning sweep child into the base agent's canonical config and promoting that base agent to paper mode.
 - `quanttradeai agent run --all -c config/project.yaml --mode live --acknowledge-live <project_name>` is implemented for local multi-agent live batches, requiring an explicit project-name acknowledgement, live-mode agent configs, live runtime prerequisites, preserved child runs under `runs/agent/live/...`, and batch-level manifests plus scoreboards under `runs/agent/batches/...`.
-- `quanttradeai init [PROJECT_DIR] --template strategy-lab` is implemented as the package-user workspace initializer, writing `config/project.yaml`, a disposable uv project pinned to the local QuantTradeAI checkout, minimal `AGENTS.md`/`CLAUDE.md` guidance, environment files, and workspace metadata. Reusable agent skills are now supplied by the globally installed QuantTradeAI plugin instead of generated workspace skill copies.
+- `quanttradeai init [PROJECT_DIR] --template strategy-lab` is implemented as the package-user workspace initializer, writing `config/project.yaml`, a disposable uv project pinned to the released QuantTradeAI package version, minimal `AGENTS.md`/`CLAUDE.md` guidance, environment files, and workspace metadata. Reusable agent skills are now supplied by the globally installed QuantTradeAI plugin instead of generated workspace skill copies.
+- `quanttradeai doctor` is implemented as a read-only workspace health check for coding agents, with concise text diagnostics, deterministic exit codes, and `--json` output.
 - `strategy-lab` is the default init template and provides a YAML-only multi-strategy lab with `rsi_reversion`, `sma_trend`, replay-enabled paper settings, top-level risk/runtime defaults, and starter sweeps for RSI thresholds and SMA risk sizing.
 - `rule.preset: sma_crossover` is implemented for deterministic rule agents, using `rule.fast_feature` and `rule.slow_feature` from shared project feature definitions and agent context.
 

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -109,9 +109,8 @@ def test_init_refuses_existing_without_force_and_overwrites_with_force(tmp_path:
         rendered["project"]["name"] == PROJECT_TEMPLATES["research"]["project"]["name"]
     )
     assert "QuantTradeAI Project Workspace" in agents_path.read_text(encoding="utf-8")
-    assert "quanttradeai @ file://" in (tmp_path / "pyproject.toml").read_text(
-        encoding="utf-8"
-    )
+    pyproject = tomllib.loads((tmp_path / "pyproject.toml").read_text("utf-8"))
+    assert "quanttradeai==0.1.0" in pyproject["project"]["dependencies"]
 
 
 def test_init_current_directory_uses_strategy_lab_by_default(
@@ -209,8 +208,9 @@ def test_init_named_workspace_writes_agent_context_and_metadata(tmp_path: Path):
     pyproject = tomllib.loads((workspace / "pyproject.toml").read_text("utf-8"))
     assert pyproject["project"]["name"] == "my-lab"
     assert pyproject["project"]["requires-python"] == ">=3.11,<4.0"
-    assert any(
-        dependency.startswith("quanttradeai @ file://")
+    assert "quanttradeai==0.1.0" in pyproject["project"]["dependencies"]
+    assert all(
+        "file://" not in dependency
         for dependency in pyproject["project"]["dependencies"]
     )
     assert pyproject["tool"]["uv"]["package"] is False
@@ -239,13 +239,53 @@ def test_init_named_workspace_writes_agent_context_and_metadata(tmp_path: Path):
     assert metadata["project_config"] == "config/project.yaml"
     assert metadata["python_project"]["manager"] == "uv"
     assert metadata["python_project"]["pyproject"] == "pyproject.toml"
-    assert metadata["python_project"]["quanttradeai_dependency"].startswith("file://")
+    assert (
+        metadata["python_project"]["quanttradeai_dependency"] == "quanttradeai==0.1.0"
+    )
+    assert metadata["python_project"]["quanttradeai_version"] == "0.1.0"
     assert metadata["agent_context"] == {
         "agents_md": "AGENTS.md",
         "claude_md": "CLAUDE.md",
         "plugin": "quanttradeai",
     }
     assert metadata["created_by"] == "quanttradeai"
+
+
+def test_init_can_pin_explicit_package_version_for_contributor_testing(
+    tmp_path: Path,
+):
+    workspace = tmp_path / "my-lab"
+
+    result = runner.invoke(
+        app,
+        ["init", str(workspace), "--quanttradeai-version", "0.1.1"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    pyproject = tomllib.loads((workspace / "pyproject.toml").read_text("utf-8"))
+    assert pyproject["project"]["dependencies"] == ["quanttradeai==0.1.1"]
+    metadata = yaml.safe_load(
+        (workspace / ".quanttradeai" / "workspace.yaml").read_text("utf-8")
+    )
+    assert (
+        metadata["python_project"]["quanttradeai_dependency"] == "quanttradeai==0.1.1"
+    )
+    assert metadata["python_project"]["quanttradeai_version"] == "0.1.1"
+
+
+def test_init_rejects_path_like_package_version(tmp_path: Path):
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            str(tmp_path / "my-lab"),
+            "--quanttradeai-version",
+            "file:///tmp/QuantTradeAI",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Local paths and file URLs are not supported" in result.stderr
 
 
 def test_init_context_resource_loader_works_from_temp_directory(
@@ -283,6 +323,68 @@ def test_validate_passes_for_generated_templates(tmp_path: Path):
         result = runner.invoke(app, ["validate", "--config", str(cfg_path)])
         assert result.exit_code == 0, result.stdout
         assert "Resolved project config summary:" in result.stdout
+
+
+def test_doctor_passes_generated_workspace_without_writing_artifacts(
+    tmp_path: Path, monkeypatch
+):
+    workspace = tmp_path / "doctor-lab"
+    init_result = runner.invoke(app, ["init", str(workspace)])
+    assert init_result.exit_code == 0, init_result.stdout
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ok"
+    assert payload["summary"]["errors"] == 0
+    assert payload["package"]["workspace_dependency"] == "quanttradeai==0.1.0"
+    assert not (workspace / "reports").exists()
+    assert not (workspace / "runs").exists()
+
+
+def test_doctor_fails_local_quanttradeai_dependency(tmp_path: Path, monkeypatch):
+    workspace = tmp_path / "doctor-lab"
+    init_result = runner.invoke(app, ["init", str(workspace)])
+    assert init_result.exit_code == 0, init_result.stdout
+    pyproject_path = workspace / "pyproject.toml"
+    pyproject_path.write_text(
+        pyproject_path.read_text("utf-8").replace(
+            "quanttradeai==0.1.0",
+            "quanttradeai @ file:///tmp/QuantTradeAI",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, ["doctor", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert any(
+        item["code"] == "package.dependency_local" for item in payload["diagnostics"]
+    )
+
+
+def test_doctor_fails_invalid_project_yaml(tmp_path: Path, monkeypatch):
+    workspace = tmp_path / "doctor-lab"
+    init_result = runner.invoke(app, ["init", str(workspace)])
+    assert init_result.exit_code == 0, init_result.stdout
+    (workspace / "config" / "project.yaml").write_text(
+        "project:\n  name: broken\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, ["doctor", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert any(
+        item["code"] == "project.config_invalid" for item in payload["diagnostics"]
+    )
 
 
 def test_validate_fails_missing_required_sections(tmp_path: Path):

--- a/tests/test_project_config_cli.py
+++ b/tests/test_project_config_cli.py
@@ -242,50 +242,12 @@ def test_init_named_workspace_writes_agent_context_and_metadata(tmp_path: Path):
     assert (
         metadata["python_project"]["quanttradeai_dependency"] == "quanttradeai==0.1.0"
     )
-    assert metadata["python_project"]["quanttradeai_version"] == "0.1.0"
     assert metadata["agent_context"] == {
         "agents_md": "AGENTS.md",
         "claude_md": "CLAUDE.md",
         "plugin": "quanttradeai",
     }
     assert metadata["created_by"] == "quanttradeai"
-
-
-def test_init_can_pin_explicit_package_version_for_contributor_testing(
-    tmp_path: Path,
-):
-    workspace = tmp_path / "my-lab"
-
-    result = runner.invoke(
-        app,
-        ["init", str(workspace), "--quanttradeai-version", "0.1.1"],
-    )
-
-    assert result.exit_code == 0, result.stdout
-    pyproject = tomllib.loads((workspace / "pyproject.toml").read_text("utf-8"))
-    assert pyproject["project"]["dependencies"] == ["quanttradeai==0.1.1"]
-    metadata = yaml.safe_load(
-        (workspace / ".quanttradeai" / "workspace.yaml").read_text("utf-8")
-    )
-    assert (
-        metadata["python_project"]["quanttradeai_dependency"] == "quanttradeai==0.1.1"
-    )
-    assert metadata["python_project"]["quanttradeai_version"] == "0.1.1"
-
-
-def test_init_rejects_path_like_package_version(tmp_path: Path):
-    result = runner.invoke(
-        app,
-        [
-            "init",
-            str(tmp_path / "my-lab"),
-            "--quanttradeai-version",
-            "file:///tmp/QuantTradeAI",
-        ],
-    )
-
-    assert result.exit_code == 1
-    assert "Local paths and file URLs are not supported" in result.stderr
 
 
 def test_init_context_resource_loader_works_from_temp_directory(


### PR DESCRIPTION
## Summary

- Stop `quanttradeai init` from searching for a local source checkout or generating `file://` dependencies; generated workspaces now pin the running package as `quanttradeai==<version>` and record that dependency in workspace metadata.
- Keep version selection outside the CLI: use `uvx quanttradeai@<version> init ...` or the active installed package to choose what gets pinned.
- Add `quanttradeai doctor` as a read-only workspace health check for coding agents, with concise text output, deterministic exit codes, and `--json` diagnostics.
- Update generated workspace guidance, docs, roadmap notes, and tests for the package-pin and doctor workflows.

## Validation

- `make format-check`
- `make lint`
- `make test` (409 passed)
- `poetry run quanttradeai doctor --json`