### PR TITLE
[codex] add agent-first onboarding flow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "quanttradeai",
       "displayName": "QuantTradeAI",
       "source": "./plugins/quanttradeai",
-      "description": "QuantTradeAI workspace skills for strategy experiments, model research, run analysis, promotion, and deployment.",
+      "description": "QuantTradeAI workspace skills for onboarding, strategy experiments, model research, run analysis, promotion, and deployment.",
       "author": {
         "name": "Akshat Joshi",
         "email": "joshiakshat0511@gmail.com"

--- a/LLM.md
+++ b/LLM.md
@@ -9,31 +9,37 @@ agent runs, promotion, and deployment.
 Use the small CLI surface first:
 
 ```bash
-poetry run quanttradeai init --template research -o config/project.yaml
-poetry run quanttradeai validate -c config/project.yaml
-poetry run quanttradeai research run -c config/project.yaml
-poetry run quanttradeai research run -c config/project.yaml --sweep <sweep_name> --max-concurrency 4
-poetry run quanttradeai runs list --scoreboard --sort-by net_sharpe
-poetry run quanttradeai promote --run research/<run_id> -c config/project.yaml
+uvx quanttradeai init research-lab --template research
+cd research-lab
+uv sync
+uv run quanttradeai doctor
+uv run quanttradeai validate -c config/project.yaml
+uv run quanttradeai research run -c config/project.yaml
+uv run quanttradeai research run -c config/project.yaml --sweep <sweep_name> --max-concurrency 4
+uv run quanttradeai runs list --scoreboard --sort-by net_sharpe
+uv run quanttradeai promote --run research/<run_id> -c config/project.yaml
 ```
 
 Agent projects follow the same pattern:
 
 ```bash
-poetry run quanttradeai init --template llm-agent -o config/project.yaml
-poetry run quanttradeai validate -c config/project.yaml
-poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
-poetry run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
-poetry run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
-poetry run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live breakout_gpt
+uvx quanttradeai init llm-lab --template llm-agent
+cd llm-lab
+uv sync
+uv run quanttradeai doctor
+uv run quanttradeai validate -c config/project.yaml
+uv run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode backtest
+uv run quanttradeai promote --run agent/backtest/<run_id> -c config/project.yaml
+uv run quanttradeai agent run --agent breakout_gpt -c config/project.yaml --mode paper
+uv run quanttradeai promote --run agent/paper/<run_id> -c config/project.yaml --to live --acknowledge-live breakout_gpt
 ```
 
 Deployment stays under the same command:
 
 ```bash
-poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
-poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
-poetry run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target render -o deployments/breakout-render
+uv run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target local
+uv run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target docker-compose
+uv run quanttradeai deploy --agent breakout_gpt -c config/project.yaml --target render -o deployments/breakout-render
 ```
 
 ## Product Objects

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # QuantTradeAI
 
-### Tell your coding agent to run quant research. Let the plugin do the plumbing.
+### Give your coding agent a quant research lab, not a blank terminal.
 
 <p>
   <a href="docs/getting-started.md">Getting Started</a> |
@@ -23,9 +23,9 @@
 
 ---
 
-QuantTradeAI is built for Claude Code and Codex. Install the plugin, open your agent, and describe the quant research you want in plain English.
+QuantTradeAI is built for coding agents like Claude Code, Codex, Cursor, and similar tools to research trading strategies without repeatedly writing data, backtest, sweep, artifact, and deployment plumbing from scratch.
 
-The plugin handles the boring parts: workspace creation, `uvx`, uv setup, `config/project.yaml`, validation, experiments, scoreboards, and artifact analysis. You stay at the research-intent level.
+You give the research objective. The agent uses a generated workspace, `project.yaml`, and the `quanttradeai` CLI to run repeatable strategy experiments, compare artifacts, and recommend winners.
 
 ---
 
@@ -52,10 +52,9 @@ Then open a fresh Claude Code or Codex session in the folder where you want the 
 ```text
 use QuantTradeAI and make me a workspace called vibe-lab.
 vibe quant research: test AAPL/MSFT daily momentum vs mean reversion, RSI and SMA crossover stuff, 2022-2024, real costs, no live trading.
-set up uv, edit the yaml, validate it, run the sweeps, read the artifacts, and tell me what looks least fake plus what to try next.
 ```
 
-The agent should create the workspace with `uvx quanttradeai init`, run `uv sync`, check `uv run quanttradeai doctor`, edit `config/project.yaml`, validate, run backtest/research workflows, inspect `runs/`, and report evidence instead of vibes.
+The agent should create the workspace, run the CLI and give you an evidence-backed answer.
 
 More install detail: [Agent Plugins](docs/plugins.md). Full walkthrough: [Getting Started](docs/getting-started.md).
 
@@ -63,51 +62,45 @@ More install detail: [Agent Plugins](docs/plugins.md). Full walkthrough: [Gettin
 
 ## Why QuantTradeAI
 
-AI agents can write code, but quant research needs repeatable structure.
+AI agents can write code, but quant research requires repeatable infrastructure.
 
-Without structure, agents write one-off scripts, scatter outputs across folders, and produce runs that cannot be compared. Every session starts from scratch.
+Without structure, agents write one-off scripts, scatter outputs across directories, and produce runs that cannot be compared or built on. Every session starts fresh with no memory of what worked.
 
 QuantTradeAI provides:
 
-- **One project config** - data, features, research, agents, sweeps, risk, and deployment live in `config/project.yaml`.
-- **Standard run artifacts** - every run writes machine-readable outputs under `runs/`.
-- **Agent-readable scoreboards** - sweeps and batches can be ranked without scraping terminal text.
-- **A promotion path** - backtest -> paper -> live, with live execution gated behind explicit human approval.
+- **A stable experiment environment** — one project config drives data, features, research, and agents
+- **Standard run artifacts** - every run writes structured outputs agents can read directly
+- **A promotion path** - backtest -> paper -> live, with live execution gated behind explicit human approval
 
-## What The Agent Can Do
+## Before and After
 
-- Create a strategy lab from templates.
-- Edit YAML instead of inventing one-off scripts.
-- Run model research, agent backtests, and parameter sweeps.
-- Compare scoreboards by Sharpe, PnL, drawdown, activity, warnings, and failures.
-- Inspect `summary.json`, `scoreboard.json`, `results.json`, `metrics.json`, and `resolved_project_config.yaml`.
-- Promote selected research/backtest results only when asked.
-- Generate local, Docker Compose, or Render deployment bundles.
-- Keep live trading behind explicit approval.
+| | Without QuantTradeAI | With QuantTradeAI |
+| :--- | :--- | :--- |
+| **Setup** | Agent writes custom fetch and backtest scripts each time | Agent reuses the `quanttradeai` CLI against one project config |
+| **Outputs** | Scattered across ad-hoc directories | Every run writes to `runs/` with standardized artifacts |
+| **Comparison** | No way to compare strategy variants | Scoreboards and `--compare` are built in |
+| **Structure** | Research and agent code in separate scripts | One `project.yaml` drives both |
+| **Safety** | No gate before live execution | Backtest → paper → live, each requiring explicit promotion |
+
+## What the Agent Can Do
+
+- **Create strategy labs** — initialize multi-agent projects from templates (`rule`, `model`, `llm`, `hybrid`)
+- **Run parameter sweeps** — expand YAML-defined grids into parallel backtest variants
+- **Compare scoreboards** — rank runs by Sharpe ratio, PnL, or other metrics
+- **Inspect artifacts** — read `summary.json.run_result` and `scoreboard.json` from any run
+- **Promote backtests to paper** — move winning runs forward through explicit gates
+- **Generate deployment bundles** — emit local runners, Docker Compose, or Render worker configs
+- **Keep live trading gated** — live mode requires human acknowledgement at every promotion step
 
 ---
 
-## Manual `uvx` And uv Workflow
-
-Use this when you want to drive the CLI yourself instead of asking the plugin to do it.
+## Quickstart: Drive the CLI Yourself
 
 ```bash
 uvx quanttradeai init my-lab
 cd my-lab
 uv sync
-uv run quanttradeai doctor
-uv run quanttradeai validate -c config/project.yaml
-uv run quanttradeai agent run --all -c config/project.yaml --mode backtest
 ```
-
-Simple lifecycle:
-
-- `uvx quanttradeai init my-lab` runs the published package in a temporary tool environment and creates the workspace.
-- The generated `pyproject.toml` pins `quanttradeai==<version>` for that workspace.
-- `uv sync` creates `.venv` from the workspace pin.
-- `uv run quanttradeai ...` runs the pinned workspace CLI.
-
-Use `uvx` to create or regenerate a workspace. Use `uv run` once you are inside that workspace.
 
 To pin a published release explicitly:
 
@@ -119,17 +112,17 @@ uvx quanttradeai@0.1.0 init my-lab
 
 ```text
 my-lab/
-|-- config/project.yaml
+|-- config/project.yaml             # canonical project config
 |-- pyproject.toml
 |-- .python-version
 |-- .env.example
 |-- .gitignore
-|-- AGENTS.md
-|-- CLAUDE.md
-`-- .quanttradeai/workspace.yaml
+|-- AGENTS.md                       # minimal workspace-local guidance
+|-- CLAUDE.md                       # Claude adapter for the same guidance
+`-- .quanttradeai/workspace.yaml     # workspace metadata
 ```
 
-Reusable workflow skills come from the installed QuantTradeAI plugin. Generated workspaces only carry local context and the uv project files.
+Reusable workflow skills come from the installed QuantTradeAI plugin. Generated workspaces only carry local context and the project configuration.
 
 ---
 
@@ -139,15 +132,15 @@ Every run writes durable artifacts the agent can inspect before recommending any
 
 | Artifact | What it contains |
 | :--- | :--- |
-| `summary.json` -> `run_result` | High-level outcome, ranked candidates, failures, and warnings. |
-| `scoreboard.json` | Ranked metrics across sweep or batch variants. |
-| `results.json` | Child run IDs, statuses, parameters, variant configs, and failures. |
-| `metrics.json` | Full metrics for a single run. |
-| `resolved_project_config.yaml` | Exact config used for the run. |
+| `summary.json` -> `run_result` | High-level outcome: winner, ranked candidates, failures |
+| `scoreboard.json` | Ranked metrics across sweep or batch variants |
+| `results.json` | Per-variant metrics for batch and sweep runs |
+| `metrics.json` | Full metrics for a single run |
+| `resolved_project_config.yaml` | Exact config used for the run - Fully reproducible |
 
 ## Safety Model
 
-Experiments start in backtest. Agents cannot quietly jump to live trading.
+Experiments start in backtest. Agents cannot self-promote to live trading.
 
 | Mode | Gate |
 | :--- | :--- |
@@ -160,37 +153,23 @@ Experiments start in backtest. Agents cannot quietly jump to live trading.
 
 ---
 
-## Documentation
-
-**Start** - [Getting Started](docs/getting-started.md) | [Agent Plugins](docs/plugins.md) | [Docs Home](docs/README.md)
-
-**Configure** - [Project YAML](docs/config/project-file.md) | [Config Overview](docs/config/)
-
-**Reference** - [CLI](docs/cli/) | [Artifacts](docs/artifacts.md) | [API Docs](docs/api/) | [Roadmap](roadmap.md)
-
----
-
-## Contributor Setup
-
-Clone the source only when you are contributing to QuantTradeAI itself or testing local package changes.
+## Local Development
 
 ```bash
 git clone https://github.com/AKKI0511/QuantTradeAI.git
 cd QuantTradeAI
 poetry install --with dev
-make test
 ```
 
-Create a test workspace from the checkout:
+Create a workspace:
 
 ```bash
 poetry run quanttradeai init my-lab
 cd my-lab
 uv sync
-uv run quanttradeai doctor
 ```
 
-When testing checkout changes inside a generated workspace, keep the generated package pin and install the checkout into that workspace environment explicitly:
+When testing changes inside a generated workspace, keep the generated package pin and install the checkout into that workspace environment explicitly:
 
 ```bash
 uv pip install --reinstall -e ..
@@ -203,6 +182,16 @@ make format
 make lint
 make test
 ```
+
+---
+
+## Documentation
+
+**Start** - [Getting Started](docs/getting-started.md) | [Agent Plugins](docs/plugins.md) | [Docs Home](docs/README.md)
+
+**Configure** - [Project YAML](docs/config/project-file.md) | [Config Overview](docs/config/)
+
+**Reference** - [CLI](docs/cli/) | [Artifacts](docs/artifacts.md) | [API Docs](docs/api/) | [Roadmap](roadmap.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # QuantTradeAI
 
-### Give your coding agent a quant research lab, not a blank terminal.
+### Tell your coding agent to run quant research. Let the plugin do the plumbing.
 
 <p>
-  <a href="docs/getting-started.md">Getting Started</a> ·
-  <a href="docs/plugins.md">Agent Plugins</a> ·
-  <a href="docs/config/project-file.md">Project YAML</a> ·
-  <a href="docs/README.md">Docs</a> ·
-  <a href="roadmap.md">Roadmap</a> ·
+  <a href="docs/getting-started.md">Getting Started</a> |
+  <a href="docs/plugins.md">Agent Plugins</a> |
+  <a href="docs/config/project-file.md">Project YAML</a> |
+  <a href="docs/README.md">Docs</a> |
+  <a href="roadmap.md">Roadmap</a> |
   <a href="CONTRIBUTING.md">Contributing</a>
 </p>
 
@@ -23,173 +23,165 @@
 
 ---
 
-QuantTradeAI is built for coding agents — Claude Code, Codex, Cursor, and similar tools — to research trading strategies without repeatedly writing data, backtest, sweep, artifact, and deployment plumbing from scratch.
+QuantTradeAI is built for Claude Code and Codex. Install the plugin, open your agent, and describe the quant research you want in plain English.
 
-You give the research objective. The agent uses a generated workspace, `config/project.yaml`, and the `quanttradeai` CLI to run repeatable strategy experiments, compare artifacts, and recommend winners.
+The plugin handles the boring parts: workspace creation, `uvx`, uv setup, `config/project.yaml`, validation, experiments, scoreboards, and artifact analysis. You stay at the research-intent level.
+
+---
+
+## Fast Path: Agent First
+
+Install the QuantTradeAI plugin in your coding agent.
+
+Codex:
+
+```bash
+codex plugin marketplace add AKKI0511/QuantTradeAI --sparse .agents/plugins --sparse plugins
+codex plugin add quanttradeai@quanttradeai
+```
+
+Claude Code:
+
+```bash
+claude plugin marketplace add AKKI0511/QuantTradeAI --sparse .claude-plugin plugins
+claude plugin install quanttradeai@quanttradeai
+```
+
+Then open a fresh Claude Code or Codex session in the folder where you want the lab to live and ask for the whole thing:
+
+```text
+use QuantTradeAI and make me a workspace called vibe-lab.
+vibe quant research: test AAPL/MSFT daily momentum vs mean reversion, RSI and SMA crossover stuff, 2022-2024, real costs, no live trading.
+set up uv, edit the yaml, validate it, run the sweeps, read the artifacts, and tell me what looks least fake plus what to try next.
+```
+
+The agent should create the workspace with `uvx quanttradeai init`, run `uv sync`, check `uv run quanttradeai doctor`, edit `config/project.yaml`, validate, run backtest/research workflows, inspect `runs/`, and report evidence instead of vibes.
+
+More install detail: [Agent Plugins](docs/plugins.md). Full walkthrough: [Getting Started](docs/getting-started.md).
 
 ---
 
 ## Why QuantTradeAI
 
-AI agents can write code, but quant research requires repeatable infrastructure.
+AI agents can write code, but quant research needs repeatable structure.
 
-Without structure, agents write one-off scripts, scatter outputs across directories, and produce runs that cannot be compared or built on. Every session starts fresh with no memory of what worked.
+Without structure, agents write one-off scripts, scatter outputs across folders, and produce runs that cannot be compared. Every session starts from scratch.
 
 QuantTradeAI provides:
 
-- **A stable experiment environment** — one project config drives data, features, research, and agents
-- **Standardized run artifacts** — every run writes structured outputs agents can read directly
-- **A promotion model** — backtest → paper → live, with live execution gated behind explicit human approval
+- **One project config** - data, features, research, agents, sweeps, risk, and deployment live in `config/project.yaml`.
+- **Standard run artifacts** - every run writes machine-readable outputs under `runs/`.
+- **Agent-readable scoreboards** - sweeps and batches can be ranked without scraping terminal text.
+- **A promotion path** - backtest -> paper -> live, with live execution gated behind explicit human approval.
 
-## Before and After
+## What The Agent Can Do
 
-| | Without QuantTradeAI | With QuantTradeAI |
-| :--- | :--- | :--- |
-| **Setup** | Agent writes custom fetch and backtest scripts each time | Agent reuses the `quanttradeai` CLI against one project config |
-| **Outputs** | Scattered across ad-hoc directories | Every run writes to `runs/` with standardized artifacts |
-| **Comparison** | No way to compare strategy variants | Scoreboards and `--compare` are built in |
-| **Structure** | Research and agent code in separate scripts | One `config/project.yaml` drives both |
-| **Safety** | No gate before live execution | Backtest → paper → live, each requiring explicit promotion |
+- Create a strategy lab from templates.
+- Edit YAML instead of inventing one-off scripts.
+- Run model research, agent backtests, and parameter sweeps.
+- Compare scoreboards by Sharpe, PnL, drawdown, activity, warnings, and failures.
+- Inspect `summary.json`, `scoreboard.json`, `results.json`, `metrics.json`, and `resolved_project_config.yaml`.
+- Promote selected research/backtest results only when asked.
+- Generate local, Docker Compose, or Render deployment bundles.
+- Keep live trading behind explicit approval.
 
 ---
 
-## Quickstart
+## Manual `uvx` And uv Workflow
+
+Use this when you want to drive the CLI yourself instead of asking the plugin to do it.
 
 ```bash
 uvx quanttradeai init my-lab
 cd my-lab
 uv sync
 uv run quanttradeai doctor
+uv run quanttradeai validate -c config/project.yaml
+uv run quanttradeai agent run --all -c config/project.yaml --mode backtest
 ```
 
-Open `my-lab` in Claude Code, Cursor, Codex, or another coding agent and ask:
+Simple lifecycle:
 
-> "Research RSI and SMA crossover strategies on AAPL and MSFT and find the best one."
+- `uvx quanttradeai init my-lab` runs the published package in a temporary tool environment and creates the workspace.
+- The generated `pyproject.toml` pins `quanttradeai==<version>` for that workspace.
+- `uv sync` creates `.venv` from the workspace pin.
+- `uv run quanttradeai ...` runs the pinned workspace CLI.
 
-The agent uses `config/project.yaml` and the `quanttradeai` CLI to run experiments, compare results on a scoreboard, and recommend a winner — without you writing any backtest code.
+Use `uvx` to create or regenerate a workspace. Use `uv run` once you are inside that workspace.
 
----
-
-## Agent Plugin Install
-
-QuantTradeAI ships a universal agent plugin for Codex and Claude Code. It packages the strategy experiment, model research, run analysis, and promotion/deployment skills from `plugins/quanttradeai/skills/`.
-
-Initial release branch:
+To pin a published release explicitly:
 
 ```bash
-git clone -b release/v0.1.0 https://github.com/AKKI0511/QuantTradeAI.git
-cd QuantTradeAI
+uvx quanttradeai@0.1.0 init my-lab
 ```
-
-Codex:
-
-```bash
-codex plugin marketplace add .
-```
-
-Then restart Codex, open Plugins, select **QuantTradeAI Plugins**, and install **QuantTradeAI**.
-
-Claude Code:
-
-```bash
-claude plugin marketplace add .
-claude plugin install quanttradeai@quanttradeai
-```
-
-Or install from inside Claude Code:
-
-```text
-/plugin marketplace add .
-/plugin install quanttradeai@quanttradeai
-```
-
-More details: [Agent Plugins](docs/plugins.md).
-
----
 
 ## What `init` Creates
 
 ```text
 my-lab/
-|-- config/project.yaml             # canonical project config
-|-- pyproject.toml                  # uv project pinned to the released QuantTradeAI package
+|-- config/project.yaml
+|-- pyproject.toml
 |-- .python-version
 |-- .env.example
 |-- .gitignore
-|-- AGENTS.md                       # minimal workspace-local guidance
-|-- CLAUDE.md                       # Claude adapter for the same guidance
-`-- .quanttradeai/workspace.yaml     # workspace metadata
+|-- AGENTS.md
+|-- CLAUDE.md
+`-- .quanttradeai/workspace.yaml
 ```
 
-Reusable QuantTradeAI workflow skills come from the globally installed plugin.
-
----
-
-## What the Agent Can Do
-
-- **Create strategy labs** — initialize multi-agent projects from templates (`rule`, `model`, `llm`, `hybrid`)
-- **Run parameter sweeps** — expand YAML-defined grids into parallel backtest variants
-- **Compare scoreboards** — rank runs by Sharpe ratio, PnL, or other metrics
-- **Inspect artifacts** — read `summary.json.run_result` and `scoreboard.json` from any run
-- **Promote backtests to paper** — move winning runs forward through explicit gates
-- **Generate deployment bundles** — emit local runners, Docker Compose, or Render worker configs
-- **Keep live trading gated** — live mode requires human acknowledgement at every promotion step
+Reusable workflow skills come from the installed QuantTradeAI plugin. Generated workspaces only carry local context and the uv project files.
 
 ---
 
 ## Artifact-Based Research
 
-Every run writes machine-readable artifacts. Agents read these to decide what to do next — no manual result-parsing required.
+Every run writes durable artifacts the agent can inspect before recommending anything.
 
 | Artifact | What it contains |
 | :--- | :--- |
-| `summary.json` → `run_result` | High-level outcome: winner, ranked candidates, failures |
-| `scoreboard.json` | Ranked metrics across all sweep variants |
-| `results.json` | Per-variant metrics for batch and sweep runs |
-| `metrics.json` | Full metrics for a single run |
-| `resolved_project_config.yaml` | Exact config used for the run — fully reproducible |
-
----
+| `summary.json` -> `run_result` | High-level outcome, ranked candidates, failures, and warnings. |
+| `scoreboard.json` | Ranked metrics across sweep or batch variants. |
+| `results.json` | Child run IDs, statuses, parameters, variant configs, and failures. |
+| `metrics.json` | Full metrics for a single run. |
+| `resolved_project_config.yaml` | Exact config used for the run. |
 
 ## Safety Model
 
-Experiments start in backtest. Agents cannot self-promote to live trading.
+Experiments start in backtest. Agents cannot quietly jump to live trading.
 
 | Mode | Gate |
 | :--- | :--- |
-| **Backtest** | Always available — no credentials needed |
-| **Paper** | Replay-backed simulation — requires explicit `promote` from a passing backtest |
-| **Live** | Requires `--acknowledge-live` from a human, plus validated streaming and risk config |
+| **Backtest** | Always available; no broker credentials needed. |
+| **Paper** | Replay-backed simulation; promote from a passing backtest first. |
+| **Live** | Requires explicit human acknowledgement plus validated streaming and risk config. |
 
 > [!CAUTION]
-> Live mode and broker-backed execution are fully opt-in. QuantTradeAI does not guarantee profitability.
+> Live mode and broker-backed execution are opt-in. QuantTradeAI does not guarantee profitability.
 
 ---
 
-## Current Capabilities
+## Documentation
 
-| Capability | Status |
-| :--- | :---: |
-| Strategy labs, sweeps, and research runs | Supported |
-| Rule, model, LLM, and hybrid agents | Supported |
-| Backtest, paper (replay-backed), and live modes | Supported |
-| Scoreboards and run comparison | Supported |
-| Research-to-agent promotion pipeline | Supported |
-| Deployment bundles (local, Docker Compose, Render) | Supported |
+**Start** - [Getting Started](docs/getting-started.md) | [Agent Plugins](docs/plugins.md) | [Docs Home](docs/README.md)
 
-For the full list, see the [docs](docs/README.md).
+**Configure** - [Project YAML](docs/config/project-file.md) | [Config Overview](docs/config/)
+
+**Reference** - [CLI](docs/cli/) | [Artifacts](docs/artifacts.md) | [API Docs](docs/api/) | [Roadmap](roadmap.md)
 
 ---
 
-## Local Development
+## Contributor Setup
+
+Clone the source only when you are contributing to QuantTradeAI itself or testing local package changes.
 
 ```bash
 git clone https://github.com/AKKI0511/QuantTradeAI.git
 cd QuantTradeAI
 poetry install --with dev
+make test
 ```
 
-Initialize a workspace and open it in your coding agent:
+Create a test workspace from the checkout:
 
 ```bash
 poetry run quanttradeai init my-lab
@@ -198,11 +190,7 @@ uv sync
 uv run quanttradeai doctor
 ```
 
-Generated workspaces always pin `quanttradeai==<version>` in `pyproject.toml`.
-Use `uvx quanttradeai@<version> init my-lab` when you need to generate a
-workspace from a specific published package version. When testing local source
-changes from a generated workspace, keep the generated pin intact and install the
-checkout into the workspace environment explicitly:
+When testing checkout changes inside a generated workspace, keep the generated package pin and install the checkout into that workspace environment explicitly:
 
 ```bash
 uv pip install --reinstall -e ..
@@ -211,20 +199,10 @@ uv pip install --reinstall -e ..
 Dev commands:
 
 ```bash
-make format   # auto-format
-make lint     # run linters
-make test     # run test suite
+make format
+make lint
+make test
 ```
-
----
-
-## Documentation
-
-**Get started** — [Getting Started](docs/getting-started.md) · [Docs](docs/README.md)
-
-**Configure** — [Project YAML](docs/config/project-file.md) · [Config Overview](docs/config/)
-
-**Reference** — [API Docs](docs/api/) · [Roadmap](roadmap.md) · [Contributing](CONTRIBUTING.md)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,47 +1,63 @@
 # QuantTradeAI Docs
 
-> **Give your coding agent a quant research lab, not a blank terminal.**
+> Tell Claude Code or Codex what quant research you want. Let the QuantTradeAI plugin build and run the lab.
 
-QuantTradeAI is an agent-native workspace for researching trading strategies. It is built so Claude Code, Codex, Cursor, and similar coding agents can work from a structured lab instead of creating messy one-off scripts for every data pull, backtest, sweep, and comparison.
+QuantTradeAI is an agent-first research workflow. Install the plugin, open your coding agent, and ask naturally for a workspace plus experiments. The plugin should handle `uvx`, uv setup, YAML edits, validation, runs, scoreboards, and artifact analysis.
 
-You give the research objective. The agent uses `config/project.yaml`, the `quanttradeai` CLI, and machine-readable artifacts to run repeatable experiments, compare strategy variants, and recommend the next step.
+## Start Here
 
-## Start here
+Install the plugin:
 
-<table>
-  <tr>
-    <td width="50%">
-      <a href="getting-started.md"><strong>Getting Started</strong></a><br>
-      Set up a QuantTradeAI workspace and hand it to a coding agent.
-    </td>
-    <td width="50%">
-      <a href="artifacts.md"><strong>Artifacts</strong></a><br>
-      Understand the outputs agents use to compare runs and explain recommendations.
-    </td>
-  </tr>
-</table>
+```bash
+# Codex
+codex plugin marketplace add AKKI0511/QuantTradeAI --sparse .agents/plugins --sparse plugins
+codex plugin add quanttradeai@quanttradeai
 
-## Documentation map
+# Claude Code
+claude plugin marketplace add AKKI0511/QuantTradeAI --sparse .claude-plugin plugins
+claude plugin install quanttradeai@quanttradeai
+```
+
+Open Claude Code or Codex in the folder where you want the workspace, then prompt it like this:
+
+```text
+use QuantTradeAI and create a workspace called vibe-lab.
+vibe quant research: AAPL/MSFT, daily bars, RSI mean reversion vs SMA trend, 2022-2024, costs included, no live trading.
+set up uv, validate the yaml, run the experiments, inspect the artifacts, and tell me what actually held up.
+```
+
+The agent should create the workspace, run the CLI through `uv run`, inspect `runs/`, and give you an evidence-backed answer.
+
+## Documentation Map
 
 | Area | What it covers |
 | :--- | :--- |
-| [Getting Started](getting-started.md) | Setup, workspace creation, and agent usage. |
-| [Agent Plugins](plugins.md) | Install the QuantTradeAI plugin in Codex or Claude Code. |
+| [Getting Started](getting-started.md) | Agent-first flow, manual uv workflow, and generated workspace files. |
+| [Agent Plugins](plugins.md) | Codex and Claude Code marketplace install, checks, and plugin skill behavior. |
 | [Artifacts](artifacts.md) | Run outputs, scoreboards, summaries, and recommendation evidence. |
-| [CLI](cli/) | Commands, when to use them, inputs, outputs, and artifacts. |
+| [CLI](cli/) | Commands, inputs, outputs, and artifacts. |
 | [Config](config/) | `project.yaml` and supported data, research, agent, and execution sections. |
+| [Examples](examples/) | Agent-native patterns for strategy sweeps and model promotion. |
 | [API](api/) | Python API reference for advanced users. |
-| [Examples](examples/) | Agent-native working patterns for strategy sweeps and model promotion. |
 
-## Safety model
+## Manual Path
 
-> Backtest first. Replay-backed paper next. Live trading and broker-backed execution require explicit human approval.
+If you are driving the CLI yourself:
 
-<div align="center">
+```bash
+uvx quanttradeai init my-lab
+cd my-lab
+uv sync
+uv run quanttradeai doctor
+uv run quanttradeai validate -c config/project.yaml
+```
 
-### Building with QuantTradeAI?
+Use `uvx` to create a workspace from the published package. Use `uv run` inside that workspace so commands use the pinned local `.venv`.
 
-If it helps your agent research cleaner trading strategies, give the project a star on GitHub:
-**[github.com/AKKI0511/QuantTradeAI](https://github.com/AKKI0511/QuantTradeAI)**.
+## Safety Model
 
-</div>
+Backtest first. Replay-backed paper next. Live trading and broker-backed execution require explicit human approval.
+
+## Source Work
+
+Clone the repository only for contributor development or local plugin testing. See [Getting Started](getting-started.md#source-and-contributor-setup).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,23 @@
 # QuantTradeAI Docs
 
-> Tell Claude Code or Codex what quant research you want. Let the QuantTradeAI plugin build and run the lab.
+> **Give your coding agent a quant research lab, not a blank terminal.**
 
-QuantTradeAI is an agent-first research workflow. Install the plugin, open your coding agent, and ask naturally for a workspace plus experiments. The plugin should handle `uvx`, uv setup, YAML edits, validation, runs, scoreboards, and artifact analysis.
+QuantTradeAI is an agent-native workspace for researching trading strategies. It is built so Claude Code, Codex, Cursor, and similar coding agents can work from a structured lab instead of creating messy one-off scripts for every data pull, backtest, sweep, and comparison.
+
+You give the research objective. The agent uses `project.yaml`, the `quanttradeai` CLI, and machine-readable artifacts to run repeatable experiments, compare strategy variants, and recommend the next step.
+
+<table>
+  <tr>
+    <td width="50%">
+      <a href="getting-started.md"><strong>Getting Started</strong></a><br>
+      Set up a QuantTradeAI workspace and hand it to a coding agent.
+    </td>
+    <td width="50%">
+      <a href="plugins.md"><strong>Agent Plugins</strong></a><br>
+      Codex and Claude Code marketplace install, checks, and plugin skill behavior.
+    </td>
+  </tr>
+</table>
 
 ## Start Here
 
@@ -23,16 +38,15 @@ Open Claude Code or Codex in the folder where you want the workspace, then promp
 ```text
 use QuantTradeAI and create a workspace called vibe-lab.
 vibe quant research: AAPL/MSFT, daily bars, RSI mean reversion vs SMA trend, 2022-2024, costs included, no live trading.
-set up uv, validate the yaml, run the experiments, inspect the artifacts, and tell me what actually held up.
 ```
 
-The agent should create the workspace, run the CLI through `uv run`, inspect `runs/`, and give you an evidence-backed answer.
+The agent should create the workspace, run the CLI and give you an evidence-backed answer.
 
 ## Documentation Map
 
 | Area | What it covers |
 | :--- | :--- |
-| [Getting Started](getting-started.md) | Agent-first flow, manual uv workflow, and generated workspace files. |
+| [Getting Started](getting-started.md) | Setup, workspace creation, and agent usage. |
 | [Agent Plugins](plugins.md) | Codex and Claude Code marketplace install, checks, and plugin skill behavior. |
 | [Artifacts](artifacts.md) | Run outputs, scoreboards, summaries, and recommendation evidence. |
 | [CLI](cli/) | Commands, inputs, outputs, and artifacts. |
@@ -40,24 +54,15 @@ The agent should create the workspace, run the CLI through `uv run`, inspect `ru
 | [Examples](examples/) | Agent-native patterns for strategy sweeps and model promotion. |
 | [API](api/) | Python API reference for advanced users. |
 
-## Manual Path
-
-If you are driving the CLI yourself:
-
-```bash
-uvx quanttradeai init my-lab
-cd my-lab
-uv sync
-uv run quanttradeai doctor
-uv run quanttradeai validate -c config/project.yaml
-```
-
-Use `uvx` to create a workspace from the published package. Use `uv run` inside that workspace so commands use the pinned local `.venv`.
-
 ## Safety Model
 
-Backtest first. Replay-backed paper next. Live trading and broker-backed execution require explicit human approval.
+> Backtest first. Replay-backed paper next. Live trading and broker-backed execution require explicit human approval.
 
-## Source Work
+<div align="center">
 
-Clone the repository only for contributor development or local plugin testing. See [Getting Started](getting-started.md#source-and-contributor-setup).
+### Building with QuantTradeAI?
+
+If it helps your agent research cleaner trading strategies, give the project a star on GitHub:
+**[github.com/AKKI0511/QuantTradeAI](https://github.com/AKKI0511/QuantTradeAI)**.
+
+</div>

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-QuantTradeAI agent classes are framework components for turning market context into normalized trading decisions. They are different from coding agents such as Claude, Codex, or Cursor, which are operators that can edit files or run the CLI/YAML workflows.
+QuantTradeAI agent classes are framework components for turning market context into normalized trading decisions. They are different from coding agents such as Claude Code or Codex, which are operators that can edit files or run the CLI/YAML workflows.
 
 Use this API when you want to extend strategy logic in Python or embed project-defined agent runs in another Python process.
 

--- a/docs/config/agents.md
+++ b/docs/config/agents.md
@@ -2,7 +2,7 @@
 
 The `agents` section defines trading agents that QuantTradeAI can backtest, run in paper mode, run in live mode, sweep, promote, and deploy.
 
-> **Important distinction:** a coding agent/operator is Claude Code, Codex, or Cursor editing YAML and running CLI commands. A trading agent is a YAML-defined `rule`, `model`, `llm`, or `hybrid` strategy executed by QuantTradeAI.
+> **Important distinction:** a coding agent/operator is Claude Code or Codex editing YAML and running CLI commands. A trading agent is a YAML-defined `rule`, `model`, `llm`, or `hybrid` strategy executed by QuantTradeAI.
 
 ## Used By
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-These examples are working patterns for using QuantTradeAI with a coding agent such as Claude Code, Codex, or Cursor. They are not deep tutorials and they do not replace the CLI, config, or artifact reference pages.
+These examples are working patterns for using QuantTradeAI with a coding agent such as Claude Code or Codex. They are not deep tutorials and they do not replace the CLI, config, or artifact reference pages.
 
 Start with [Strategy Lab Sweep](strategy-lab-sweep.md) if you want the quickest realistic workflow: define rule-based strategies in YAML, run backtest sweeps, and have the agent recommend a candidate from artifacts.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,100 +1,115 @@
 # Getting Started
 
-> **Create an agent-ready QuantTradeAI workspace.**
+> Install the QuantTradeAI plugin, open your coding agent, and ask for the research.
 
-This page helps you create a QuantTradeAI workspace that is ready for both humans and AI coding agents. The workspace gives the agent a project config, local instructions, and the `quanttradeai` CLI entrypoint.
+QuantTradeAI is easiest when Claude Code or Codex drives it. You describe the market question. The plugin creates a workspace, runs `uvx`, sets up uv, edits `config/project.yaml`, validates it, runs experiments, and reads the artifacts before recommending anything.
 
-## Install
-
-```bash
-pip install quanttradeai
-```
-
-> [!NOTE]
-> Package publishing is being stabilized. Until PyPI is available, use the local development setup below.
-
-## Optional Agent Plugin
-
-For Codex or Claude Code, install the QuantTradeAI agent plugin before opening a workspace. The plugin packages the reusable strategy experiment, model research, run analysis, and promotion/deployment skills from this repository.
-
-```bash
-git clone -b release/v0.1.0 https://github.com/AKKI0511/QuantTradeAI.git
-cd QuantTradeAI
-```
+## 1. Install The Plugin
 
 Codex:
 
 ```bash
-codex plugin marketplace add .
+codex plugin marketplace add AKKI0511/QuantTradeAI --sparse .agents/plugins --sparse plugins
+codex plugin add quanttradeai@quanttradeai
 ```
 
 Claude Code:
 
 ```bash
-claude plugin marketplace add .
+claude plugin marketplace add AKKI0511/QuantTradeAI --sparse .claude-plugin plugins
 claude plugin install quanttradeai@quanttradeai
 ```
 
-See [Agent Plugins](plugins.md) for provider-specific install, validation, and usage notes.
+See [Agent Plugins](plugins.md) for checks, provider notes, and local marketplace testing.
 
-## Create A Workspace
+## 2. Open The Coding Agent
+
+Open Claude Code or Codex in the parent folder where you want the QuantTradeAI workspace.
+
+Do not prebuild the project by hand unless you want the manual path below. Let the plugin turn your prompt into the workspace and commands.
+
+## 3. Ask Naturally
+
+Raw example:
+
+```text
+use QuantTradeAI and create a workspace called vibe-lab.
+vibe quant research: AAPL/MSFT daily, 2022-2024, RSI mean reversion vs SMA trend, include costs, no live trading.
+set up uv, configure the yaml, validate it, run sweeps, inspect the artifacts, and tell me what is least fake plus the next experiment.
+```
+
+The agent should do the operational work:
+
+- create the workspace with `uvx quanttradeai init`
+- run `uv sync`
+- run `uv run quanttradeai doctor`
+- edit `config/project.yaml`
+- run `uv run quanttradeai validate -c config/project.yaml`
+- run research, agent backtests, or sweeps
+- inspect `runs/` artifacts before calling a winner
+
+## What `init` Creates
+
+```text
+my-lab/
+|-- config/project.yaml
+|-- pyproject.toml
+|-- .python-version
+|-- .env.example
+|-- .gitignore
+|-- AGENTS.md
+|-- CLAUDE.md
+`-- .quanttradeai/workspace.yaml
+```
+
+| Path | Purpose |
+| :--- | :--- |
+| `config/project.yaml` | Canonical config for data, features, research, agents, sweeps, risk, and deployment defaults. |
+| `pyproject.toml` | Disposable uv project with `quanttradeai==<version>` pinned. |
+| `.python-version` | Python version hint for uv-managed environments. |
+| `.env.example` | Optional environment variable placeholders; keep real secrets in `.env` or exported env vars. |
+| `.gitignore` | Ignores local virtualenvs, secrets, and generated outputs. |
+| `AGENTS.md` | Workspace-local guidance that points agents at the installed plugin. |
+| `CLAUDE.md` | Claude Code adapter for the same local guidance. |
+| `.quanttradeai/workspace.yaml` | Workspace metadata, selected template, package pin, and plugin name. |
+
+The plugin skills are not copied into each workspace. They stay in the installed QuantTradeAI plugin.
+
+## Manual `uvx` And uv Workflow
+
+Use this when you want to drive the CLI yourself.
 
 ```bash
 uvx quanttradeai init my-lab
 cd my-lab
 uv sync
 uv run quanttradeai doctor
+uv run quanttradeai validate -c config/project.yaml
+uv run quanttradeai agent run --all -c config/project.yaml --mode backtest
 ```
 
-To initialize the current directory instead:
+Lifecycle in plain terms:
+
+- `uvx quanttradeai init my-lab` downloads/runs the published package in a temporary tool environment and writes the workspace.
+- `pyproject.toml` in the workspace pins the package version that created it.
+- `uv sync` creates `.venv` from that pin.
+- `uv run quanttradeai ...` runs the pinned workspace CLI.
+
+Use `uvx` outside the workspace to create it. Use `uv run` inside the workspace so the agent and you are using the same local environment.
+
+To create a workspace from a specific published version:
 
 ```bash
-quanttradeai init
+uvx quanttradeai@0.1.0 init my-lab
 ```
 
-## What `init` Creates
-
-```text
-config/project.yaml
-pyproject.toml
-.python-version
-.env.example
-.gitignore
-AGENTS.md
-CLAUDE.md
-.quanttradeai/workspace.yaml
-```
-
-| Path | Purpose |
-| :--- | :--- |
-| `config/project.yaml` | Canonical project config for data, features, research settings, agents, sweeps, and execution defaults. |
-| `pyproject.toml` | Disposable uv project metadata with QuantTradeAI pinned to the released package version. |
-| `.python-version` | Python version hint for uv-managed environments. |
-| `.env.example` | Optional environment variable placeholders; copy to `.env` only for local secrets. |
-| `.gitignore` | Ignores local virtualenvs, secrets, and generated run/output directories. |
-| `AGENTS.md` | Minimal workspace-local instructions that point agents to the global plugin. |
-| `CLAUDE.md` | Claude Code adapter for the same workspace-local guidance. |
-| `.quanttradeai/workspace.yaml` | Workspace metadata, including the selected template and init version. |
-
-## Use With A Coding Agent
-
-Open the workspace folder in Claude Code, Cursor, Codex, or a similar coding agent.
-
-Give the agent a natural request, for example:
-
-> "Research RSI and SMA crossover strategies on AAPL/MSFT and find the best one."
-
-The agent should use `AGENTS.md`, `CLAUDE.md`, the globally installed QuantTradeAI plugin, `config/project.yaml`, and `uv run quanttradeai ...` commands instead of creating one-off scripts.
-
-## First Manual Check
-
-This is optional, but useful if you want to confirm the CLI is available:
+To initialize the current directory:
 
 ```bash
-quanttradeai --help
+uvx quanttradeai init .
+uv sync
+uv run quanttradeai doctor
 ```
-
-Validation happens later when you or the agent starts editing or running the project.
 
 ## Templates
 
@@ -110,44 +125,42 @@ Available templates:
 Example:
 
 ```bash
-quanttradeai init my-research-lab --template research
-```
-
-## Local Development Setup
-
-<table>
-  <tr>
-    <td><strong>Temporary/dev path</strong><br>Use this until package installation from PyPI is available.</td>
-  </tr>
-</table>
-
-```bash
-git clone https://github.com/AKKI0511/QuantTradeAI.git
-cd QuantTradeAI
-poetry install --with dev
-poetry run quanttradeai init my-lab
-cd my-lab
-uv sync
-uv run quanttradeai doctor
-```
-
-Open the generated `my-lab` folder in your coding agent.
-
-Use `uvx quanttradeai@<version> init my-lab` when you need a workspace generated
-from a specific published package version. To test local source changes from
-that generated workspace, keep the generated `quanttradeai==<version>` pin and
-install the checkout into `.venv` explicitly:
-
-```bash
-uv pip install --reinstall -e ..
+uvx quanttradeai init my-research-lab --template research
 ```
 
 ## Where To Go Next
 
 | Topic | Link |
 | :--- | :--- |
+| Plugin install and checks | [Agent Plugins](plugins.md) |
 | Run artifacts and outputs | [Artifacts](artifacts.md) |
 | CLI command reference | [CLI](cli/) |
 | Project configuration | [Config](config/) |
 | Example patterns | [Examples](examples/) |
 | Python API reference | [API](api/) |
+
+## Source And Contributor Setup
+
+Clone the source only when you are contributing to QuantTradeAI itself or testing local changes.
+
+```bash
+git clone https://github.com/AKKI0511/QuantTradeAI.git
+cd QuantTradeAI
+poetry install --with dev
+make test
+```
+
+Create a workspace from the checkout:
+
+```bash
+poetry run quanttradeai init my-lab
+cd my-lab
+uv sync
+uv run quanttradeai doctor
+```
+
+When testing checkout changes from a generated workspace, keep the generated package pin and install the checkout into that workspace environment explicitly:
+
+```bash
+uv pip install --reinstall -e ..
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,101 +1,120 @@
 # Agent Plugins
 
-> Install the QuantTradeAI skills package for Codex or Claude Code.
+> Install QuantTradeAI in Claude Code or Codex, then ask the agent to run the lab.
 
-The QuantTradeAI plugin lives at `plugins/quanttradeai/` and uses one shared `skills/` folder for both providers:
+The QuantTradeAI plugin lives at `plugins/quanttradeai/` and ships one shared `skills/` folder for both providers:
 
-- `strategy-experiments`: run YAML-first strategy backtests and sweeps.
-- `model-research`: train, evaluate, promote, and backtest model artifacts.
-- `run-analysis`: inspect completed runs, scoreboards, and artifacts.
-- `promote-deploy`: move selected results toward paper checks or deployment bundles with live-trading safety gates.
+- `workspace-onboarding` - first-run workspace creation, `uvx`, uv setup, `doctor`, validation, and handoff into research.
+- `strategy-experiments` - YAML-first strategy backtests, sweeps, scoreboards, and artifact-backed recommendations.
+- `model-research` - ML research runs, research sweeps, promotion to stable model paths, and model-agent backtests.
+- `run-analysis` - completed run inspection, scoreboard comparison, failure analysis, and evidence summaries.
+- `promote-deploy` - promotion, paper checks, deployment bundles, and live-trading safety gates.
 
-## Initial Release Branch
-
-Until this distribution is merged into `main`, install from the release integration branch:
-
-```bash
-git clone -b release/v0.1.0 https://github.com/AKKI0511/QuantTradeAI.git
-cd QuantTradeAI
-```
+Install the plugin first. Then open a fresh agent session and ask for the full QuantTradeAI workflow in normal language.
 
 ## Codex
 
-Codex reads repo marketplaces from `.agents/plugins/marketplace.json`. This repository exposes the plugin through that file and points it at `./plugins/quanttradeai`.
+Codex reads this repository's marketplace from `.agents/plugins/marketplace.json`. The marketplace points to `./plugins/quanttradeai`, whose Codex manifest is `plugins/quanttradeai/.codex-plugin/plugin.json`.
 
-Install from a local clone:
-
-```bash
-codex plugin marketplace add .
-```
-
-Then restart Codex, open Plugins, choose **QuantTradeAI Plugins**, and install **QuantTradeAI**.
-
-For a direct Git-backed install from the release branch:
+Install from the GitHub marketplace source:
 
 ```bash
-codex plugin marketplace add AKKI0511/QuantTradeAI --ref release/v0.1.0 --sparse .agents/plugins --sparse plugins
+codex plugin marketplace add AKKI0511/QuantTradeAI --sparse .agents/plugins --sparse plugins
+codex plugin add quanttradeai@quanttradeai
 ```
 
 Useful checks:
 
 ```bash
 codex plugin marketplace list
+codex plugin list --available --json
 ```
+
+In the Codex app, you can also open Plugins, choose the **QuantTradeAI Plugins** marketplace, and install **QuantTradeAI**.
 
 ## Claude Code
 
-Claude Code reads marketplace catalogs from `.claude-plugin/marketplace.json`. This repository lists `quanttradeai` there and points the plugin entry at `./plugins/quanttradeai`.
+Claude Code reads this repository's marketplace from `.claude-plugin/marketplace.json`. The marketplace points to `./plugins/quanttradeai`, whose Claude manifest is `plugins/quanttradeai/.claude-plugin/plugin.json`.
 
-Install from a local clone:
+Install from the GitHub marketplace source:
 
 ```bash
-claude plugin marketplace add .
+claude plugin marketplace add AKKI0511/QuantTradeAI --sparse .claude-plugin plugins
 claude plugin install quanttradeai@quanttradeai
 ```
 
-Or from inside Claude Code:
+The same flow works inside Claude Code:
 
 ```text
-/plugin marketplace add .
+/plugin marketplace add AKKI0511/QuantTradeAI --sparse .claude-plugin plugins
 /plugin install quanttradeai@quanttradeai
-```
-
-For a direct Git-backed install from the release branch:
-
-```bash
-claude plugin marketplace add AKKI0511/QuantTradeAI@release/v0.1.0 --sparse .claude-plugin plugins
-claude plugin install quanttradeai@quanttradeai
 ```
 
 Useful checks:
 
 ```bash
-claude plugin validate .
 claude plugin marketplace list
+claude plugin validate ./plugins/quanttradeai
 ```
 
 Run `/help` in Claude Code after installation to confirm the `quanttradeai` namespaced skills are available.
 
-## Using The Plugin
+## First Prompt
 
-Open a QuantTradeAI workspace, usually created with:
-
-```bash
-quanttradeai init my-lab
-cd my-lab
-uv sync
-```
-
-Then ask your coding agent for a QuantTradeAI workflow, for example:
+Open Claude Code or Codex in the folder where the workspace should be created and ask for the whole run:
 
 ```text
-Use QuantTradeAI to run a strategy sweep, inspect the scoreboard, and recommend the best backtest candidate.
+use QuantTradeAI and make a workspace called vibe-lab.
+vibe quant research: AAPL/MSFT daily bars, RSI mean reversion vs SMA crossover, 2022-2024, realistic costs, no live trading.
+handle uvx, uv sync, yaml config, validation, sweeps, scoreboard, artifact analysis, and tell me what held up.
 ```
 
-The plugin teaches the agent to use `config/project.yaml`, `quanttradeai validate`, backtest/research commands, run artifacts under `runs/`, promotion checks, and deployment bundle commands without inventing one-off scripts.
+The plugin should guide the agent to:
+
+- run `uvx quanttradeai init <workspace>`
+- run `uv sync`
+- run `uv run quanttradeai doctor`
+- edit `config/project.yaml`
+- validate with `uv run quanttradeai validate -c config/project.yaml`
+- run research or agent workflows through `uv run quanttradeai ...`
+- inspect durable artifacts under `runs/` before recommending a candidate
+
+## What The Manifests Expose
+
+| Provider | Marketplace | Plugin manifest | Skills path |
+| :--- | :--- | :--- | :--- |
+| Codex | `.agents/plugins/marketplace.json` | `plugins/quanttradeai/.codex-plugin/plugin.json` | `plugins/quanttradeai/skills/` |
+| Claude Code | `.claude-plugin/marketplace.json` | `plugins/quanttradeai/.claude-plugin/plugin.json` | `plugins/quanttradeai/skills/` |
+
+Both marketplaces use the plugin name `quanttradeai`. The Codex marketplace display name is **QuantTradeAI Plugins**.
+
+## Local Marketplace Testing
+
+Clone the source only when you are developing the plugin or testing a local marketplace checkout.
+
+```bash
+git clone https://github.com/AKKI0511/QuantTradeAI.git
+cd QuantTradeAI
+```
+
+Codex local marketplace:
+
+```bash
+codex plugin marketplace add .
+codex plugin add quanttradeai@quanttradeai
+```
+
+Claude Code local marketplace:
+
+```bash
+claude plugin marketplace add .
+claude plugin install quanttradeai@quanttradeai
+claude plugin validate ./plugins/quanttradeai
+```
 
 ## Provider References
 
-- Codex plugin docs: <https://developers.openai.com/codex/plugins/build>
-- Claude Code plugin docs: <https://code.claude.com/docs/en/plugins>
+- Codex plugin docs: <https://developers.openai.com/codex/plugins>
+- Codex plugin build docs: <https://developers.openai.com/codex/plugins/build>
 - Claude Code marketplace docs: <https://code.claude.com/docs/en/plugin-marketplaces>
+- Claude Code plugin reference: <https://code.claude.com/docs/en/plugins-reference>

--- a/plugins/quanttradeai/.claude-plugin/plugin.json
+++ b/plugins/quanttradeai/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "quanttradeai",
   "displayName": "QuantTradeAI",
   "version": "0.1.0",
-  "description": "QuantTradeAI workspace skills for strategy experiments, model research, run analysis, promotion, and deployment.",
+  "description": "QuantTradeAI workspace skills for onboarding, strategy experiments, model research, run analysis, promotion, and deployment.",
   "author": {
     "name": "Akshat Joshi",
     "email": "joshiakshat0511@gmail.com",

--- a/plugins/quanttradeai/.codex-plugin/plugin.json
+++ b/plugins/quanttradeai/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quanttradeai",
   "version": "0.1.0",
-  "description": "QuantTradeAI workspace skills for strategy experiments, model research, run analysis, promotion, and deployment.",
+  "description": "QuantTradeAI workspace skills for onboarding, strategy experiments, model research, run analysis, promotion, and deployment.",
   "author": {
     "name": "Akshat Joshi",
     "email": "joshiakshat0511@gmail.com",
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "QuantTradeAI",
     "shortDescription": "Run, compare, promote, and deploy QuantTradeAI workflows.",
-    "longDescription": "A production-ready plugin that packages QuantTradeAI workspace skills for YAML-first strategy experiments, ML model research, artifact analysis, run comparison, promotion, paper checks, live-trading safety boundaries, and deployment bundle generation.",
+    "longDescription": "A production-ready plugin that packages QuantTradeAI workspace skills for agent-first onboarding, uv setup, YAML-first strategy experiments, ML model research, artifact analysis, run comparison, promotion, paper checks, live-trading safety boundaries, and deployment bundle generation.",
     "developerName": "Akshat Joshi",
     "category": "Productivity",
     "capabilities": [
@@ -31,6 +31,7 @@
     ],
     "websiteURL": "https://akkijoshi.gitbook.io/quanttradeai/",
     "defaultPrompt": [
+      "Create a QuantTradeAI workspace and run a strategy research pass.",
       "Run a QuantTradeAI strategy backtest from config/project.yaml.",
       "Train and evaluate a QuantTradeAI research model.",
       "Analyze QuantTradeAI run artifacts and choose a candidate.",

--- a/plugins/quanttradeai/.codex-plugin/plugin.json
+++ b/plugins/quanttradeai/.codex-plugin/plugin.json
@@ -21,7 +21,7 @@
   "interface": {
     "displayName": "QuantTradeAI",
     "shortDescription": "Run, compare, promote, and deploy QuantTradeAI workflows.",
-    "longDescription": "A production-ready plugin that packages QuantTradeAI workspace skills for agent-first onboarding, uv setup, YAML-first strategy experiments, ML model research, artifact analysis, run comparison, promotion, paper checks, live-trading safety boundaries, and deployment bundle generation.",
+    "longDescription": "A production-ready plugin that packages QuantTradeAI workspace skills for agent-first onboarding, YAML-first strategy experiments, ML model research, artifact analysis, run comparison, promotion, paper checks, live-trading safety boundaries, and deployment bundle generation.",
     "developerName": "Akshat Joshi",
     "category": "Productivity",
     "capabilities": [

--- a/plugins/quanttradeai/skills/workspace-onboarding/SKILL.md
+++ b/plugins/quanttradeai/skills/workspace-onboarding/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: workspace-onboarding
+description: Use when a user wants to start with QuantTradeAI from outside an initialized workspace, create a new QuantTradeAI lab, set up uv, run doctor, validate the generated project YAML, or asks for a natural-language quant research workflow that should begin by creating a workspace. Handles the agent-first onboarding path with `uvx quanttradeai init`, `uv sync`, `uv run quanttradeai doctor`, and handoff into strategy, model, or run-analysis workflows.
+---
+
+# Workspace Onboarding
+
+Use this skill when the user asks to start QuantTradeAI from a normal folder rather than from an existing QuantTradeAI workspace.
+
+The goal is to create a clean workspace, verify it, then continue with the appropriate research workflow. Do not clone the QuantTradeAI source repository for normal users. Do not create one-off backtest scripts.
+
+## First Check
+
+Check whether the current directory is already a QuantTradeAI workspace:
+
+- `config/project.yaml`
+- `pyproject.toml`
+- `.quanttradeai/workspace.yaml`
+
+If those exist, do not run `init` again unless the user explicitly asks to regenerate or overwrite. Continue with `uv sync`, `uv run quanttradeai doctor`, and the relevant research commands.
+
+## Create The Workspace
+
+If the user gave a workspace name, use it. If not, choose a short name from the request, such as `vibe-lab`, `strategy-lab`, or `research-lab`.
+
+Default template:
+
+```bash
+uvx quanttradeai init <workspace>
+cd <workspace>
+```
+
+Template examples:
+
+```bash
+uvx quanttradeai init <workspace> --template strategy-lab
+uvx quanttradeai init <workspace> --template research
+uvx quanttradeai init <workspace> --template rule-agent
+uvx quanttradeai init <workspace> --template model-agent
+uvx quanttradeai init <workspace> --template llm-agent
+uvx quanttradeai init <workspace> --template hybrid
+```
+
+Use `strategy-lab` for general strategy comparison, sweeps, RSI, SMA, or "vibe quant research" prompts. Use `research` when the request is clearly about training historical ML models. Use an agent template only when the user specifically asks for that agent type.
+
+If `uvx quanttradeai ...` fails because the package is not available from the configured package registry, report that package installation is blocked. Do not switch to `pip install` or clone the source unless the user asks for contributor setup.
+
+## Set Up uv
+
+Inside the workspace:
+
+```bash
+uv sync
+uv run quanttradeai doctor
+```
+
+If `doctor` reports warnings, fix what is actionable before running experiments. Common fixes:
+
+- Run `uv sync` if `.venv` is missing.
+- Use the Python version from `.python-version` when possible.
+- Keep the generated `quanttradeai==<version>` pin unless the user intentionally changes package versions.
+
+## Validate The Project
+
+Before research or backtests:
+
+```bash
+uv run quanttradeai validate -c config/project.yaml
+```
+
+If validation fails, edit `config/project.yaml` and validate again. Keep edits small and tied to the user's research request.
+
+## Continue Into Research
+
+For broad strategy prompts, use the strategy experiment workflow:
+
+```bash
+uv run quanttradeai agent run --all -c config/project.yaml --mode backtest
+uv run quanttradeai agent run --sweep <sweep_name> -c config/project.yaml --mode backtest --max-concurrency <n>
+uv run quanttradeai runs list --type agent --mode backtest --scoreboard --sort-by net_sharpe
+```
+
+For model prompts, use the model research workflow:
+
+```bash
+uv run quanttradeai research run -c config/project.yaml
+uv run quanttradeai research run -c config/project.yaml --sweep <sweep_name> --max-concurrency <n>
+uv run quanttradeai runs list --type research --scoreboard
+```
+
+After any run, inspect durable artifacts under `runs/` before recommending a winner. Terminal output alone is not enough.
+
+## Reporting Standards
+
+When reporting back, include:
+
+- Workspace path created or reused.
+- Template used.
+- Setup commands run.
+- `doctor` and validation status.
+- Config changes made.
+- Experiments run.
+- Artifact paths inspected.
+- Best candidate or `no clear winner`.
+- Caveats about dates, costs, risk, sparse trades, failures, and overfitting.
+
+Stay in backtest/research mode unless the user explicitly asks for paper, deployment, or live trading.

--- a/plugins/quanttradeai/skills/workspace-onboarding/SKILL.md
+++ b/plugins/quanttradeai/skills/workspace-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-onboarding
-description: Use when a user wants to start with QuantTradeAI from outside an initialized workspace, create a new QuantTradeAI lab, set up uv, run doctor, validate the generated project YAML, or asks for a natural-language quant research workflow that should begin by creating a workspace. Handles the agent-first onboarding path with `uvx quanttradeai init`, `uv sync`, `uv run quanttradeai doctor`, and handoff into strategy, model, or run-analysis workflows.
+description: Use when a user wants to start with QuantTradeAI from outside an initialized workspace, create a new QuantTradeAI lab, validate the generated project YAML, or asks for a natural-language quant research workflow that should begin by creating a workspace. Handles the agent-first onboarding path with `uvx quanttradeai init`, `uv sync`, and handoff into strategy, model, or run-analysis workflows.
 ---
 
 # Workspace Onboarding


### PR DESCRIPTION
## Summary

- Make README, docs home, getting started, and plugin docs lead with the Claude Code/Codex plugin-first onboarding flow.
- Add a `workspace-onboarding` plugin skill so the documented first-run flow is backed by an installed skill that handles `uvx`, uv setup, `doctor`, validation, and workflow handoff.
- Move manual `uvx`/`uv run` usage after the agent-first path and keep source clone/contributor setup at the bottom.
- Remove stale release-branch clone, package-publishing caveat, Cursor, old `pip install`, and invalid `init -o` onboarding references.

## Validation

- Parsed Codex and Claude marketplace/plugin JSON manifests.
- Verified plugin skill directory now exposes `workspace-onboarding`, `strategy-experiments`, `model-research`, `run-analysis`, and `promote-deploy`.
- Verified `quanttradeai init`, generated workspace files, `doctor`, and `validate` through the local package environment.
- Built a local `quanttradeai==0.1.0` wheel and verified generated workspace lifecycle with `uv sync --find-links <local-wheel-dir>`, `uv run quanttradeai doctor`, and `uv run quanttradeai validate -c config/project.yaml`.
- `poetry check`
- JSON manifest validation with `python -m json.tool`
- `poetry run pytest tests/test_project_config_cli.py -q`
- Commit hook: format, lint, test

## Notes

A true `uvx quanttradeai ...` public-registry run was not possible because the current package lookup returned no public `quanttradeai` distribution in this environment. The documented flow assumes the PyPI package is published, and the uv lifecycle was verified against a locally built wheel with the same `quanttradeai==0.1.0` pin.